### PR TITLE
chore(authelia): bump authelia to 4.39.22

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -4,7 +4,7 @@ name: authelia
 description: Authelia authentication and authorization server with SSO, MFA, and OpenID Connect
 type: application
 version: 1.5.9
-appVersion: "4.39.20"
+appVersion: "4.39.22"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/authelia.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1080)"
+      description: "bump Authelia to 4.39.22 and verify encrypted storage migration (#1127)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -47,7 +47,7 @@ A disabled placeholder `admin` account is shipped because Authelia requires a no
 Enable it only after setting a strong password hash. Generate one with:
 
 ```bash
-docker run authelia/authelia:4.39.20 authelia crypto hash generate argon2
+docker run authelia/authelia:4.39.22 authelia crypto hash generate argon2
 ```
 
 ```yaml
@@ -185,19 +185,37 @@ auth_request /authelia;
 auth_request_set $user $upstream_http_remote_user;
 ```
 
+## Upgrading to 4.39.22
+
+Authelia 4.39.21 changes storage encryption to use HKDF and authenticated
+additional data; 4.39.22 fixes the access-token JWT session migration. Back up
+the database and retain the storage encryption key before upgrading. Allow
+startup migrations to complete before serving traffic. Restore the matching
+database backup and key if a rollback requires the previous storage format.
+
+The chart preserves generated credentials through Helm cluster lookup. Use an
+existing Secret for GitOps or offline rendering, where lookup cannot retrieve
+the installed key. Do not rotate the storage key as part of an image update.
+After rollout, run `authelia storage encryption check --config /config/configuration.yml`
+inside the Authelia container and verify application health and MFA enrollment.
+
+Release notes: [4.39.21](https://github.com/authelia/authelia/releases/tag/v4.39.21),
+[4.39.22](https://github.com/authelia/authelia/releases/tag/v4.39.22).
+
 ## More Information
 
 - [Architecture](docs/architecture.md) — deployment model, configuration injection, forward auth setup
 - [Authelia Documentation](https://www.authelia.com/configuration/prologue/introduction/)
 - [Source Code](https://github.com/helmforgedev/charts/tree/main/charts/authelia)
 
-### 🟢 Security Scan: `authelia`
+### Security Scan: `authelia`
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **90.31987%** |
+| MITRE + NSA + SOC2 | **87.88%** |
 
-> ✅ Security posture acceptable.
+Scan of rendered Kubernetes resources; application authentication and storage
+behavior require separate runtime validation.
 
 <!-- @AI-METADATA
 @description: README for the Authelia Helm chart

--- a/charts/authelia/examples/simple.yaml
+++ b/charts/authelia/examples/simple.yaml
@@ -21,7 +21,7 @@ usersDatabase:
     admin:
       displayname: "Admin User"
       email: "admin@example.com"
-      # Password: "password" (argon2id hash - generate with: docker run --rm authelia/authelia:4.39.20 authelia crypto hash generate argon2)
+      # Password: "password" (argon2id hash - generate with: docker run --rm authelia/authelia:4.39.22 authelia crypto hash generate argon2)
       password: "$argon2id$v=19$m=65536,t=3,p=4$REPLACE_WITH_REAL_HASH"
       groups:
         - admins

--- a/charts/authelia/scripts/runtime-smoke.mjs
+++ b/charts/authelia/scripts/runtime-smoke.mjs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync, spawn} from 'node:child_process';
+import {setTimeout as delay} from 'node:timers/promises';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const target = ['--context', context, '-n', namespace];
+const kubectl = args => execFileSync('kubectl', [...target, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(kubectl(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'authelia'));
+assert.ok(pod, 'Ready Authelia pod required');
+const exec = args => kubectl(['exec', pod.metadata.name, '-c', 'authelia', '--', 'authelia', ...args]);
+assert.match(exec(['--version']), /v4\.39\.22\b/);
+assert.match(exec(['storage', 'encryption', 'check', '--config', '/config/configuration.yml']), /SUCCESS/);
+const metrics = pod.spec.containers.find(c => c.name === 'authelia').ports.some(p => p.name === 'metrics');
+const ports = metrics ? [9091, 9959] : [9091];
+const child = spawn('kubectl', [...target, 'port-forward', `pod/${pod.metadata.name}`,
+  ...ports.map(p => `:${p}`), '--address=127.0.0.1'], {windowsHide: true, stdio: ['ignore', 'pipe', 'pipe']});
+let output = '', error;
+child.stdout.on('data', chunk => { output += chunk; });
+child.stderr.on('data', () => {});
+child.on('error', caught => { error = caught; });
+try {
+  const forwarded = {};
+  for (let i = 0; i < 150 && Object.keys(forwarded).length < ports.length && !error; i++) {
+    for (const m of output.matchAll(/127\.0\.0\.1:(\d+) -> (\d+)/g)) forwarded[m[2]] = m[1];
+    await delay(100);
+  }
+  if (error) throw error;
+  assert.equal(Object.keys(forwarded).length, ports.length);
+  const health = await fetch(`http://127.0.0.1:${forwarded[9091]}/api/health`, {signal: AbortSignal.timeout(10000)});
+  assert.equal(health.status, 200);
+  await health.arrayBuffer();
+  if (metrics) {
+    const response = await fetch(`http://127.0.0.1:${forwarded[9959]}/metrics`, {signal: AbortSignal.timeout(10000)});
+    assert.equal(response.status, 200);
+    const body = await response.text();
+    assert.match(body, /^# HELP /m);
+    assert.match(body, /^# TYPE /m);
+  }
+  console.log(`PASS: Authelia 4.39.22, storage encryption and API health${metrics ? ', Prometheus scrape' : ''}`);
+} finally {
+  if (child.exitCode === null) {
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], {stdio: 'ignore'});
+      } catch (cleanupError) {
+        // The forwarder can exit before taskkill observes it. Suppress only
+        // that race; retain failures when the process still exists.
+        let exists = true;
+        try { process.kill(child.pid, 0); }
+        catch (error) { if (error.code === 'ESRCH') exists = false; else throw error; }
+        if (exists) throw cleanupError;
+      }
+    } else child.kill('SIGTERM');
+  }
+}

--- a/charts/authelia/tests/deployment_test.yaml
+++ b/charts/authelia/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/authelia/authelia:4.39.20"
+          value: "docker.io/authelia/authelia:4.39.22"
 
   - it: should use custom image tag
     template: templates/deployment.yaml

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Authelia container image
   repository: docker.io/authelia/authelia
   # -- Image tag
-  tag: "4.39.20"
+  tag: "4.39.22"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -231,7 +231,7 @@ usersDatabase:
   # A disabled placeholder account is shipped because Authelia requires a non-empty
   # file users database when the file backend is enabled. Enable it only after
   # setting a strong password hash. Generate a hash with:
-  # docker run authelia/authelia:4.39.20 authelia crypto hash generate argon2
+  # docker run authelia/authelia:4.39.22 authelia crypto hash generate argon2
   users:
     admin:
       disabled: true


### PR DESCRIPTION
Authelia now uses 4.39.22, including the encrypted-storage changes in 4.39.21 and the JWT access-token session migration fix. Upgrade guidance explains database backups and retaining the storage encryption key. Runtime checks verify the running version, storage encryption, API health and optional Prometheus endpoint.

Resolves #1127

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence

- [4.39.21 release](https://github.com/authelia/authelia/releases/tag/v4.39.21): storage HKDF/AAD, WebAuthn derivation, authentication fixes and missing metric recording.
- [4.39.22 release](https://github.com/authelia/authelia/releases/tag/v4.39.22): JWT access-token session migration fix.
- [Storage encryption change](https://github.com/authelia/authelia/pull/12447) and [JWT migration fix](https://github.com/authelia/authelia/pull/12958) reviewed.
- Official authelia/authelia:4.39.22 manifest verified for linux/amd64, linux/arm and linux/arm64. HelmForge dependencies checked against current releases.

| Change | Chart impact | Runtime scenario |
|---|---|---|
| Encrypted storage migration | Preserve existing key and document database backup | default SQLite, ci/postgres-values.yaml, ci/mysql-values.yaml; persisted TOTP upgrade in every backend |
| JWT session migration correction | Complete startup storage migration before readiness | All three database profiles; full OIDC token-session matrix not exercised |
| Metrics recording fix | Preserve telemetry and ServiceMonitor configuration | ci/monitoring-values.yaml with live Prometheus scrape |

## Validation

- Final full gate passed all 14 layers, including default, monitoring, MySQL and PostgreSQL/Redis runtime profiles.
- Persisted 4.39.20 -> 4.39.22 TOTP upgrade and pod replacement passed on SQLite, PostgreSQL and MySQL.
- Preflight and template standards passed. Kubescape 4.0.13: 87.88% MITRE/NSA/SOC2.
- Site production build and 156 local links/anchors passed.
- Zero runtime restarts. MySQL had four transient startup-probe warnings before readiness; the final workload was healthy.
- The first gate exposed a Windows port-forward cleanup race after successful application checks. The helper now tolerates only an already-exited PID; the complete gate passed after that correction.

The upgrade test installs 4.39.20, generates a TOTP record through the official CLI, upgrades to 4.39.22, and compares decrypted export digests and encryption keys after upgrade and pod replacement. No TOTP material or credentials are printed. Other CI profiles remain statically covered; ingress, Gateway, external Secret mapping and networking contracts are unchanged. Chart version remains CI-managed.
