### PR TITLE
chore(drupal): bump to 11.4.6 and verify installer runtime

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.12
-appVersion: "11.4.5"
+appVersion: "11.4.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.4.5-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.4.6-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.4.5-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.4.6-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,12 +53,13 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.5` is a patch release with upstream bug fixes. Review the upstream
-release notes for the complete list of resolved issues and any known regressions.
+Drupal `11.4.6` fixes entity loading, PHP 8.5 deprecations, administrative UI
+escaping and entity-preview rendering. Review the
+[official release notes](https://www.drupal.org/project/drupal/releases/11.4.6).
 
 Before upgrading production workloads, test the site in staging with the same
 PHP extensions, Composer dependency set, storage class, and database mode used
-in production. Review the Drupal 11.4.5 release notes before running database
+in production. Review the Drupal 11.4.6 release notes before running database
 updates.
 
 ## Production Example
@@ -147,7 +148,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.4.5-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.4.6-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |
@@ -182,6 +183,6 @@ mysql:
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **81.82%** |
+| MITRE + NSA + SOC2 | **83.33%** |
 
-> Security posture acceptable.
+Rendered-manifest scan using Kubescape 4.0.13. Review application and database security settings, filesystem permissions and network isolation for the production deployment.

--- a/charts/drupal/scripts/runtime-smoke.mjs
+++ b/charts/drupal/scripts/runtime-smoke.mjs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const kubectl = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(kubectl(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'drupal'));
+assert.ok(pod, 'Ready Drupal pod required');
+const php = code => kubectl(['exec', pod.metadata.name, '-c', 'drupal', '--', 'php', '-r', code]);
+const runtime = JSON.parse(php('require "/var/www/html/core/lib/Drupal.php"; echo json_encode(["drupal" => Drupal::VERSION, "php" => PHP_VERSION, "drivers" => PDO::getAvailableDrivers()]);'));
+assert.equal(runtime.drupal, '11.4.6');
+assert.match(runtime.php, /^8\.5\./);
+assert.ok(runtime.drivers.includes('mysql'), 'MySQL PDO driver required');
+assert.ok(runtime.drivers.includes('sqlite'), 'SQLite PDO driver required');
+const installer = php('echo file_get_contents("http://127.0.0.1/core/install.php");');
+assert.match(installer, /Choose language|Select a language/);
+console.log('Drupal 11.4.6 / PHP 8.5: MySQL and SQLite PDO drivers available; Apache served the fresh-site installer.');

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.4.5-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.6-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.4.5-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.6-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.4.5-php8.5-apache-bookworm"
+  tag: "11.4.6-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Drupal now uses 11.4.6 while retaining the PHP 8.5 Apache Bookworm image variant. A runtime smoke check verifies the running Drupal/PHP versions, PDO drivers and the fresh-site installer response.

Resolves #1131

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- [Official Drupal 11.4.6 release](https://www.drupal.org/project/drupal/releases/11.4.6): entity loading, PHP 8.5 deprecation, administrative UI escaping and entity preview fixes.
- Verified docker.io/library/drupal:11.4.6-php8.5-apache-bookworm manifest, including linux/amd64 and linux/arm64.
- HelmForge MySQL 2.0.3 dependency is current. Container, database selection, ports and persistent sites layout remain compatible.

| Change | Chart impact | Validation |
|---|---|---|
| Drupal core/PHP fixes | Update pinned image and appVersion | Actual Drupal 11.4.6 / PHP 8.5, MySQL and SQLite PDO drivers, Apache installer response |
| Installed-site behavior | Review modules/themes and database updates in staging | Operator upgrade guidance; no claim of testing custom site content |

## Validation

- Complete chart gate passed all 11 layers with the default bundled MySQL scenario; all CI values rendered and schema-validated.
- Application and database became ready with zero restarts. Four transient MySQL startup-probe warnings resolved during initialization.
- Dependency freshness, template standards, standards-check and preflight passed.
- Kubescape 4.0.13: 83.33% MITRE/NSA/SOC2; README updated.
- Site production build and 156 local links/anchors passed.

Only default runtime was selected because this patch changes no chart database, storage, backup or scaling contract. Other profiles remain statically covered. The chart deliberately leaves site installation to the Drupal installer. Chart version remains CI-managed.
