### PR TITLE
chore(cloudflared): bump cloudflared to 2026.8.3

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.14
-appVersion: "2026.8.2"
+appVersion: "2026.8.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump cloudflared to 2026.8.2 (#999)"
+      description: "bump cloudflared to 2026.8.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -178,24 +178,24 @@ topologySpreadConstraints:
 
 ## Upgrade Notes
 
-Cloudflared 2026.8.2 fixes the HTTP-origin path regressions introduced in
-2026.8.0 and 2026.8.1. Those releases could strip trailing slashes or normalize
-encoded paths, causing redirect loops or changing application URLs. The
-Kubernetes tunnel command and chart values contract are unchanged.
+Cloudflared 2026.8.3 updates its WebSocket dependency and distroless base image.
+It removes the hidden stdin reconnect test control and obsolete remote protocol
+percentage lookup. Automatic reconnection after real transport failures remains
+supported, and the chart's tunnel command and values contract are unchanged.
 
 Review the
-[official 2026.8.2 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.8.2)
+[official 2026.8.3 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.8.3)
 before production rollout.
 
 ## Security Scan
 
-🟢 Security Scan: `cloudflared`
+### Security Scan: `cloudflared`
 
 | Framework | Score |
 |---|---|
 | MITRE + NSA + SOC2 | **87.88%** |
 
-> ✅ Security posture acceptable.
+Security posture acceptable. Verified with Kubescape 4.0.13 against rendered default manifests.
 
 Local details:
 
@@ -205,10 +205,10 @@ Local details:
 | NSA | 85.00% |
 | SOC2 | 80.00% |
 
-The remaining local scan findings are expected for raw chart scanning and
-platform-level controls: NetworkPolicy is supplied by the platform layer, token
-Secret access is intentionally scoped to the pod, and raw-template static
-analysis does not fully evaluate Helm-rendered non-root defaults.
+The rendered-manifest scan reports non-root, service-account token mapping,
+and network-isolation findings. The container explicitly runs as UID 65532;
+the chart does not create a NetworkPolicy. Review the service account and
+platform network policies for the deployment environment.
 
 ## More Information
 

--- a/charts/cloudflared/scripts/runtime-smoke.mjs
+++ b/charts/cloudflared/scripts/runtime-smoke.mjs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {setTimeout as delay} from 'node:timers/promises';
+const [context,namespace,release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const target = ['--context',context,'-n',namespace];
+const kubectl = args => execFileSync('kubectl',[...target,...args],{encoding:'utf8',timeout:30000,stdio:['ignore','pipe','pipe']});
+const pods = JSON.parse(kubectl(['get','pods','-l',`app.kubernetes.io/instance=${release}`,'-o','json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp && p.spec.containers.some(c => c.name === 'cloudflared'));
+assert.ok(pod,'cloudflared pod required');
+const version = kubectl(['exec',pod.metadata.name,'-c','cloudflared','--','cloudflared','version']);
+assert.match(version,/cloudflared version 2026\.8\.3\b/);
+const container = pod.spec.containers.find(c => c.name === 'cloudflared');
+if (container.command?.includes('--hello-world')) {
+  const logs = kubectl(['logs',pod.metadata.name,'-c','cloudflared']);
+  const url = logs.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com\b/)?.[0];
+  assert.ok(url,'Quick tunnel hostname required');
+  let status, error;
+  for (let i=0; i<6; i++) {
+    try {
+      const response = await fetch(url,{redirect:'manual',signal:AbortSignal.timeout(15000)});
+      status = response.status;
+      await response.arrayBuffer();
+      if (status === 200) break;
+    } catch (caught) { error = caught.message; }
+    await delay(3000);
+  }
+  assert.equal(status,200,`Quick tunnel HTTPS origin request failed: ${error || status}`);
+  console.log('cloudflared 2026.8.3: HTTPS request through the live quick tunnel reached the built-in origin.');
+} else {
+  console.log('cloudflared 2026.8.3: binary version verified; custom/managed origin is not requested by this smoke test.');
+}

--- a/charts/cloudflared/scripts/runtime-smoke.mjs
+++ b/charts/cloudflared/scripts/runtime-smoke.mjs
@@ -9,8 +9,10 @@ if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
 const target = ['--context',context,'-n',namespace];
 const kubectl = args => execFileSync('kubectl',[...target,...args],{encoding:'utf8',timeout:30000,stdio:['ignore','pipe','pipe']});
 const pods = JSON.parse(kubectl(['get','pods','-l',`app.kubernetes.io/instance=${release}`,'-o','json'])).items;
-const pod = pods.find(p => !p.metadata.deletionTimestamp && p.spec.containers.some(c => c.name === 'cloudflared'));
-assert.ok(pod,'cloudflared pod required');
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'cloudflared'));
+assert.ok(pod,'Ready cloudflared pod required');
 const version = kubectl(['exec',pod.metadata.name,'-c','cloudflared','--','cloudflared','version']);
 assert.match(version,/cloudflared version 2026\.8\.3\b/);
 const container = pod.spec.containers.find(c => c.name === 'cloudflared');

--- a/charts/cloudflared/tests/deployment_test.yaml
+++ b/charts/cloudflared/tests/deployment_test.yaml
@@ -37,7 +37,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/cloudflare/cloudflared:2026.8.2"
+          value: "docker.io/cloudflare/cloudflared:2026.8.3"
 
   - it: should use custom image tag
     template: templates/deployment.yaml

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.8.2"
+  tag: "2026.8.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Cloudflared now uses 2026.8.3 on the same stable image distribution. The update includes the WebSocket dependency security fix and distroless refresh, and removes obsolete test reconnect and remote protocol-percentage code. A chart-owned smoke check verifies the running binary version and an HTTPS request through the live demonstration tunnel.

Resolves #1130

Companion site update: https://github.com/helmforgedev/site/pull/555

### Upstream evidence and risk

- [Official 2026.8.3 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.8.3) and [complete comparison from 2026.8.2](https://github.com/cloudflare/cloudflared/compare/2026.8.2...2026.8.3).
- Verified `docker.io/cloudflare/cloudflared:2026.8.3` manifest for linux/amd64 and linux/arm64; OCI configuration retains the non-root distroless distribution.
- [Official Kubernetes guidance](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/deployment-guides/kubernetes/): /ready reflects an active connection to Cloudflare.

| Change | Chart impact | Runtime scenario |
|---|---|---|
| Transport setup and protocol-selection cleanup | Existing command remains valid; verify automatic and explicitly selected transport | default and ci/quick-tunnel-values.yaml (HTTP/2) |
| WebSocket dependency and base image update | Pinned image update | binary version, readiness, stable logs, HTTPS origin roundtrip |
| Hidden test-only reconnect control removed | Chart does not use that flag; genuine automatic reconnection remains supported | static command/CI matrix; no claim of forced reconnection testing |

### Results

- `make validate-chart CHART=cloudflared K3D_SCENARIOS="default ci/quick-tunnel-values.yaml" TIMEOUT=600`: all 12 layers passed. Both modes served the built-in origin through a live HTTPS quick tunnel; zero workload restarts.
- `make preflight`, dependency freshness, template standards, standards-check and standards-guard passed.
- Kubescape 4.0.13: 87.88% MITRE/NSA/SOC2; README describes the rendered-manifest findings and retains operator guidance.
- Site build and 156 local links/anchors passed; playground default synchronized.

Managed token/ESO profiles remain statically covered; account-specific tunnels and custom origins were not used. Release CI manages chart version.
