### PR TITLE
chore(heimdall): bump heimdall to 2.8.3

### DIFF
--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: heimdall
 type: application
 version: 1.1.13
-appVersion: "2.8.2"
+appVersion: "2.8.3"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Heimdall application dashboard on Kubernetes
 maintainers:

--- a/charts/heimdall/README.md
+++ b/charts/heimdall/README.md
@@ -37,11 +37,13 @@ helm install heimdall oci://ghcr.io/helmforgedev/helm/heimdall
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **72.72727%** |
+| MITRE + NSA + SOC2 | **72.73%** |
 
 > Security posture acceptable with operator-provided resource limits, security contexts, and network policy.
 
 ## Configuration
+
+Set a non-empty `image.repository` and `image.tag`; the chart rejects empty values before creating a workload.
 
 ### Minimal
 

--- a/charts/heimdall/templates/_helpers.tpl
+++ b/charts/heimdall/templates/_helpers.tpl
@@ -1,4 +1,10 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "heimdall.validate" -}}
+{{- if or (not (trim .Values.image.repository)) (not (trim .Values.image.tag)) -}}
+{{- fail "image.repository and image.tag must not be empty" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "heimdall.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/heimdall/templates/deployment.yaml
+++ b/charts/heimdall/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "heimdall.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/heimdall/tests/deployment_test.yaml
+++ b/charts/heimdall/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/linuxserver/heimdall:2.8.2"
+          value: "docker.io/linuxserver/heimdall:2.8.3"
 
   - it: should set PUID, PGID, and TZ env vars
     asserts:

--- a/charts/heimdall/tests/validation_test.yaml
+++ b/charts/heimdall/tests/validation_test.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: image configuration validation
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: rejects an empty image tag before creating a broken workload
+    set:
+      image.tag: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: image.repository and image.tag must not be empty
+  - it: rejects a whitespace-only image repository
+    set:
+      image.repository: "   "
+    asserts:
+      - failedTemplate:
+          errorMessage: image.repository and image.tag must not be empty

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Container image repository
   repository: docker.io/linuxserver/heimdall
   # -- Image tag
-  tag: "2.8.2"
+  tag: "2.8.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Heimdall now uses LinuxServer.io image 2.8.3. This includes upstream redirect/icon URL validation and dashboard ordering fixes. The chart also rejects empty image repository/tag values before creating a workload, addressing the missing validation-helper standard with two negative unit tests.

Resolves #1136

Companion site update: https://github.com/helmforgedev/site/pull/555

### Evidence and validation scope

- [Official Heimdall v2.8.3 release](https://github.com/linuxserver/Heimdall/releases/tag/v2.8.3).
- [Docker development configuration change](https://github.com/linuxserver/Heimdall/pull/1597/files) only removes the obsolete Compose version field; container storage and ports remain unchanged.
- Verified `docker.io/linuxserver/heimdall:2.8.3` manifest for linux/amd64 and linux/arm64. Preserve the stable LinuxServer.io distribution.

| Change | Chart impact | Validation |
|---|---|---|
| SSRF redirect/icon handling and dashboard import/export ordering fixes | Application image update; no deployment contract change | default k3d readiness/endpoints and startup logs |
| Missing chart validation helper | Reject invalid image inputs before Deployment creation | two negative Helm unit tests |
| Existing persistence, routing and backup configuration | No configuration changes | all CI profiles rendered and schema-validated |

### Results

- Final `make validate-chart CHART=heimdall K3D_SCENARIOS=default TIMEOUT=600`: all 11 layers passed, including k3d after the helper change.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 72.73%; README score refreshed.
- Site production build and 156 local links/anchors passed.

Chart version remains managed by release CI. This update does not claim adversarial SSRF testing, complete dashboard import/export coverage, or a backup restoration test; those application and optional service contracts were not changed by the chart.
