### PR TITLE
chore(matterbridge): bump standalone image to 3.10.8

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Test distribution tag filtering
+        run: node --test scripts/filter-upstream-tags.test.mjs
+
       - name: Install yq
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
@@ -163,6 +166,7 @@ jobs:
             # Filter tags and find latest stable version
             # ---------------------------------------------------------------
             LATEST=$(echo "$ALL_TAGS" | grep -v '^$' \
+              | node scripts/filter-upstream-tags.mjs "$REPO" \
               | { if [ -n "$TAG_VARIANT" ]; then
                     grep -E "^v?[0-9]+\.[0-9]+(\.[0-9]+)?${TAG_VARIANT}$"
                   else

--- a/charts/matterbridge/Chart.yaml
+++ b/charts/matterbridge/Chart.yaml
@@ -4,7 +4,7 @@ name: matterbridge
 description: Production-ready Matter plugin manager for bridging smart-home platforms to Matter ecosystems
 type: application
 version: 1.0.1
-appVersion: "3.10.7"
+appVersion: "3.10.8"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/matterbridge
 sources:

--- a/charts/matterbridge/PLAN.md
+++ b/charts/matterbridge/PLAN.md
@@ -3,7 +3,7 @@
 **Chart:** `matterbridge`
 **Issue:** helmforgedev/charts#1077
 **Initial chart version:** `1.0.0`
-**Application version:** `3.10.7`
+**Application version:** `3.10.8`
 **Maturity:** stable
 **Complexity:** medium
 
@@ -20,7 +20,7 @@ advanced pod-network users can add a UDP Service and CNI/reflector integration.
 
 ### P1-1: Stable Official Runtime
 
-- Pin `docker.io/luligu/matterbridge:3.10.7`.
+- Pin `docker.io/luligu/matterbridge:3.10.8`.
 - Configure frontend port 8283 and Matter base port 5540.
 - Preserve the upstream `matterbridge --docker` command contract.
 - Support an optional profile and additional CLI arguments.
@@ -151,7 +151,7 @@ Optional Matter Service (UDP range for portable mode)
 
 ## Validation Strategy
 
-1. `make image-verify IMAGE=docker.io/luligu/matterbridge:3.10.7`.
+1. `make image-verify IMAGE=docker.io/luligu/matterbridge:3.10.8`.
 2. `make deps-check CHART=matterbridge` (expected: no dependencies).
 3. `make validate-chart CHART=matterbridge` for the full static and k3d gate.
 4. `make standards-check CHART=matterbridge` and template standards check.

--- a/charts/matterbridge/README.md
+++ b/charts/matterbridge/README.md
@@ -55,7 +55,7 @@ Only use it on a trusted node and protect the administrative frontend.
 ## Features
 
 - Official, pinned multi-architecture Matterbridge image
-- Stable chart version `1.0.0` with upstream Matterbridge `3.10.7`
+- Stable chart with upstream Matterbridge `3.10.8`
 - StatefulSet singleton with explicit validation against unsafe scaling
 - One retained PVC for plugins, fabrics, certificates and configuration
 - Non-root UID/GID 1000, read-only root filesystem and all capabilities dropped
@@ -71,13 +71,13 @@ Only use it on a trusted node and protect the administrative frontend.
 - Existing PVC, extra volumes, sidecars, init containers and manifests
 - Graceful 60-second shutdown for storage and Matter session cleanup
 
-### 🟢 Security Scan: `matterbridge`
+### Security Scan: `matterbridge`
 
 | Framework | Score |
 |---|---|
 | MITRE + NSA + SOC2 | **93.93939%** |
 
-> ✅ Security posture acceptable.
+Rendered-manifest security posture assessed with Kubescape 4.0.13.
 
 The two medium findings are the intentionally optional NetworkPolicy controls.
 The default workload passes non-root, immutable filesystem, capability,
@@ -297,6 +297,16 @@ Do not publish commissioning codes from logs. They grant access to an
 uncommissioned Matter bridge.
 
 ## Upgrades
+
+Matterbridge 3.10.8 updates persistent-storage dependencies, fixes frontend
+WebSocket handling and corrects Matter cluster behavior. Closure dimensions now
+advertise 1% granularity by default. Review the
+[official release notes](https://github.com/Luligu/matterbridge/releases/tag/3.10.8)
+and test the installed plugins with a real Matter controller in staging.
+
+Use the standalone `luligu/matterbridge:3.10.8` distribution. Year-based tags such
+as `2026.9.1` in the same repository belong to the Home Assistant add-on and are
+not interchangeable with this chart's runtime.
 
 Before upgrading:
 

--- a/charts/matterbridge/RESEARCH.md
+++ b/charts/matterbridge/RESEARCH.md
@@ -3,7 +3,7 @@
 **Chart request:** helmforgedev/charts#1077
 **Requester:** drieks
 **Upstream:** [Matterbridge on GitHub](https://github.com/Luligu/matterbridge)
-**Research date:** 2026-08-29
+**Research date:** 2026-09-09
 
 ## Product and Runtime
 
@@ -11,12 +11,15 @@ Matterbridge is an Apache-2.0 Matter plugin manager. It exposes devices from
 platforms such as Zigbee2MQTT, MQTT, Home Assistant, Homebridge and Shelly to
 Matter controllers including Apple Home, Google Home and Amazon Alexa.
 
-The stable upstream release selected for this chart is `3.10.7`, published on
-2026-08-28. The official pinned image is
-`docker.io/luligu/matterbridge:3.10.7`. HelmForge manifest verification
-confirmed `linux/amd64` and `linux/arm64` support. The manifest digest observed
-during implementation was
-`sha256:568d9fae6342aadbd62aa72560b6e6c070c33b1c0c5224fe2925a28c1cb4ebc6`.
+The stable upstream release selected for this chart is `3.10.8`, published on
+2026-09-04. The official pinned image is
+`docker.io/luligu/matterbridge:3.10.8`. HelmForge manifest verification
+confirmed `linux/amd64` and `linux/arm64` support. The selected standalone image
+reports OCI application version `3.10.8` and source revision `3a44ab8`.
+
+Year-based tags such as `2026.9.1` in the same repository are Home Assistant
+add-on images with an s6 `/init` entrypoint. They are a different distribution
+and are excluded by the upstream watcher for this standalone chart.
 
 The image is based on `node:24-trixie-slim`, runs as root, starts
 `matterbridge --docker`, and includes the `mb_health` binary. Its Docker
@@ -193,7 +196,7 @@ reflection as supported features.
 ## Primary Sources
 
 - [Matterbridge repository](https://github.com/Luligu/matterbridge)
-- [Matterbridge 3.10.7 release](https://github.com/Luligu/matterbridge/releases/tag/3.10.7)
+- [Matterbridge 3.10.8 release](https://github.com/Luligu/matterbridge/releases/tag/3.10.8)
 - [Official Docker documentation](https://github.com/Luligu/matterbridge/blob/main/README-DOCKER.md)
 - [Official Docker Compose file](https://github.com/Luligu/matterbridge/blob/main/docker/docker-compose.yml)
 - [Official health check source](https://github.com/Luligu/matterbridge/blob/main/packages/core/src/mb_health.ts)

--- a/charts/matterbridge/scripts/runtime-smoke.mjs
+++ b/charts/matterbridge/scripts/runtime-smoke.mjs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const kubectl = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(kubectl(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'matterbridge'));
+assert.ok(pod, 'Ready Matterbridge pod required');
+const container = pod.spec.containers.find(c => c.name === 'matterbridge');
+const port = container.ports.find(p => p.name === 'http').containerPort;
+const code = `
+const fs=require('node:fs'),path=require('node:path');
+let dir=path.dirname(fs.realpathSync('/usr/local/bin/matterbridge')), version;
+while(dir!==path.dirname(dir)) {
+  const file=path.join(dir,'package.json');
+  if(fs.existsSync(file)){const pkg=JSON.parse(fs.readFileSync(file));if(pkg.name==='matterbridge'){version=pkg.version;break;}}
+  dir=path.dirname(dir);
+}
+fetch('http://127.0.0.1:${port}/health').then(async r=>{
+ if(r.status!==200)throw new Error('Health status '+r.status);
+ console.log(JSON.stringify({version,health:await r.json()}));
+}).catch(e=>{console.error(e.message);process.exitCode=1;});`;
+const result = JSON.parse(kubectl(['exec', pod.metadata.name, '-c', 'matterbridge', '--', 'node', '-e', code]));
+assert.equal(result.version, '3.10.8');
+assert.equal(result.health.status, 'ok');
+console.log('Matterbridge standalone 3.10.8: installed package version and live HTTP health verified.');

--- a/charts/matterbridge/tests/statefulset_test.yaml
+++ b/charts/matterbridge/tests/statefulset_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/luligu/matterbridge:3.10.7
+          value: docker.io/luligu/matterbridge:3.10.8
 
   - it: bypasses the root entrypoint and uses the persistent home
     asserts:

--- a/charts/matterbridge/values.yaml
+++ b/charts/matterbridge/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Official Matterbridge container repository.
   repository: docker.io/luligu/matterbridge
   # -- Pinned stable Matterbridge image tag.
-  tag: "3.10.7"
+  tag: "3.10.8"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 

--- a/scripts/filter-upstream-tags.mjs
+++ b/scripts/filter-upstream-tags.mjs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+export function filterDistributionTags(repository, tags) {
+  const standaloneMatterbridge = repository.replace(/^docker\.io\//, '') === 'luligu/matterbridge';
+  // This repository also publishes Home Assistant add-on images under year-based tags.
+  return tags.filter(tag => !standaloneMatterbridge || !/^v?\d{4}\./.test(tag));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const repository = process.argv[2];
+  if (!repository) throw new Error('Image repository is required');
+  const tags = readFileSync(0, 'utf8').split(/\r?\n/).filter(Boolean);
+  process.stdout.write(filterDistributionTags(repository, tags).join('\n') + '\n');
+}

--- a/scripts/filter-upstream-tags.test.mjs
+++ b/scripts/filter-upstream-tags.test.mjs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {filterDistributionTags} from './filter-upstream-tags.mjs';
+
+test('excludes Home Assistant tags while retaining future standalone major releases', () => {
+  for (const repository of ['docker.io/luligu/matterbridge', 'luligu/matterbridge']) {
+    assert.deepEqual(filterDistributionTags(repository, ['3.10.7', '2026.9.1', '3.10.8', 'v2027.1.0', '4.0.0']), ['3.10.7', '3.10.8', '4.0.0']);
+  }
+});
+test('preserves calendar versions for other distributions', () => {
+  assert.deepEqual(filterDistributionTags('docker.io/cloudflare/cloudflared', ['2026.8.3']), ['2026.8.3']);
+});
+test('filters newline-delimited registry output through the CLI', () => {
+  const script = fileURLToPath(new URL('./filter-upstream-tags.mjs', import.meta.url));
+  const output = execFileSync(process.execPath, [script, 'luligu/matterbridge'], {
+    input: '3.10.8\r\n2026.9.1\r\n\r\n', encoding: 'utf8',
+  });
+  assert.equal(output, '3.10.8\n');
+});


### PR DESCRIPTION
Matterbridge now uses standalone 3.10.8. Issue #1140 selected 2026.9.1 from the same repository, but that tag is a Home Assistant add-on with a different s6 /init entrypoint. The upstream watcher now excludes those add-on calendar tags only for luligu/matterbridge, while retaining future standalone major releases and calendar tags for other repositories.

Resolves #1140

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- [Official 3.10.8 release](https://github.com/Luligu/matterbridge/releases/tag/3.10.8), [tagged Docker documentation](https://github.com/Luligu/matterbridge/blob/3.10.8/README-DOCKER.md).
- Verified luligu/matterbridge:3.10.8 for linux/amd64 and linux/arm64. OCI configuration identifies standalone version 3.10.8, source revision 3a44ab8 and matterbridge --docker. The 2026.9.1 add-on configuration has /init instead.
- Existing singleton, non-root homedir /data, storage and network contracts remain compatible; dependency freshness passed.

| Change | Chart impact | Validation |
|---|---|---|
| Shared repository contains a different add-on distribution | Repository-specific watcher filter | Three regression tests, including CLI/CRLF input, future standalone major and unrelated calendar-version repository |
| Persistent-storage dependency update | Retain PVC layout and orderly singleton upgrade | 3.10.7 to 3.10.8 application startup-counter continuity and subsequent pod replacement |
| Matter cluster and frontend WebSocket fixes | Pinned image; document closure 1% default | Default and host-network runtime; package version and HTTP health |

## Validation

- Full chart gate passed all 12 layers, including default and host-network profiles; zero workload restarts.
- Persistent upgrade passed: application-managed startup counter increased by exactly one at each startup, with actual versions and homedir verified through the frontend API. No paired physical controller or device was used.
- Tag-filter tests, actionlint, dependency freshness, template standards, standards-check and preflight passed.
- Kubescape 4.0.13: 93.94% MITRE/NSA/SOC2.
- Site build and 157 local links/anchors passed; playground default synchronized.

Other profiles remain statically covered because their contracts are unchanged. Physical LAN commissioning, installed third-party plugin compatibility and fabric backup restoration require operator staging validation. Chart version remains CI-managed.
