### PR TITLE
chore(netbird): bump to 0.78.1 and verify combined services

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump NetBird to 0.77.1 (#1053)"
+      description: "bump NetBird to 0.78.1 (#1145)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.9
-appVersion: "0.77.1"
+appVersion: "0.78.1"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -151,6 +151,7 @@ installation even while the multiplexed API and relay are serving requests.
 Use API authentication, OIDC discovery, relay connectivity and metrics for local
 smoke checks; validate public relay reachability separately in the deployed
 network. The chart's existing TCP probe policy is unchanged.
+
 ## Validation
 
 ```bash

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.77.1` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.78.1` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.10` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -105,30 +105,32 @@ SQLite remains available for lab installs with `database.mode=sqlite` and
 
 Use `externalSecrets.items[]` to synchronize sensitive values such as `config.yaml`, owner bootstrap credentials, OIDC client secrets, or database credentials from an external secret store.
 
-## Security Scan
+### Security Scan: `netbird`
 
-Local security scan:
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **86.87%** |
 
-```text
-Image: netbirdio/netbird-server:0.77.1
-Image: netbirdio/dashboard:v2.90.10
-Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
-Result: 86.86869 compliance score
-```
+Rendered-manifest scan using Kubescape 4.0.13.
 
 The local scan reported no critical failures and an overall score above the
 repository security gate. Remaining findings are tracked as hardening trade-offs
 for optional NetworkPolicy enablement, upstream dashboard startup model, and
 operator-owned resource limit tuning across the database-backed topology.
 
-## Upgrade to 0.77.1
+## Upgrade to 0.78.1
 
-NetBird `0.77.1` fixes Linux session extension and SSH authentication, rejects
-unsupported one-off setup-key limits, and skips unnecessary store migrations
-for PostgreSQL deployments. The chart's combined server image keeps management,
-signal, relay, and proxy components on the same version. Review the
-[upstream 0.77.1 release](https://github.com/netbirdio/netbird/releases/tag/v0.77.1)
-before upgrading.
+NetBird `0.78.1` includes the 0.78.0 Go/QUIC updates, embedded proxy Rosenpass
+support in permissive mode, lazy proxy connections and the SQLite network-map
+fix for peer-based routers. Review both the
+[0.78.0 release](https://github.com/netbirdio/netbird/releases/tag/v0.78.0) and
+[0.78.1 release](https://github.com/netbirdio/netbird/releases/tag/v0.78.1).
+
+Remote debug jobs now require an explicit opt-in on the peer
+(`--allow-remote-jobs` or managed `allowRemoteJobs`). The chart does not enable
+remote jobs on clients. To opt out of the proxy's new Rosenpass behavior, supply
+`NB_PROXY_ROSENPASS=false` through `server.env`. Test real peers, routes and
+reverse-proxy services in staging before upgrading production.
 
 Back up the configured database and `/var/lib/netbird`, then apply the new chart
 defaults while preserving your explicit overrides:
@@ -141,8 +143,14 @@ helm upgrade netbird helmforge/netbird \
 ```
 
 Using `--reuse-values` alone retains the previous default image tag. Remove any
-explicit `server.image.tag` override if you want the chart default `0.77.1`.
+explicit `server.image.tag` override if you want the chart default `0.78.1`.
 
+The combined server's port-9000 `/health` endpoint checks the advertised public
+relay address and standalone listener list. It can return 503 in a private
+installation even while the multiplexed API and relay are serving requests.
+Use API authentication, OIDC discovery, relay connectivity and metrics for local
+smoke checks; validate public relay reachability separately in the deployed
+network. The chart's existing TCP probe policy is unchanged.
 ## Validation
 
 ```bash

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -120,7 +120,7 @@ operator-owned resource limit tuning across the database-backed topology.
 
 ## Upgrade to 0.78.1
 
-NetBird `0.78.1` includes the 0.78.0 Go/QUIC updates, embedded proxy Rosenpass
+NetBird `0.78.1` includes the 0.78.0 Go/QUIC updates, reverse-proxy Rosenpass
 support in permissive mode, lazy proxy connections and the SQLite network-map
 fix for peer-based routers. Review both the
 [0.78.0 release](https://github.com/netbirdio/netbird/releases/tag/v0.78.0) and
@@ -128,9 +128,10 @@ fix for peer-based routers. Review both the
 
 Remote debug jobs now require an explicit opt-in on the peer
 (`--allow-remote-jobs` or managed `allowRemoteJobs`). The chart does not enable
-remote jobs on clients. To opt out of the proxy's new Rosenpass behavior, supply
-`NB_PROXY_ROSENPASS=false` through `server.env`. Test real peers, routes and
-reverse-proxy services in staging before upgrading production.
+remote jobs on clients. Rosenpass settings belong to the separately deployed
+NetBird Reverse Proxy; `server.env` configures the combined server. Configure
+`NB_PROXY_ROSENPASS=false` on that separate proxy if opting out. Test real peers,
+routes and reverse-proxy services in staging before upgrading production.
 
 Back up the configured database and `/var/lib/netbird`, then apply the new chart
 defaults while preserving your explicit overrides:

--- a/charts/netbird/scripts/runtime-smoke.mjs
+++ b/charts/netbird/scripts/runtime-smoke.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync, spawn} from 'node:child_process';
+import {setTimeout as delay} from 'node:timers/promises';
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const target = ['--context', context, '-n', namespace];
+const kubectl = args => execFileSync('kubectl', [...target, ...args], {encoding:'utf8', timeout:30000, stdio:['ignore','pipe','pipe']});
+const pods = JSON.parse(kubectl(['get','pods','-l',`app.kubernetes.io/instance=${release}`,'-o','json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'server'));
+assert.ok(pod, 'Ready NetBird server pod required');
+let logs='';
+for(let i=0;i<30;i++) {
+  logs=kubectl(['logs',pod.metadata.name,'-c','server']);
+  if(logs.includes('running metrics server:')) break;
+  await delay(1000);
+}
+assert.match(logs,/management server version 0\.78\.1\b/);
+assert.match(logs,/running metrics server:/);
+const child = spawn('kubectl', [...target,'port-forward',`pod/${pod.metadata.name}`,':80',':9090','--address=127.0.0.1'], {
+  windowsHide:true, stdio:['ignore','pipe','pipe'],
+});
+let output='', error;
+child.stdout.on('data', chunk => {output+=chunk;});
+child.stderr.on('data', () => {});
+child.on('error', caught => {error=caught;});
+try {
+  const ports = {};
+  for (let i=0;i<150 && Object.keys(ports).length<2 && !error;i++) {
+    for (const m of output.matchAll(/127\.0\.0\.1:(\d+) -> (\d+)/g)) ports[m[2]]=m[1];
+    await delay(100);
+  }
+  if(error) throw error;
+  assert.equal(Object.keys(ports).length,2,'All port forwards required');
+  const deadline=Date.now()+90000;
+  async function get(port, route, expected) {
+    let last;
+    for(let i=0;i<30 && Date.now()<deadline;i++) {
+      try {
+        const response=await fetch(`http://127.0.0.1:${ports[port]}${route}`, {redirect:'manual',signal:AbortSignal.timeout(4000)});
+        const body=await response.text();
+        if(response.status===expected) return body;
+        last=`HTTP ${response.status}`;
+      } catch(caught) {last=caught.message;}
+      await delay(1000);
+    }
+    throw new Error(`${route}: expected ${expected}, last result ${last}`);
+  }
+  // The relay health endpoint validates the public URL; it is not local readiness.
+  await get(80,'/api/accounts',401);
+  const discovery=JSON.parse(await get(80,'/oauth2/.well-known/openid-configuration',200));
+  assert.ok(discovery.issuer && discovery.jwks_uri,'OIDC issuer and signing keys required');
+  assert.match(await get(9090,'/metrics',200),/# (?:HELP|TYPE) /);
+  await new Promise((resolve,reject) => {
+    const socket=new WebSocket(`ws://127.0.0.1:${ports[80]}/relay`);
+    const timer=setTimeout(()=>{socket.close();reject(new Error('Relay WebSocket upgrade timed out'));},10000);
+    socket.addEventListener('open',()=>{clearTimeout(timer);socket.close();resolve();},{once:true});
+    socket.addEventListener('error',()=>{clearTimeout(timer);reject(new Error('Relay WebSocket upgrade failed'));},{once:true});
+  });
+  console.log('NetBird 0.78.1: unauthenticated API rejection, embedded OIDC discovery, relay WebSocket upgrade and Prometheus exposition verified.');
+} finally {
+  if(child.exitCode===null) {
+    if(process.platform==='win32') execFileSync('taskkill',['/PID',String(child.pid),'/T','/F'],{stdio:'ignore'});
+    else child.kill('SIGTERM');
+  }
+}

--- a/charts/netbird/scripts/runtime-smoke.mjs
+++ b/charts/netbird/scripts/runtime-smoke.mjs
@@ -2,6 +2,9 @@
 import assert from 'node:assert/strict';
 import {execFileSync, spawn} from 'node:child_process';
 import {setTimeout as delay} from 'node:timers/promises';
+if (Number(process.versions.node.split('.')[0]) < 22) {
+  throw new Error('Node.js >= 22 is required for the relay WebSocket smoke test');
+}
 const [context, namespace, release] = process.argv.slice(2);
 if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
   throw new Error('Explicit HelmForge lab context, namespace and release required');

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.77.1
+          value: netbirdio/netbird-server:0.78.1
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.77.1"
+    tag: "0.78.1"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
NetBird's combined server now uses 0.78.1, retaining the separate dashboard release and existing database/probe contracts. New runtime checks exercise authenticated-boundary behavior, embedded OIDC discovery, relay WebSocket upgrade and Prometheus exposition on both PostgreSQL and SQLite installations.

Resolves #1145

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- [0.78.0 release](https://github.com/netbirdio/netbird/releases/tag/v0.78.0): Go/QUIC updates, separate reverse-proxy Rosenpass in permissive mode, lazy proxy peers, management hardening and client remote-jobs opt-in.
- [0.78.1 release](https://github.com/netbirdio/netbird/releases/tag/v0.78.1): SQLite network maps include peer-based routers.
- Verified netbirdio/netbird-server:0.78.1 for linux/amd64, linux/arm64 and linux/arm. PostgreSQL dependency 2.0.5 is current.
- [Combined-server verification guidance](https://docs.netbird.io/selfhosted/migration/combined-container) documents OIDC discovery and unauthenticated management API rejection.

| Change | Chart impact | Runtime scenario |
|---|---|---|
| Combined management/relay and toolchain updates | Pinned server image; dashboard version remains independent | default PostgreSQL, API 401, OIDC discovery, relay WebSocket, metrics |
| SQLite network-map fix | Keep SQLite configuration compatible | ci/sqlite-values.yaml with the same service checks |
| Proxy Rosenpass and remote-jobs behavior | Operator notes for separate proxy and peer configuration | No forced client opt-in or proxy feature changes |

## Validation

- Final complete gate passed all 12 layers, including PostgreSQL/default and SQLite runtime scenarios with zero restarts.
- Focused playground tests passed on Chromium, Firefox and WebKit; site build and 156 local links/anchors passed.
- Preflight, dependency freshness, template standards and standards-check passed.
- Kubescape 4.0.13: 86.87% MITRE/NSA/SOC2; scan section refreshed.

The relay port-9000 /health endpoint validates the advertised public address and listener list, rather than local combined-server readiness. It returns 503 in this private lab; its implementation is unchanged from 0.77.1. The PR documents this limitation and validates management/OIDC endpoints, relay WebSocket and metrics directly while retaining the existing TCP probe policy.

No real peers, remote jobs, end-to-end routed traffic or Rosenpass peer negotiation were exercised. Other CI profiles are statically covered because their chart contracts are unchanged. Chart version remains CI-managed.
