### PR TITLE
chore(poznote): bump poznote to 6.80.0

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 2.0.1
-appVersion: "6.68.7"
+appVersion: "6.80.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump app to 6.68.7 (#1120)"
+      description: "bump app to 6.80.0 (#1148)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.68.7
+ghcr.io/timothepoznanski/poznote:6.80.0
 ```
 
-The tag maps to the upstream `6.68.7` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.80.0` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.68.7-rootless` variant. It is not the chart
+Upstream also publishes a `6.80.0-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.68.7` |
+| `image.tag` | Image tag | `6.80.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -143,16 +143,23 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.68.4` through `6.68.7` include proxy share-link and attachment
-sanitization fixes, a critical backup-restore SQL execution fix, and stored XSS
-fixes. Review the
-[upstream 6.68.7 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.7)
-before upgrading. The default local SQLite and filesystem deployment remains
-compatible; S3 integration is configured inside Poznote when needed.
+Poznote `6.80.0` includes the 6.69–6.80 background export, restore and import
+workers, chunked archive uploads, snapshot retention and conflict-safe autosave.
+Complete backups and restores now continue in detached workers, with progress
+polled by the browser. Keep the pod running until the job completes and verify
+its final status before downloading or relying on the backup.
 
-No upstream storage migration is required. Back up the `data` PVC before
-upgrading because it stores the SQLite database, notes, attachments, and
-application configuration.
+Back up the complete `data` PVC before upgrading and verify a restore in a
+separate instance. It contains SQLite, notes, attachments and application
+configuration. Existing S3 integrations remain application configuration;
+confirm attachment access when exporting or restoring an account.
+
+Shared links default to read-only. API integrations should retain the returned
+note version and use `if_version` or `If-Match` to detect concurrent edits.
+MCP user selection and optional `POZNOTE_MCP_AUTH_TOKEN` apply to the separate
+MCP server; the chart does not deploy or expose it. Review the
+[upstream releases](https://github.com/timothepoznanski/poznote/releases)
+before upgrading integrations.
 
 ## Security Scan
 
@@ -160,7 +167,7 @@ Security Scan: `poznote`
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **87.878784%** |
+| MITRE + NSA + SOC2 | **87.88%** |
 
 > Security posture acceptable.
 

--- a/charts/poznote/scripts/runtime-smoke.mjs
+++ b/charts/poznote/scripts/runtime-smoke.mjs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const kubectl = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(kubectl(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'poznote'));
+assert.ok(pod, 'Ready Poznote pod required');
+const exec = args => kubectl(['exec', pod.metadata.name, '-c', 'poznote', '--', ...args]);
+assert.equal(exec(['cat', '/var/www/html/version.txt']).trim(), '6.80.0');
+const health = exec(['php', '-r', `
+$context = stream_context_create(['http' => ['timeout' => 10]]);
+$body = file_get_contents('http://127.0.0.1/api/health', false, $context);
+if ($body === false || !preg_match('/^HTTP\\/\\S+ 200\\b/', $http_response_header[0] ?? '')) {
+    fwrite(STDERR, "Poznote health endpoint failed\\n"); exit(1);
+}
+echo "health status 200\\n";
+`]);
+assert.match(health, /health status 200/);
+console.log('PASS: Poznote 6.80.0 and live PHP/API health');

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.68.7"
+          value: "ghcr.io/timothepoznanski/poznote:6.80.0"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.68.7"
+  tag: "6.80.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Poznote now uses 6.80.0, preserving its single-pod SQLite deployment and the standard upstream image. Upgrade guidance covers detached backup/restore workers, chunk uploads, optimistic note updates and the separately deployed MCP server.

Resolves #1148

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- Reviewed all stable releases from 6.68.7 through 6.80.0 in the [official release history](https://github.com/timothepoznanski/poznote/releases), including [6.80.0](https://github.com/timothepoznanski/poznote/releases/tag/6.80.0).
- Official ghcr.io/timothepoznanski/poznote:6.80.0 and the documented rootless variant have verified manifests; the chart retains the standard distribution and its volume ownership contract.
- [Tagged API contract](https://github.com/timothepoznanski/poznote/blob/6.80.0/src/api-docs/openapi.yaml), [background exports](https://github.com/timothepoznanski/poznote/blob/6.80.0/src/api_backup_job.php), and [chunked restores](https://github.com/timothepoznanski/poznote/blob/6.80.0/src/api_restore_upload.php) reviewed.

| Change | Chart impact | Validation |
|---|---|---|
| Background archive jobs and chunk uploads | Existing PHP runtime, writable data PVC and single replica | Default runtime; actual background export and two-chunk restore |
| SQLite, snapshots and note persistence | Preserve data directory and standard image ownership | 6.68.7 to 6.80.0 upgrade with retained UTF-8 note and pod replacement |
| Conflict-safe autosave | Document version preconditions for API integrations | Successful conditional save followed by stale-version HTTP 409 |
| Sharing defaults and MCP identity/token changes | Operator notes; MCP remains a separate deployment | Existing sharing/Secret/networking CI profiles statically rendered |

## Validation

- Full gate passed all 11 layers, including live Poznote 6.80.0/PHP/API health with zero restarts.
- Persisted 6.68.7 -> 6.80.0 UTF-8 note, conditional-save conflict (HTTP 409), background ZIP export, two-chunk background restore and pod replacement passed.
- Preflight, dependency freshness and template standards passed. Kubescape 4.0.13: 87.88% MITRE/NSA/SOC2.
- Site production build, 156 local links/anchors and focused playground tests in Chromium, Firefox and WebKit passed.

S3 attachment access, external OIDC login and separately deployed MCP were not exercised. The update does not configure those integrations or add an MCP Service. All CI values receive static validation; default runtime covers the affected application filesystem and worker process model. Chart version remains CI-managed.
