### PR TITLE
chore(jenkins): bump jenkins to 2.568.3 lts

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -4,7 +4,7 @@ name: jenkins
 description: Jenkins Helm Chart with secure controller defaults, JCasC, plugin bootstrap, Gateway API, and Kubernetes agent RBAC
 type: application
 version: 1.0.8
-appVersion: "2.568.2"
+appVersion: "2.568.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -3,13 +3,17 @@
 Jenkins is an open source automation server for continuous integration and delivery.
 
 This HelmForge chart deploys the official `jenkins/jenkins` controller image
-at the pinned `2.568.2-lts-jdk21` release with production-oriented Kubernetes
+at the pinned `2.568.3-lts-jdk21` release with production-oriented Kubernetes
 defaults. It includes a StatefulSet
 controller, persistent Jenkins home, secure initial admin bootstrap, optional
 Jenkins Configuration as Code, optional plugin installation with
 `jenkins-plugin-cli`, optional RBAC for Kubernetes agents, dual-stack Service
 support, Gateway API, Ingress, NetworkPolicy, ExternalSecret, ServiceMonitor,
 PodDisruptionBudget, and Helm tests.
+
+Jenkins 2.568.3 includes the core fixes in the
+[September 2 security advisory](https://www.jenkins.io/security/advisory/2026-09-02/).
+The chart retains the LTS/JDK 21 distribution and existing plugin configuration.
 
 NetworkPolicy supports `networkPolicy.egress.extraEgress` for appending custom egress
 rules without replacing the chart-generated DNS, cluster, internet, and
@@ -86,7 +90,7 @@ Artifact Hub lint, markdown lint, security scans, and k3d runtime validation.
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **86.111115%** |
+| MITRE + NSA + SOC2 | **91.41%** |
 
 > Security posture acceptable with controller security contexts, non-root execution, optional NetworkPolicy, and operator-controlled plugin/JCasC inputs.
 

--- a/charts/jenkins/scripts/runtime-smoke.mjs
+++ b/charts/jenkins/scripts/runtime-smoke.mjs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync, spawn} from 'node:child_process';
+import {setTimeout as delay} from 'node:timers/promises';
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const run = (bin, args) => execFileSync(bin, args, {encoding:'utf8', timeout:30000, stdio:['ignore','pipe','pipe']});
+const target = ['--context',context,'-n',namespace];
+const pods = JSON.parse(run('kubectl',[...target,'get','pods','-l',`app.kubernetes.io/instance=${release}`,'-o','json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp && p.spec.containers.some(c => c.name === 'jenkins'));
+assert.ok(pod, 'Jenkins controller pod required');
+const container = pod.spec.containers.find(c => c.name === 'jenkins');
+function env(name) {
+  const entry = container.env?.find(e => e.name === name);
+  if (entry?.value !== undefined) return entry.value;
+  const ref = entry?.valueFrom?.secretKeyRef;
+  if (!ref) return undefined;
+  const secret = JSON.parse(run('kubectl',[...target,'get','secret',ref.name,'-o','json']));
+  assert.ok(secret.data?.[ref.key], `Missing credential key ${ref.key}`);
+  return Buffer.from(secret.data[ref.key],'base64').toString();
+}
+const user = env('JENKINS_ADMIN_USER'), password = env('JENKINS_ADMIN_PASSWORD');
+const port = container.ports.find(p => p.name === 'http').containerPort;
+const child = spawn('kubectl',[...target,'port-forward',`pod/${pod.metadata.name}`,`:${port}`,'--address=127.0.0.1'],{windowsHide:true,stdio:['ignore','pipe','pipe']});
+let output = '';
+child.stdout.on('data',c => {output += c;});
+child.stderr.on('data',() => {});
+let childError;
+child.on('error',error => {childError = error;});
+try {
+  for (let i=0; i<150 && !/127\.0\.0\.1:(\d+) ->/.test(output) && !childError; i++) await delay(100);
+  if (childError) throw childError;
+  const localPort = output.match(/127\.0\.0\.1:(\d+) ->/)?.[1];
+  assert.ok(localPort,'Jenkins port-forward did not become ready');
+  const base = `http://127.0.0.1:${localPort}`;
+  const request = (route, options={}) => fetch(base+route,{...options,redirect:'manual',signal:AbortSignal.timeout(20000)});
+  const login = await request('/login');
+  assert.equal(login.status,200,'Login page');
+  assert.equal(login.headers.get('x-jenkins'),'2.568.3','Actual Jenkins version');
+  await login.arrayBuffer();
+  if (user && password) {
+    const anonymous = await request('/api/json');
+    assert.equal(anonymous.status,403,'Anonymous controller access must be denied');
+    await anonymous.arrayBuffer();
+    const headers = {Authorization:`Basic ${Buffer.from(`${user}:${password}`).toString('base64')}`};
+    const crumbResponse = await request('/crumbIssuer/api/json',{headers});
+    assert.equal(crumbResponse.status,200,'Authenticated crumb request');
+    const cookie = crumbResponse.headers.getSetCookie().map(c => c.split(';')[0]).join('; ');
+    const crumb = await crumbResponse.json();
+    assert.ok(cookie && crumb.crumb && crumb.crumbRequestField,'Session-bound CSRF protection');
+    Object.assign(headers,{Cookie:cookie,[crumb.crumbRequestField]:crumb.crumb,'Content-Type':'application/xml'});
+    const name = 'helmforge-upstream-smoke';
+    const created = await request(`/createItem?name=${name}`,{method:'POST',headers,body:'<project><description>helmforge-configuration-roundtrip</description><disabled>true</disabled></project>'});
+    assert.equal(created.status,200,'Create disabled test job with CSRF crumb');
+    await created.arrayBuffer();
+    const config = await request(`/job/${name}/config.xml`,{headers});
+    assert.equal(config.status,200,'Read persisted job configuration');
+    assert.match(await config.text(),/helmforge-configuration-roundtrip/);
+    const deleted = await request(`/job/${name}/doDelete`,{method:'POST',headers});
+    assert.ok([200,302,303].includes(deleted.status),'Delete test job');
+    await deleted.arrayBuffer();
+    console.log('Jenkins 2.568.3: anonymous denial, admin authentication, session CSRF and job configuration roundtrip passed.');
+  } else {
+    console.log('Jenkins 2.568.3: login/version passed; bootstrap credentials are not configured in this scenario.');
+  }
+} finally {
+  if (child.exitCode === null && child.pid) {
+    if (process.platform === 'win32') run('taskkill',['/PID',String(child.pid),'/T','/F']);
+    else child.kill('SIGTERM');
+  }
+}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Jenkins controller image repository.
   repository: docker.io/jenkins/jenkins
   # -- Jenkins controller image tag.
-  tag: "2.568.2-lts-jdk21"
+  tag: "2.568.3-lts-jdk21"
   # -- Jenkins controller image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Jenkins now runs 2.568.3 on the existing LTS/JDK 21 distribution. This includes the September 2 core security fixes while preserving controller storage and plugin configuration. A chart-owned runtime check verifies the actual server version, access control, session-bound CSRF, and job configuration handling.

Resolves #1138

Companion site update: https://github.com/helmforgedev/site/pull/555

### Upstream evidence and scope

- [LTS changelog](https://www.jenkins.io/changelog-stable/) and [September 2 security advisory](https://www.jenkins.io/security/advisory/2026-09-02/).
- [Scripted client CSRF requirements](https://www.jenkins.io/doc/book/security/csrf-protection/): password-authenticated POSTs use both the crumb and its session cookie.
- Verified `docker.io/jenkins/jenkins:2.568.3-lts-jdk21` for linux/amd64, arm64, s390x, ppc64le and riscv64.

| Change | Chart impact | Runtime validation |
|---|---|---|
| Deserialization and request-binding hardening | Existing initial configuration must work on the patched core | Create, read and delete a disabled test job through the authenticated API |
| CSRF, session and permission fixes | Preserve secure admin bootstrap | anonymous controller access denied; admin crumb and session cookie accepted |
| LTS core and embedded servlet engine update | Preserve JDK 21, home PVC and ports | exact X-Jenkins version, login page, StatefulSet readiness, stable logs and endpoints |

### Results

- `make validate-chart CHART=jenkins K3D_SCENARIOS=default TIMEOUT=900`: all 11 layers passed, including the API application check and k3d with no restarts or warning events.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 91.41%; README refreshed.
- Site build and 156 local links/anchors passed; playground image default synchronized.

All CI profiles remain statically validated. Optional plugins/JCasC, external security realms and existing persistent homes are unchanged; this patch does not claim exhaustive plugin compatibility or an existing-home upgrade test. Chart version remains managed by release CI.
