### PR TITLE
chore(homarr): bump homarr to 1.77.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.2.7
-appVersion: "1.76.2"
+appVersion: "1.77.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump app to 1.76.2 (#1113)"
+      description: "bump app to 1.77.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.76.2`.
+Current application version: `v1.77.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.76.2"` | Homarr image tag |
+| `image.tag` | `"v1.77.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,12 +265,12 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image to `v1.76.2`. Review the
-[upstream v1.76.2 release](https://github.com/homarr-labs/homarr/releases/tag/v1.76.2)
-before upgrading production environments. Homarr `v1.76.1` and `v1.76.2`
-contain documentation, user-interface, and maintenance fixes. No breaking
-changes or new required environment variables were identified in the upstream
-release metadata.
+This update moves the default image to `v1.77.0`. Review the
+[upstream v1.77.0 release](https://github.com/homarr-labs/homarr/releases/tag/v1.77.0)
+before upgrading production environments. The comparison from `v1.76.2` contains
+translation and documentation updates plus an announcement of the separate v2 beta.
+The chart remains on stable v1. No database, storage, port, or required environment
+variable changes were identified in the upstream comparison.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.
@@ -311,9 +311,9 @@ kubectl logs -l app.kubernetes.io/name=homarr -n <namespace> --all-containers --
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **86.580086%** |
+| MITRE + NSA + SOC2 | **84.85%** |
 
-> ✅ Security posture acceptable.
+Security posture acceptable. Validated with Kubescape 4.0.13 against the rendered default manifests.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.76.2"
+          value: "ghcr.io/homarr-labs/homarr:v1.77.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.76.2"
+  tag: "v1.77.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
Homarr now defaults to stable v1.77.0. The upstream update contains translations, documentation, and a v2 beta announcement; the chart continues to deploy v1 with its existing database and storage configuration.

Resolves #1137

Companion site update: https://github.com/helmforgedev/site/pull/555

### Evidence and risk

- [Official v1.77.0 release](https://github.com/homarr-labs/homarr/releases/tag/v1.77.0) and [complete comparison from v1.76.2](https://github.com/homarr-labs/homarr/compare/v1.76.2...v1.77.0).
- Verified `ghcr.io/homarr-labs/homarr:v1.77.0` for linux/amd64 and linux/arm64.
- Preserve stable v1; the beta announcement does not switch the image to v2.

| Change | Chart impact | Validation |
|---|---|---|
| Translations, documentation, beta announcement UI | Image/application version and documentation | default k3d startup/readiness/endpoints |
| No changed database, port, storage or required environment contract in the comparison | Keep existing configuration | All CI values rendered and schema-validated; unchanged optional profiles do not need repeated runtime installs |

### Validation

- `make validate-chart CHART=homarr K3D_SCENARIOS=default TIMEOUT=600`: all 11 layers passed, including k3d with no restarts or warning events.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13: 84.85% MITRE/NSA/SOC2; README refreshed from the current rendered scan.
- Site production build and 156 local links/anchors passed.

Chart version is managed by release CI. This update does not claim an exhaustive existing-database upgrade, authentication-provider, or backup restoration test.
