### PR TITLE
chore(generic): bump nginx to 1.31.5

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,14 +7,14 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 version: 3.1.4
-appVersion: "1.31.4"
+appVersion: "1.31.5"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump nginx to 1.31.4 (#1045)"
+      description: "bump nginx to 1.31.5"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -3,8 +3,9 @@
 A single chart that handles **Deployments**, **StatefulSets**, **DaemonSets**, **Jobs**, and **CronJobs** with a unified values
 interface. Designed for teams that deploy many services and want one chart to rule them all.
 
-The default `nginx:1.31.4` image adds stricter protocol validation, standards-correct
-HTTP/2 and gRPC upstream host handling, and worker stability and memory-safety fixes.
+The default `nginx:1.31.5` image includes fixes for buffered HTTP/2 proxy responses,
+worker shutdown, and FastCGI/uWSGI parameter handling. New control API, predicate
+location, JSON module, and early request-body features require explicit configuration.
 Existing Generic chart configuration remains compatible with this image update.
 
 ## Install
@@ -306,10 +307,13 @@ templated (e.g. `{{ .Release.Namespace }}`) to derive per-environment paths from
 
 ## Security Scan
 
-🟢 Security Scan: generic
-Framework    Score
-MITRE + NSA + SOC2    75.76%
-✅ Security posture acceptable.
+### Security Scan: `generic`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **75.76%** |
+
+Security posture acceptable. Verified with Kubescape 4.0.13 against the rendered default manifests.
 
 ### When this chart fits well
 
@@ -370,7 +374,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Image** | | |
 | `global.imageRegistry` | Optional registry prefix for unqualified repositories | `""` |
 | `image.repository` | Container image repository | `docker.io/library/nginx` |
-| `image.tag` | Image tag | `1.31.4` |
+| `image.tag` | Image tag | `1.31.5` |
 | `image.digest` | Image digest, takes precedence over tag | `""` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets | `[]` |

--- a/charts/generic/ci/deployment-values.yaml
+++ b/charts/generic/ci/deployment-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.4"
+  tag: "1.31.5"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/ci/multi-container-values.yaml
+++ b/charts/generic/ci/multi-container-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.4"
+  tag: "1.31.5"
 
 containers:
   - name: api

--- a/charts/generic/ci/platform-values.yaml
+++ b/charts/generic/ci/platform-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.4"
+  tag: "1.31.5"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -15,4 +15,4 @@ tests:
           of: DaemonSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/nginx:1.31.4
+          value: docker.io/library/nginx:1.31.5

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -56,7 +56,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/nginx:1.31.4"
+          value: "docker.io/library/nginx:1.31.5"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -88,7 +88,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/nginx:1.31.4"
+          value: "registry.example.com/nginx:1.31.5"
 
   - it: should apply global registry to namespaced unqualified repositories
     set:
@@ -97,7 +97,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/team/app:1.31.4"
+          value: "registry.example.com/team/app:1.31.5"
 
   - it: should not apply global registry to fully qualified repositories
     set:
@@ -106,7 +106,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/team/app:1.31.4"
+          value: "ghcr.io/team/app:1.31.5"
 
   - it: should allow per-container image digest override
     set:

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -81,7 +81,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "1.31.4"
+          "default": "1.31.5"
         },
         "digest": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -52,7 +52,7 @@ global:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.4"
+  tag: "1.31.5"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Generic now defaults to NGINX 1.31.5 on the existing mainline 1.31 track. Image defaults, schema examples, CI profiles, unit expectations, and documentation are synchronized. Custom application images remain controlled by the existing values contract.

Resolves #1134

Companion site update: https://github.com/helmforgedev/site/pull/555

### Upstream evidence and scope

- [Official 1.31.5 changes](https://nginx.org/en/CHANGES) and [release](https://github.com/nginx/nginx/releases/tag/release-1.31.5).
- Verified `docker.io/library/nginx:1.31.5` manifest for linux/amd64, arm, arm64, 386, ppc64le, riscv64, and s390x.

| Change | Chart impact | Validation |
|---|---|---|
| Buffered HTTP/2 proxy, shutdown, FastCGI/uWSGI, HTTP/3 and slice/memcached fixes | Default image update | default NGINX startup, readiness and service endpoints on k3d |
| New control API, predicate locations, JSON module and early body directive | Features require explicit application configuration; default configuration remains compatible | all chart CI profiles rendered and schema-validated |
| Unchanged workload kinds, storage, routing and secrets | No template contract changes | existing Helm unit and static CI matrix |

### Results

- `make validate-chart CHART=generic K3D_SCENARIOS=default TIMEOUT=600`: all 11 layers passed, including k3d.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 75.76%; refreshed the README scan format without decorative icons.
- Site build and 158 local links/anchors passed.

Release CI manages chart version. No new NGINX feature is enabled by this bump, and this validation does not claim exhaustive custom NGINX configurations or protocol-specific regression coverage.
