### PR TITLE
chore(ghost): bump ghost to 6.62.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.2.5
-appVersion: "6.61.0"
+appVersion: "6.62.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump app to 6.61.0 (#1111)"
+      description: "bump app to 6.62.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -106,7 +106,7 @@ through Ghost's environment-based configuration:
 ```yaml
 image:
   repository: registry.example.com/ghost-with-adapters
-  tag: "6.61.0"
+  tag: "6.62.0"
 
 ghost:
   extraEnv:
@@ -123,7 +123,7 @@ adapters when the container starts.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.61.0` | Ghost image tag |
+| `image.tag` | `6.62.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.11` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -137,8 +137,8 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.61.0` includes application features and maintenance fixes without a
-documented change to the official container contract. It does not change the image's port, content
+Ghost `6.62.0` adds the React tag details screen, updates bundled themes, and fixes
+member unsubscribe links and private-site landing pages. It does not change the image's port, content
 path, database contract, probes, or required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the
 chart's content PVC and S3 content backup already cover them. Review the
@@ -171,7 +171,7 @@ backup:
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **89.393936%** |
+| MITRE + NSA + SOC2 | **89.39%** |
 
 > Security posture acceptable.
 

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.61.0"
+          value: "docker.io/library/ghost:6.62.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.61.0"
+                                                                    "default":  "6.62.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.61.0"
+  tag: "6.62.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Ghost now defaults to 6.62.0, including the React tag details screen, bundled theme updates, and fixes to member unsubscribe links and private-site landing pages. The content PVC, database settings, and MySQL 8.4.11 image override are preserved.

Resolves #1135

Companion site update: https://github.com/helmforgedev/site/pull/555

### Evidence and validation scope

- [Official v6.62.0 release](https://github.com/TryGhost/Ghost/releases/tag/v6.62.0) and [comparison from v6.61.0](https://github.com/TryGhost/Ghost/compare/v6.61.0...v6.62.0).
- Verified `docker.io/library/ghost:6.62.0` manifest for linux/amd64 and linux/arm64; stable Ghost 6 track.
- HelmForge dependencies checked against current releases. MySQL stays on the chart's explicit 8.4.11 application-compatible override.

| Change | Chart impact | Validation |
|---|---|---|
| Tag details UI, bundled themes and member behavior fixes | Application version and release guidance | default k3d database-backed startup/readiness/endpoints |
| No changed port, content path or required environment contract | Existing content PVC and database configuration retained | all CI profiles rendered, unit tested and schema-validated |
| Custom production themes, integrations and newsletter flows | Application-specific verification remains necessary | retained staging/backup guidance; no claim of exhaustive custom integration tests |

### Results

- `make validate-chart CHART=ghost K3D_SCENARIOS=default TIMEOUT=600`: all 11 layers passed, including database-backed k3d startup, readiness and service endpoints, with no workload restarts.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 89.39%; README refreshed.
- Site production build and 156 local links/anchors passed.

The release workflow owns chart version. No content/database migration or backup implementation changes are included in this patch.
