### PR TITLE
chore(metabase): bump to 0.63.16 and preserve encryption key

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.27
-appVersion: "v0.63.15"
+appVersion: "v0.63.16"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -189,7 +189,6 @@ database and review the [official Metabase 63 changelog](https://www.metabase.co
 before upgrading. Keep the encryption key stable and validate the `/api/health`
 endpoint after rollout.
 
-
 The generated application encryption key is reused from the existing Kubernetes
 Secret during connected Helm upgrades. For GitOps or offline rendering, set
 `metabase.existingSecret` to a stable Secret; `helm template` cannot look up the
@@ -231,7 +230,8 @@ coordinate activation with users. See the
 |---|---|
 | MITRE + NSA + SOC2 | **86.36364%** |
 
-Rendered-manifest scan: 86.36% across MITRE, NSA and SOC2. Findings include writable filesystems, service account token mounting and network isolation; review production security settings for the application and PostgreSQL subchart.
+Rendered-manifest scan: 86.36% across MITRE, NSA and SOC2. Findings include writable filesystems, service account token mounting and network isolation;
+review production security settings for the application and PostgreSQL subchart.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.63.15
+  tag: v0.63.16
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.63.15` | Metabase container image tag |
+| `image.tag` | `v0.63.16` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,10 +184,32 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.63.15` is a public maintenance release. Back up the Metabase application
-database and review the [official Metabase 63 changelog](https://www.metabase.com/changelog/63#metabase-6315)
+Metabase `v0.63.16` is a public maintenance release. Back up the Metabase application
+database and review the [official Metabase 63 changelog](https://www.metabase.com/changelog/63#metabase-6316)
 before upgrading. Keep the encryption key stable and validate the `/api/health`
 endpoint after rollout.
+
+
+The generated application encryption key is reused from the existing Kubernetes
+Secret during connected Helm upgrades. For GitOps or offline rendering, set
+`metabase.existingSecret` to a stable Secret; `helm template` cannot look up the
+cluster's current key. An explicit `metabase.encryptionSecretKey` takes precedence
+and must not change after installation.
+
+Starting with 0.63.16, adding encryption to an existing unencrypted application
+database requires an explicit migration. Back up the database and key, stop all
+Metabase instances, and run the upstream `enable-encryption` JAR command with the
+same database environment and `MB_ENCRYPTION_SECRET_KEY` used by the deployment.
+Restart with that same key. Existing encrypted databases do not need this command.
+If encryption was already configured and Metabase reports an unencrypted database,
+investigate and restore a known-good backup; do not automatically re-encrypt it.
+See [Metabase encryption instructions](https://www.metabase.com/docs/latest/databases/encrypting-details-at-rest).
+
+For signed database sessions, inject `MB_SESSION_SECRET_KEY` through
+`metabase.extraEnv` using a Kubernetes `secretKeyRef`. Use a separate stable secret
+of at least 16 characters. Setting or changing it logs out existing sessions;
+coordinate activation with users. See the
+[session secret documentation](https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_session_secret_key).
 
 ## Examples
 
@@ -203,13 +225,13 @@ endpoint after rollout.
 - [Metabase documentation](https://www.metabase.com/docs/latest/)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/metabase)
 
-### 🟢 Security Scan: `metabase`
+### Security Scan: `metabase`
 
 | Framework | Score |
 |---|---|
 | MITRE + NSA + SOC2 | **86.36364%** |
 
-> ✅ Security posture acceptable.
+Rendered-manifest scan: 86.36% across MITRE, NSA and SOC2. Findings include writable filesystems, service account token mounting and network isolation; review production security settings for the application and PostgreSQL subchart.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/metabase/docs/database.md
+++ b/charts/metabase/docs/database.md
@@ -48,7 +48,8 @@ metabase:
 Back up this key with the database. Changing it after Metabase has stored credentials can make saved connection secrets
 unreadable.
 
-Connected Helm upgrades preserve the generated application key. Offline rendering cannot perform this lookup; use a stable existing Secret for GitOps. See the [upgrade notes](../README.md#upgrade-notes) before adding encryption to an existing unencrypted database on Metabase 0.63.16 or later.
+Connected Helm upgrades preserve the generated application key. Offline rendering cannot perform this lookup; use a stable existing Secret for GitOps.
+See the [upgrade notes](../README.md#upgrade-notes) before adding encryption to an existing unencrypted database on Metabase 0.63.16 or later.
 
 ## Backups
 

--- a/charts/metabase/docs/database.md
+++ b/charts/metabase/docs/database.md
@@ -48,6 +48,8 @@ metabase:
 Back up this key with the database. Changing it after Metabase has stored credentials can make saved connection secrets
 unreadable.
 
+Connected Helm upgrades preserve the generated application key. Offline rendering cannot perform this lookup; use a stable existing Secret for GitOps. See the [upgrade notes](../README.md#upgrade-notes) before adding encryption to an existing unencrypted database on Metabase 0.63.16 or later.
+
 ## Backups
 
 The chart can create a PostgreSQL dump CronJob and upload the archive to S3-compatible storage:

--- a/charts/metabase/templates/secret.yaml
+++ b/charts/metabase/templates/secret.yaml
@@ -1,5 +1,11 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if not .Values.metabase.existingSecret }}
+{{- $secretName := printf "%s-app" (include "metabase.fullname" .) }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $key := .Values.metabase.encryptionSecretKey }}
+{{- if and (not $key) $existing }}
+{{- $key = index $existing.data "encryption-secret-key" | default "" | b64dec }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,7 +14,7 @@ metadata:
     {{- include "metabase.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  encryption-secret-key: {{ .Values.metabase.encryptionSecretKey | default (randAlphaNum 32) | quote }}
+  encryption-secret-key: {{ $key | default (randAlphaNum 32) | quote }}
 {{- end }}
 ---
 {{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.63.15"
+          value: "docker.io/metabase/metabase:v0.63.16"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/tests/secret_test.yaml
+++ b/charts/metabase/tests/secret_test.yaml
@@ -6,6 +6,14 @@ release:
   name: test
   namespace: default
 tests:
+  - it: should use an explicitly supplied encryption key
+    set:
+      metabase.encryptionSecretKey: stable-encryption-key-for-test-123
+    asserts:
+      - equal:
+          path: stringData.encryption-secret-key
+          value: stable-encryption-key-for-test-123
+        documentIndex: 0
   - it: should render app secret by default
     asserts:
       - isKind:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.63.15"
+  tag: "v0.63.16"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Metabase now uses v0.63.16 and preserves the generated application encryption key during connected Helm upgrades. Previously, rendering a new release generated a different key, risking access to encrypted application data. Explicit keys keep precedence; GitOps users should provide a stable existing Secret.

Resolves #1141

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- [Official 0.63.16 changelog](https://www.metabase.com/changelog/63#metabase-6316): authentication, permission and notification fixes; existing unencrypted databases now require explicit encryption activation.
- Verified docker.io/metabase/metabase:v0.63.16 for linux/amd64 and linux/arm64. PostgreSQL dependency 2.0.5 is current.
- [Encryption migration](https://www.metabase.com/docs/latest/databases/encrypting-details-at-rest): back up, stop Metabase, run enable-encryption with the deployment's database configuration/key, then restart. Already encrypted databases do not need re-encryption.
- Session-signing guidance documents the existing extraEnv configuration and session logout effect of activating/changing MB_SESSION_SECRET_KEY.

| Change | Chart impact | Validation |
|---|---|---|
| Existing-database encryption activation becomes explicit | Migration guidance; stable generated key via Secret lookup | Default installation and persistent 0.63.15 to 0.63.16 upgrade |
| Authentication/permission fixes | Pinned official image | Health and actual application version; full static CI matrix |
| Key continuity on release update | Preserve current Secret unless an explicit key is supplied | Compare key before/after upgrade and pod replacement without printing it |

## Validation

- Complete default chart gate passed all 11 layers, including PostgreSQL startup, readiness and stable application logs on k3d.
- Persistent 0.63.15 to 0.63.16 upgrade passed: retained PostgreSQL setting and generated key, confirmed the actual API version and health, then repeated verification after pod replacement.
- Preflight, dependency freshness, template standards and standards-check passed.
- Kubescape 4.0.13: 86.36% MITRE/NSA/SOC2; rendered-manifest findings documented.
- Site build and 156 local links/anchors passed.

External database/ESO/backup profiles remain statically covered because their contracts are unchanged. The upgrade check does not claim SSO-provider integration, dashboard-level regression coverage or backup restoration. Chart version remains CI-managed.
