### PR TITLE
fix(n8n)!: align 2.38.4 storage and runner contracts

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: n8n
-description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
+description: n8n workflow automation platform with SQLite or PostgreSQL and optional Redis queue mode
 type: application
 version: 1.6.17
-appVersion: "2.35.3"
+appVersion: "2.38.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1080)"
+      description: "update n8n to 2.38.4 and reject unsupported MySQL storage (#1144)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -54,10 +54,6 @@ dependencies:
     version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
-  - name: mysql
-    version: 2.0.3
-    repository: oci://ghcr.io/helmforgedev/helm
-    condition: mysql.enabled
   - name: redis
     version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm

--- a/charts/n8n/DESIGN.md
+++ b/charts/n8n/DESIGN.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This chart deploys n8n for self-hosted workflow automation. It supports the
-zero-configuration SQLite path, HelmForge-managed PostgreSQL or MySQL, external
+zero-configuration SQLite path, HelmForge-managed PostgreSQL, external
 databases, Redis-backed queue mode, worker replicas, persistent data, ingress,
 Gateway API, External Secrets, and S3-compatible backup jobs.
 
@@ -15,7 +15,7 @@ flowchart LR
   route --> svc[n8n Service]
   svc --> main[n8n main Deployment]
   main --> data[(n8n PVC)]
-  main --> db[(SQLite, PostgreSQL, or MySQL)]
+  main --> db[(SQLite or PostgreSQL)]
   main --> redis[(Redis queue)]
   worker[n8n worker Deployment] --> redis
   worker --> db
@@ -31,7 +31,7 @@ flowchart LR
 
 - Use the upstream `docker.io/n8nio/n8n` image and pin explicit release tags.
 - Keep SQLite as the default so small installations can start without subcharts.
-- Use HelmForge PostgreSQL, MySQL, and Redis subcharts when operators enable
+- Use HelmForge PostgreSQL and Redis subcharts when operators enable
   managed dependencies.
 - Auto-detect database mode from external database settings and enabled
   subcharts, while still allowing explicit `database.mode` overrides.
@@ -53,14 +53,14 @@ flowchart LR
   not depend on the Python runtime inside the main `n8nio/n8n` image.
 - Use a single `gateway` block with Gateway API `parentRefs`, matching the
   consolidated HelmForge routing pattern and avoiding competing aliases.
-- Include database-aware backup scripts for SQLite, PostgreSQL, and MySQL.
+- Include database-aware backup scripts for SQLite and PostgreSQL.
 
 ## Production Boundary
 
 For production, operators should define:
 
 - a stable `n8n.encryptionKey` or existing Secret before first workflow use
-- PostgreSQL or MySQL instead of SQLite for larger or multi-pod deployments
+- PostgreSQL instead of SQLite for larger or multi-pod deployments
 - Redis and worker sizing when queue mode is enabled
 - webhook/editor URLs that match the public ingress or Gateway endpoint
 - resource requests and limits for main, worker, backup, database, and Redis pods
@@ -82,7 +82,7 @@ type: design
 title: n8n Chart Design
 description: Design document for the n8n Helm chart architecture, database modes, queue mode, backups, and production boundaries
 
-keywords: n8n, design, workflow, automation, queue, redis, postgresql, mysql, sqlite, backup, helm, kubernetes
+keywords: n8n, design, workflow, automation, queue, redis, postgresql, sqlite, backup, helm, kubernetes
 
 purpose: Document chart architecture, operational choices, production boundaries, and non-goals
 scope: Chart Design

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -150,14 +150,14 @@ externalSecrets:
 | `n8n.diagnosticsEnabled` | `false` | Share anonymous diagnostics with n8n |
 | `n8n.gracefulShutdownTimeout` | `60` | Graceful shutdown timeout in seconds for main and workers |
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql) |
-| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.4`) |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.5`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
 | `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
 | `queue.persistence.shareMainVolume` | `true` | Mount the main n8n data PVC into worker pods |
 | `terminationGracePeriodSeconds` | `75` | Kubernetes pod shutdown grace period |
-| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `2.0.0`) |
+| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `2.0.1`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
 | `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |
 | `taskRunners.image.tag` | `""` | External task runner sidecar tag (defaults to `image.tag`) |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -6,8 +6,7 @@ Deploy [n8n](https://n8n.io/) on Kubernetes — a workflow automation platform f
 
 - **SQLite by default** — zero database configuration needed
 - **PostgreSQL subchart** — bundled via HelmForge dependency
-- **MySQL subchart** — bundled via HelmForge dependency
-- **External database** — connect to existing PostgreSQL or MySQL
+- **External database** — connect to existing PostgreSQL
 - **Queue mode** — Redis-backed horizontal scaling with worker pods
 - **Redis subchart** — bundled via HelmForge dependency for queue mode
 - **Worker-aware persistence** — queue workers keep the main data PVC by default for upgrade compatibility, with an opt-out for RWO scheduling
@@ -144,16 +143,15 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.35.3` | n8n container image tag |
+| `image.tag` | `2.38.4` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
 | `n8n.diagnosticsEnabled` | `false` | Share anonymous diagnostics with n8n |
 | `n8n.gracefulShutdownTimeout` | `60` | Graceful shutdown timeout in seconds for main and workers |
-| `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
+| `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql) |
 | `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.4`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.3`) |
 | `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
@@ -186,16 +184,39 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.35.3` includes core, scaling-mode, queue, and task-runner maintenance
-updates. Review the
-[upstream 2.35.3 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.3)
-before upgrading. Back up the database, keep the encryption key stable, and
-validate task runners and queue workers in a staging namespace. This update also
-moves the bundled Redis dependency to HelmForge Redis `2.0.0`.
+n8n `2.38.4` includes the 2.36–2.38 runner broker and shutdown fixes,
+database pool recovery, encryption-key seeding and queue execution fixes. Back
+up the database and data volume, preserve the encryption key, and validate
+workflows and credentials in staging before upgrading. Keep the app and external
+runner tags aligned; an empty `taskRunners.image.tag` inherits `image.tag`.
 
-When upgrading with `--reuse-values`, explicitly set `image.tag=2.35.3`.
-Helm preserves the previous image override in that mode; also update
-`taskRunners.image.tag` when it was pinned separately.
+Use `helm upgrade --reset-then-reuse-values` with `image.tag=2.38.4` and update
+any separately pinned runner tag. Existing generated encryption keys and runner
+tokens are retained through Helm lookup; use existing Secrets for offline
+rendering or GitOps. Automatic database migrations require a recoverable backup.
+
+SQLite updates now use `Recreate` to stop the old main process before the new
+version opens the same database. Plan for brief downtime. The Python toggle
+`taskRunners.nativePython.enabled` now controls the n8n 2.x variable
+`N8N_PYTHON_ENABLED`; it remains disabled by default and requires external runners.
+
+### MySQL and MariaDB storage migration
+
+n8n removed MySQL/MariaDB storage in version 2.0. Earlier chart releases still
+exposed these unsupported options. This chart now rejects `mysql.enabled=true`,
+`database.mode=mysql` and non-PostgreSQL external vendors, and no longer bundles
+MySQL or MySQL backup jobs. The MySQL workflow node is unaffected.
+
+If an older deployment uses MySQL/MariaDB, stop here and migrate its data using
+the upstream migration procedure on a compatible source release. Back up the
+database and encryption key, migrate into a separate PostgreSQL instance, and
+verify credentials, workflows and executions before switching traffic. Changing
+`database.mode` alone does not migrate data. Do not apply this release over an
+existing bundled MySQL installation until its data has been migrated and its
+backup and PVC recovery have been verified.
+
+See the [2.0 storage migration guidance](https://github.com/n8n-io/n8n-docs/blob/main/docs/changelog/v20-breaking-changes.md)
+and [upstream releases](https://github.com/n8n-io/n8n/releases).
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
 token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next
@@ -236,13 +257,13 @@ reduces startup log noise. Operators can opt in with
 - [Chart design](DESIGN.md)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/n8n)
 
-### 🟢 Security Scan: `n8n`
+### Security Scan: `n8n`
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **85.774414%** |
+| MITRE + NSA + SOC2 | **87.88%** |
 
-> ✅ Security posture acceptable.
+Rendered-resource scan with Kubescape 4.0.13. Application and workflow behavior are validated separately.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/n8n/ci/mysql-values.yaml
+++ b/charts/n8n/ci/mysql-values.yaml
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# CI: MySQL subchart
-mysql:
-  enabled: true
-  auth:
-    database: n8n
-    username: n8n
-    password: ci-test-password

--- a/charts/n8n/ci/runners-python-values.yaml
+++ b/charts/n8n/ci/runners-python-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Exercise the native Python executable in the external runner image.
+taskRunners:
+  mode: external
+  nativePython:
+    enabled: true

--- a/charts/n8n/docs/backup.md
+++ b/charts/n8n/docs/backup.md
@@ -8,7 +8,6 @@ The chart includes a CronJob-based backup system that uploads archives to S3-com
 |----------|------|-----------------|
 | SQLite | `tar` | Full `/home/node/.n8n` directory |
 | PostgreSQL | `pg_dump` | SQL dump (gzipped) |
-| MySQL | `mysqldump` | SQL dump (gzipped) |
 
 ## Enable Backups
 
@@ -32,7 +31,7 @@ Prefer restoring into a fresh release, validating it, and only then switching tr
 
 When n8n uses SQLite, the restore boundary is the full `/home/node/.n8n` directory, not only `database.sqlite`.
 
-When n8n uses PostgreSQL or MySQL, restore the database dump and then validate encryption-key continuity before resuming executions.
+When n8n uses PostgreSQL, restore the database dump and then validate encryption-key continuity before resuming executions.
 
 ## Restore
 
@@ -54,14 +53,6 @@ gunzip /tmp/n8n-postgresql-20260323T030000Z.sql.gz
 psql -h <host> -U n8n -d n8n < /tmp/n8n-postgresql-20260323T030000Z.sql
 ```
 
-### MySQL
-
-```bash
-mc cp backup/my-backups/n8n/n8n-mysql-20260323T030000Z.sql.gz /tmp/
-gunzip /tmp/n8n-mysql-20260323T030000Z.sql.gz
-mysql -h <host> -u n8n -p n8n < /tmp/n8n-mysql-20260323T030000Z.sql
-```
-
 ## Post-restore validation
 
 - confirm the release still uses the expected encryption key secret
@@ -75,7 +66,7 @@ type: chart-docs
 title: Backup and Restore
 description: S3 backup strategy and restore procedures for the n8n Helm chart
 
-keywords: backup, restore, s3, cronjob, sqlite, postgresql, mysql, minio
+keywords: backup, restore, s3, cronjob, sqlite, postgresql, minio
 
 purpose: Help operators configure and use the backup system
 scope: Chart

--- a/charts/n8n/docs/database.md
+++ b/charts/n8n/docs/database.md
@@ -1,21 +1,27 @@
 # Database Configuration
 
-n8n supports three database backends: **SQLite** (default), **PostgreSQL**, and **MySQL**.
+n8n supports two database backends: **SQLite** (default) and **PostgreSQL**.
 
 ## Database Mode Detection
 
 The chart uses automatic mode detection (`database.mode: auto`):
 
+External and bundled PostgreSQL settings are mutually exclusive. Configuring
+both is rejected; the chart never chooses one database over another silently.
+
 | Priority | Condition | Result |
 |----------|-----------|--------|
 | 1 | `database.external.host` or `database.external.existingSecret` | External database |
 | 2 | `postgresql.enabled: true` | PostgreSQL subchart |
-| 3 | `mysql.enabled: true` | MySQL subchart |
-| 4 | None of the above | SQLite (default) |
+| 3 | None of the above | SQLite (default) |
 
 ## SQLite (Default)
 
 Zero configuration required. Data is stored in `/home/node/.n8n/database.sqlite`.
+
+SQLite deployments use `Recreate` updates so the previous main process stops
+before its replacement opens the database and runs migrations. Plan for brief
+downtime during upgrades and keep a recoverable data-volume backup.
 
 ```yaml
 persistence:
@@ -36,23 +42,30 @@ postgresql:
     password: "strong-password"
 ```
 
-## MySQL Subchart
+## MySQL and MariaDB storage migration
 
-```yaml
-mysql:
-  enabled: true
-  auth:
-    database: n8n
-    username: n8n
-    password: "strong-password"
-```
+n8n removed MySQL/MariaDB storage in version 2.0. Earlier chart releases still
+exposed these unsupported options. This chart now rejects `mysql.enabled=true`,
+`database.mode=mysql` and non-PostgreSQL external vendors, and no longer bundles
+MySQL or MySQL backup jobs. The MySQL workflow node is unaffected.
+
+If an older deployment uses MySQL/MariaDB, stop here and migrate its data using
+the upstream migration procedure on a compatible source release. Back up the
+database and encryption key, migrate into a separate PostgreSQL instance, and
+verify credentials, workflows and executions before switching traffic. Changing
+`database.mode` alone does not migrate data. Do not apply this release over an
+existing bundled MySQL installation until its data has been migrated and its
+backup and PVC recovery have been verified.
+
+See the [2.0 storage migration guidance](https://github.com/n8n-io/n8n-docs/blob/main/docs/changelog/v20-breaking-changes.md)
+and [upstream releases](https://github.com/n8n-io/n8n/releases).
 
 ## External Database
 
 ```yaml
 database:
   external:
-    vendor: postgres   # or mysql
+    vendor: postgres
     host: db.example.com
     name: n8n
     username: n8n
@@ -64,9 +77,9 @@ The secret must contain a key named `database-password` (configurable via `exist
 <!-- @AI-METADATA
 type: chart-docs
 title: Database Configuration
-description: Guide for configuring SQLite, PostgreSQL, or MySQL with the n8n Helm chart
+description: Guide for configuring SQLite or PostgreSQL with the n8n Helm chart
 
-keywords: database, sqlite, postgresql, mysql, external, subchart, configuration
+keywords: database, sqlite, postgresql, external, subchart, configuration
 
 purpose: Help operators choose and configure the right database backend
 scope: Chart

--- a/charts/n8n/docs/queue-mode.md
+++ b/charts/n8n/docs/queue-mode.md
@@ -12,7 +12,7 @@ interface.
 
 Queue mode is intentionally rejected when the chart resolves to SQLite. SQLite
 stores state on the main pod volume and cannot safely back multiple worker pods.
-Use the PostgreSQL subchart, the MySQL subchart, or an external PostgreSQL/MySQL
+Use the PostgreSQL subchart or an external PostgreSQL
 database before enabling `queue.enabled`.
 
 ## Enable Queue Mode
@@ -50,7 +50,7 @@ queue:
 ```
 
 Worker pods wait for the main n8n readiness endpoint before starting. This keeps
-database migrations serialized on fresh PostgreSQL or MySQL subchart installs.
+database migrations serialized on fresh PostgreSQL subchart installs.
 
 The chart sets `N8N_GRACEFUL_SHUTDOWN_TIMEOUT=60` and keeps the pod
 `terminationGracePeriodSeconds` above that value so workers can stop cleanly

--- a/charts/n8n/scripts/runtime-smoke.mjs
+++ b/charts/n8n/scripts/runtime-smoke.mjs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync, spawn} from 'node:child_process';
+import {randomBytes} from 'node:crypto';
+import {setTimeout as delay} from 'node:timers/promises';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const deadline = Date.now() + 140000;
+const target = ['--context', context, '-n', namespace];
+const kubectl = args => execFileSync('kubectl', [...target, ...args], {
+  encoding: 'utf8', timeout: 15000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(kubectl(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp
+  && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'n8n'));
+assert.ok(pod, 'Ready n8n main pod required');
+assert.equal(kubectl(['exec', pod.metadata.name, '-c', 'n8n', '--', 'n8n', '--version']).trim(), '2.38.4');
+const main = pod.spec.containers.find(c => c.name === 'n8n');
+const python = main.env.some(e => e.name === 'N8N_PYTHON_ENABLED' && e.value === 'true');
+const queue = main.env.some(e => e.name === 'EXECUTIONS_MODE' && e.value === 'queue');
+const child = spawn('kubectl', [...target, 'port-forward', `pod/${pod.metadata.name}`, ':5678', '--address=127.0.0.1'], {
+  windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+});
+let output = '', error;
+child.stdout.on('data', chunk => { output += chunk; });
+child.stderr.on('data', () => {});
+child.on('error', caught => { error = caught; });
+try {
+  for (let i = 0; i < 150 && !/127\.0\.0\.1:(\d+) ->/.test(output) && !error; i++) await delay(100);
+  if (error) throw error;
+  const port = output.match(/127\.0\.0\.1:(\d+) ->/)?.[1];
+  assert.ok(port);
+  const base = `http://127.0.0.1:${port}`, cookies = new Map();
+  async function request(route, method = 'GET', body) {
+    const remaining = deadline - Date.now();
+    assert.ok(remaining > 0, 'Runtime deadline reached');
+    const response = await fetch(base + route, {
+      method, headers: {'Content-Type': 'application/json', Cookie: [...cookies].map(([a, b]) => `${a}=${b}`).join('; ')},
+      ...(body ? {body: JSON.stringify(body)} : {}), signal: AbortSignal.timeout(Math.min(60000, remaining)),
+    });
+    for (const cookie of response.headers.getSetCookie()) {
+      const pair = cookie.split(';')[0], equals = pair.indexOf('=');
+      cookies.set(pair.slice(0, equals), pair.slice(equals + 1));
+    }
+    assert.ok(response.ok, `${method} ${route}: HTTP ${response.status}`);
+    return response.json();
+  }
+  await request('/healthz/readiness');
+  await request('/rest/owner/setup', 'POST', {
+    email: 'runtime@example.invalid', firstName: 'Runtime', lastName: 'Fixture',
+    password: `Fixture-${randomBytes(18).toString('hex')}!`,
+  });
+  for (const language of python ? ['javaScript', 'pythonNative'] : ['javaScript']) {
+    const route = `helmforge-${randomBytes(8).toString('hex')}`;
+    const workflow = {name: `Runtime ${language}`, nodes: [
+      {id: 'webhook', name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2, position: [0, 0], webhookId: route,
+        parameters: {httpMethod: 'GET', path: route, responseMode: 'lastNode', options: {}}},
+      {id: 'code', name: 'Code', type: 'n8n-nodes-base.code', typeVersion: 2, position: [240, 0], parameters: {
+        language, mode: 'runOnceForAllItems', ...(language === 'javaScript'
+          ? {jsCode: 'return [{json: {answer: 6 * 7}}];'} : {pythonCode: 'return [{"json": {"answer": 6 * 7}}]'}),
+      }},
+    ], connections: {Webhook: {main: [[{node: 'Code', type: 'main', index: 0}]]}}, settings: {executionOrder: 'v1'}};
+    const created = (await request('/rest/workflows', 'POST', workflow)).data;
+    assert.ok(created.id && created.versionId);
+    await request(`/rest/workflows/${created.id}/activate`, 'POST', {versionId: created.versionId});
+    const response = await request(`/webhook/${route}`);
+    const result = Array.isArray(response) ? response[0] : response;
+    assert.equal(result.answer, 42, `${language} runner result`);
+  }
+  console.log(`PASS: n8n 2.38.4, readiness, owner authentication and published ${python ? 'JavaScript/Python' : 'JavaScript'} workflow execution${queue ? ' through Redis queue workers' : ''}`);
+} finally {
+  if (child.exitCode === null) {
+    if (process.platform === 'win32') {
+      try { execFileSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], {stdio: 'ignore'}); }
+      catch (cleanupError) {
+        let exists = true;
+        try { process.kill(child.pid, 0); }
+        catch (error) { if (error.code === 'ESRCH') exists = false; else throw error; }
+        if (exists) throw cleanupError;
+      }
+    } else child.kill('SIGTERM');
+  }
+}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -69,155 +69,94 @@ app.kubernetes.io/component: worker
 
 {{- define "n8n.databaseMode" -}}
 {{- $mode := .Values.database.mode | default "auto" -}}
-{{- if not (has $mode (list "auto" "sqlite" "external" "postgresql" "mysql")) -}}
-{{- fail (printf "database.mode must be one of: auto, sqlite, external, postgresql, mysql (got %s)" $mode) -}}
+{{- $vendor := .Values.database.external.vendor | default "postgres" -}}
+{{- if or (.Values.mysql.enabled | default false) (eq $mode "mysql") (has $vendor (list "mysql" "mariadb")) -}}
+{{- fail "n8n 2.x removed MySQL/MariaDB storage; migrate data to PostgreSQL or SQLite before upgrading" -}}
+{{- end -}}
+{{- if not (has $mode (list "auto" "sqlite" "external" "postgresql")) -}}
+{{- fail (printf "database.mode must be one of: auto, sqlite, external, postgresql (got %s)" $mode) -}}
+{{- end -}}
+{{- if ne $vendor "postgres" -}}
+{{- fail "database.external.vendor must be postgres; n8n 2.x supports only PostgreSQL and SQLite storage" -}}
 {{- end -}}
 {{- $hasExternal := or (ne (.Values.database.external.host | default "") "") (ne (.Values.database.external.existingSecret | default "") "") -}}
 {{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
-{{- $hasMysql := .Values.mysql.enabled | default false -}}
 {{- $hasRedis := or (.Values.redis.enabled | default false) (ne (.Values.queue.external.host | default "") "") -}}
-{{- $vendor := .Values.database.external.vendor | default "postgres" -}}
-{{- if not (has $vendor (list "postgres" "mysql")) -}}
-{{- fail (printf "database.external.vendor must be one of: postgres, mysql (got %s)" $vendor) -}}
-{{- end -}}
 {{- if and .Values.queue.enabled (not $hasRedis) -}}
 {{- fail "queue.enabled=true requires redis.enabled=true or queue.external.host to be set" -}}
 {{- end -}}
-{{- if and .Values.queue.enabled (eq $mode "sqlite") -}}
-{{- fail "queue.enabled=true is not supported with SQLite; configure PostgreSQL, MySQL, or an external database" -}}
-{{- end -}}
-{{- if and .Values.queue.enabled (eq $mode "auto") (not (or $hasExternal $hasPostgresql $hasMysql)) -}}
-{{- fail "queue.enabled=true is not supported with SQLite; configure PostgreSQL, MySQL, or an external database" -}}
+{{- if and .Values.queue.enabled (or (eq $mode "sqlite") (and (eq $mode "auto") (not (or $hasExternal $hasPostgresql)))) -}}
+{{- fail "queue.enabled=true is not supported with SQLite; configure PostgreSQL or an external PostgreSQL database" -}}
 {{- end -}}
 {{- if eq $mode "auto" -}}
-  {{- $count := 0 -}}
-  {{- if $hasExternal -}}{{- $count = add1 $count -}}{{- end -}}
-  {{- if $hasPostgresql -}}{{- $count = add1 $count -}}{{- end -}}
-  {{- if $hasMysql -}}{{- $count = add1 $count -}}{{- end -}}
-  {{- if gt $count 1 -}}
-    {{- fail "n8n database selection is ambiguous: configure only one of database.external.host, postgresql.enabled, or mysql.enabled" -}}
+  {{- if and $hasExternal $hasPostgresql -}}
+    {{- fail "n8n database selection is ambiguous: configure only one of database.external.host or postgresql.enabled" -}}
   {{- end -}}
   {{- if $hasExternal -}}external
   {{- else if $hasPostgresql -}}postgresql
-  {{- else if $hasMysql -}}mysql
   {{- else -}}sqlite
   {{- end -}}
 {{- else -}}
-  {{- if and (eq $mode "sqlite") (or $hasExternal $hasPostgresql $hasMysql) -}}
-    {{- fail "database.mode=sqlite cannot be combined with database.external, postgresql.enabled, or mysql.enabled" -}}
+  {{- if and (eq $mode "sqlite") (or $hasExternal $hasPostgresql) -}}
+    {{- fail "database.mode=sqlite cannot be combined with database.external or postgresql.enabled" -}}
   {{- end -}}
   {{- if and (eq $mode "external") (not $hasExternal) -}}
     {{- fail "database.mode=external requires database.external.host or database.external.existingSecret" -}}
   {{- end -}}
-  {{- if and (eq $mode "external") (or $hasPostgresql $hasMysql) -}}
-    {{- fail "database.mode=external cannot be combined with postgresql.enabled or mysql.enabled" -}}
+  {{- if and (eq $mode "external") $hasPostgresql -}}
+    {{- fail "database.mode=external cannot be combined with postgresql.enabled" -}}
   {{- end -}}
   {{- if and (eq $mode "postgresql") (not $hasPostgresql) -}}
     {{- fail "database.mode=postgresql requires postgresql.enabled=true" -}}
   {{- end -}}
-  {{- if and (eq $mode "postgresql") (or $hasExternal $hasMysql) -}}
-    {{- fail "database.mode=postgresql cannot be combined with database.external or mysql.enabled" -}}
-  {{- end -}}
-  {{- if and (eq $mode "mysql") (not $hasMysql) -}}
-    {{- fail "database.mode=mysql requires mysql.enabled=true" -}}
-  {{- end -}}
-  {{- if and (eq $mode "mysql") (or $hasExternal $hasPostgresql) -}}
-    {{- fail "database.mode=mysql cannot be combined with database.external or postgresql.enabled" -}}
+  {{- if and (eq $mode "postgresql") $hasExternal -}}
+    {{- fail "database.mode=postgresql cannot be combined with database.external" -}}
   {{- end -}}
   {{- $mode -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "n8n.databaseVendor" -}}
-{{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- .Values.database.external.vendor | default "postgres" -}}
-{{- else if eq $mode "postgresql" -}}
-postgres
-{{- else if eq $mode "mysql" -}}
-mysql
-{{- else -}}
-sqlite
-{{- end -}}
+{{- if eq (include "n8n.databaseMode" .) "sqlite" -}}sqlite{{- else -}}postgres{{- end -}}
 {{- end -}}
 
-{{/* n8n uses DB_TYPE values: sqlite, postgresdb, mysqldb */}}
+{{/* n8n 2.x supports only sqlite and postgresdb. */}}
 {{- define "n8n.dbType" -}}
-{{- $vendor := include "n8n.databaseVendor" . -}}
-{{- if eq $vendor "sqlite" -}}sqlite
-{{- else if eq $vendor "postgres" -}}postgresdb
-{{- else -}}mysqldb
-{{- end -}}
+{{- if eq (include "n8n.databaseVendor" .) "sqlite" -}}sqlite{{- else -}}postgresdb{{- end -}}
 {{- end -}}
 
 {{- define "n8n.databaseHost" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- .Values.database.external.host -}}
-{{- else if eq $mode "postgresql" -}}
-{{- printf "%s-postgresql" .Release.Name -}}
-{{- else if eq $mode "mysql" -}}
-{{- printf "%s-mysql" .Release.Name -}}
-{{- else -}}
-{{- "" -}}
+{{- if eq $mode "external" -}}{{- .Values.database.external.host -}}
+{{- else if eq $mode "postgresql" -}}{{- printf "%s-postgresql" .Release.Name -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "n8n.databasePort" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- if .Values.database.external.port -}}
-{{- .Values.database.external.port | toString -}}
-{{- else if eq (.Values.database.external.vendor | default "postgres") "mysql" -}}
-3306
-{{- else -}}
-5432
-{{- end -}}
-{{- else if eq $mode "postgresql" -}}
-5432
-{{- else if eq $mode "mysql" -}}
-3306
-{{- else -}}
-{{- "" -}}
+{{- if eq $mode "external" -}}{{- .Values.database.external.port | default 5432 | toString -}}
+{{- else if eq $mode "postgresql" -}}5432
 {{- end -}}
 {{- end -}}
 
 {{- define "n8n.databaseName" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- .Values.database.external.name -}}
-{{- else if eq $mode "postgresql" -}}
-{{- .Values.postgresql.auth.database -}}
-{{- else if eq $mode "mysql" -}}
-{{- .Values.mysql.auth.database -}}
-{{- else -}}
-{{- "" -}}
+{{- if eq $mode "external" -}}{{- .Values.database.external.name -}}
+{{- else if eq $mode "postgresql" -}}{{- .Values.postgresql.auth.database -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "n8n.databaseUsername" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- .Values.database.external.username -}}
-{{- else if eq $mode "postgresql" -}}
-{{- .Values.postgresql.auth.username -}}
-{{- else if eq $mode "mysql" -}}
-{{- .Values.mysql.auth.username -}}
-{{- else -}}
-{{- "" -}}
+{{- if eq $mode "external" -}}{{- .Values.database.external.username -}}
+{{- else if eq $mode "postgresql" -}}{{- .Values.postgresql.auth.username -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "n8n.databasePasswordValue" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
-{{- if eq $mode "external" -}}
-{{- .Values.database.external.password -}}
-{{- else if eq $mode "postgresql" -}}
-{{- .Values.postgresql.auth.password -}}
-{{- else if eq $mode "mysql" -}}
-{{- .Values.mysql.auth.password -}}
-{{- else -}}
-{{- "" -}}
+{{- if eq $mode "external" -}}{{- .Values.database.external.password -}}
+{{- else if eq $mode "postgresql" -}}{{- .Values.postgresql.auth.password -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/n8n/templates/backup-configmap.yaml
+++ b/charts/n8n/templates/backup-configmap.yaml
@@ -28,19 +28,6 @@ data:
       --username="${DB_USERNAME}" \
       --dbname="${DB_NAME}" | gzip -c > "${archive}"
     printf "%s" "${archive}" > /backup/out/backup-file
-  mysql-backup.sh: |
-    #!/bin/sh
-    set -eu
-    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-mysql-${timestamp}.sql.gz"
-    mkdir -p /backup/out
-    export MYSQL_PWD="${DB_PASSWORD}"
-    mysqldump ${MYSQL_DUMP_EXTRA_ARGS:-} \
-      --host="${DB_HOST}" \
-      --port="${DB_PORT}" \
-      --user="${DB_USERNAME}" \
-      "${DB_NAME}" | gzip -c > "${archive}"
-    printf "%s" "${archive}" > /backup/out/backup-file
   upload-backup.sh: |
     #!/bin/sh
     set -eu

--- a/charts/n8n/templates/backup-cronjob.yaml
+++ b/charts/n8n/templates/backup-cronjob.yaml
@@ -84,35 +84,6 @@ spec:
                   mountPath: /scripts
                 - name: backup-workdir
                   mountPath: /backup/out
-            {{- else if eq (include "n8n.databaseVendor" .) "mysql" }}
-            - name: mysql-backup
-              image: {{ .Values.backup.images.mysql | quote }}
-              command: ["/bin/sh", "/scripts/mysql-backup.sh"]
-              env:
-                - name: BACKUP_ARCHIVE_PREFIX
-                  value: {{ .Values.backup.archivePrefix | quote }}
-                - name: MYSQL_DUMP_EXTRA_ARGS
-                  value: {{ .Values.backup.database.mysqlDumpArgs | quote }}
-                - name: DB_HOST
-                  value: {{ include "n8n.backupDatabaseHost" . | quote }}
-                - name: DB_PORT
-                  value: {{ include "n8n.backupDatabasePort" . | quote }}
-                - name: DB_NAME
-                  value: {{ include "n8n.backupDatabaseName" . | quote }}
-                - name: DB_USERNAME
-                  value: {{ include "n8n.backupDatabaseUsername" . | quote }}
-                - name: DB_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ include "n8n.backupDatabasePasswordSecretName" . }}
-                      key: {{ include "n8n.backupDatabasePasswordSecretKey" . }}
-              resources:
-                {{- toYaml .Values.backup.resources | nindent 16 }}
-              volumeMounts:
-                - name: scripts
-                  mountPath: /scripts
-                - name: backup-workdir
-                  mountPath: /backup/out
             {{- end }}
           containers:
             - name: upload

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- if eq (include "n8n.databaseMode" .) "sqlite" }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "n8n.selectorLabels" . | nindent 6 }}
@@ -115,8 +119,7 @@ spec:
             - name: DB_TYPE
               value: {{ include "n8n.dbType" . | quote }}
             {{- if ne $dbMode "sqlite" }}
-            {{- $vendor := include "n8n.databaseVendor" . }}
-            {{- $prefix := ternary "DB_POSTGRESDB" "DB_MYSQLDB" (eq $vendor "postgres") }}
+            {{- $prefix := "DB_POSTGRESDB" }}
             - name: {{ $prefix }}_HOST
               value: {{ include "n8n.databaseHost" . | quote }}
             - name: {{ $prefix }}_PORT
@@ -174,7 +177,7 @@ spec:
                   name: {{ include "n8n.taskRunnerSecretName" . }}
                   key: {{ include "n8n.taskRunnerSecretKey" . }}
             {{- end }}
-            - name: N8N_NATIVE_PYTHON_RUNNER
+            - name: N8N_PYTHON_ENABLED
               value: {{ .Values.taskRunners.nativePython.enabled | quote }}
             {{- if .Values.queue.enabled }}
             - name: EXECUTIONS_MODE

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -106,8 +106,7 @@ spec:
               value: {{ include "n8n.dbType" . | quote }}
             {{- $dbMode := include "n8n.databaseMode" . }}
             {{- if ne $dbMode "sqlite" }}
-            {{- $vendor := include "n8n.databaseVendor" . }}
-            {{- $prefix := ternary "DB_POSTGRESDB" "DB_MYSQLDB" (eq $vendor "postgres") }}
+            {{- $prefix := "DB_POSTGRESDB" }}
             - name: {{ $prefix }}_HOST
               value: {{ include "n8n.databaseHost" . | quote }}
             - name: {{ $prefix }}_PORT
@@ -143,7 +142,7 @@ spec:
                   name: {{ include "n8n.taskRunnerSecretName" . }}
                   key: {{ include "n8n.taskRunnerSecretKey" . }}
             {{- end }}
-            - name: N8N_NATIVE_PYTHON_RUNNER
+            - name: N8N_PYTHON_ENABLED
               value: {{ .Values.taskRunners.nativePython.enabled | quote }}
             - name: EXECUTIONS_MODE
               value: queue

--- a/charts/n8n/tests/backup_test.yaml
+++ b/charts/n8n/tests/backup_test.yaml
@@ -43,21 +43,6 @@ tests:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].name
           value: postgres-backup
 
-  - it: should use mysql init for mysql
-    template: templates/backup-cronjob.yaml
-    set:
-      mysql.enabled: true
-      mysql.auth.password: test
-      backup.enabled: true
-      backup.s3.endpoint: https://s3.amazonaws.com
-      backup.s3.bucket: test-bucket
-      backup.s3.accessKey: AKIA123
-      backup.s3.secretKey: secret123
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
-          value: mysql-backup
-
   - it: should render backup scripts configmap
     template: templates/backup-configmap.yaml
     set:

--- a/charts/n8n/tests/database_contract_test.yaml
+++ b/charts/n8n/tests/database_contract_test.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Supported n8n storage backends
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+tests:
+  - it: stops the previous SQLite process before starting its replacement
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+  - it: retains the PostgreSQL rollout strategy
+    template: templates/deployment.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: fixture-password
+    asserts:
+      - notExists:
+          path: spec.strategy
+  - it: rejects the legacy bundled MySQL setting
+    set:
+      mysql.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "/mysql/enabled.*value must be false"
+  - it: rejects legacy explicit MySQL mode without falling back to SQLite
+    set:
+      database.mode: mysql
+    asserts:
+      - failedTemplate:
+          errorPattern: "/database/mode.*value must be one of"
+  - it: rejects an external MySQL server without changing its data
+    set:
+      database.external.host: mysql.example.internal
+      database.external.vendor: mysql
+    asserts:
+      - failedTemplate:
+          errorPattern: "/database/external/vendor.*value must be 'postgres'"
+  - it: rejects an external MariaDB server
+    set:
+      database.external.host: mariadb.example.internal
+      database.external.vendor: mariadb
+    asserts:
+      - failedTemplate:
+          errorPattern: "/database/external/vendor.*value must be 'postgres'"

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.35.3"
+          value: "docker.io/n8nio/n8n:2.38.4"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -123,23 +123,6 @@ tests:
             name: DB_POSTGRESDB_PORT
             value: "5432"
 
-  - it: should set mysql env vars
-    template: templates/deployment.yaml
-    set:
-      mysql.enabled: true
-      mysql.auth.password: test
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DB_TYPE
-            value: mysqldb
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DB_MYSQLDB_HOST
-            value: test-mysql
-
   - it: should set encryption key from secret
     template: templates/deployment.yaml
     asserts:
@@ -239,7 +222,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.35.3"
+          value: "docker.io/n8nio/runners:2.38.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:
@@ -274,7 +257,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: N8N_NATIVE_PYTHON_RUNNER
+            name: N8N_PYTHON_ENABLED
             value: "false"
 
   - it: should disable external task runner sidecar in internal mode

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.35.3"
+          value: "docker.io/n8nio/runners:2.38.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:
@@ -148,7 +148,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: N8N_NATIVE_PYTHON_RUNNER
+            name: N8N_PYTHON_ENABLED
             value: "false"
 
   - it: should disable diagnostics by default on workers

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "n8n Helm Chart Values",
-  "description": "Configuration values for the n8n Helm chart. Deploys a workflow automation platform with SQLite, PostgreSQL, or MySQL support and optional Redis-backed queue mode.",
+  "description": "Configuration values for the n8n Helm chart. Deploys a workflow automation platform with SQLite or PostgreSQL support and optional Redis-backed queue mode.",
   "type": "object",
   "additionalProperties": true,
   "properties": {
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.35.3"
+          "default": "2.38.4"
         },
         "pullPolicy": {
           "type": "string",
@@ -200,8 +200,8 @@
       "properties": {
         "mode": {
           "type": "string",
-          "description": "Database mode: auto | sqlite | external | postgresql | mysql",
-          "enum": ["auto", "sqlite", "external", "postgresql", "mysql"]
+          "description": "Database mode: auto, sqlite, external PostgreSQL, or bundled postgresql",
+          "enum": ["auto", "sqlite", "external", "postgresql"]
         },
         "sqlite": {
           "type": "object",
@@ -218,8 +218,8 @@
           "properties": {
             "vendor": {
               "type": "string",
-              "description": "Database vendor: postgres | mysql",
-              "enum": ["postgres", "mysql"]
+              "description": "External database vendor; n8n 2.x supports PostgreSQL only",
+              "enum": ["postgres"]
             },
             "host": {
               "type": "string",
@@ -300,46 +300,12 @@
     },
     "mysql": {
       "type": "object",
-      "description": "MySQL subchart configuration",
+      "description": "Deprecated compatibility guard. MySQL/MariaDB storage was removed in n8n 2.x; migrate data before upgrading.",
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Deploy MySQL as a subchart"
-        },
-        "architecture": {
-          "type": "string",
-          "description": "MySQL architecture (standalone or replication)"
-        },
-        "auth": {
-          "type": "object",
-          "properties": {
-            "database": { "type": "string", "description": "Database name created on first run" },
-            "username": { "type": "string", "description": "Database username created on first run" },
-            "password": { "type": "string", "description": "Database password (auto-generated if empty)" },
-            "rootPassword": { "type": "string", "description": "Root password (auto-generated if empty)" }
-          }
-        },
-        "standalone": {
-          "type": "object",
-          "properties": {
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean", "description": "Enable persistence for MySQL data" },
-                "size": { "type": "string", "description": "PVC size for MySQL" }
-              }
-            }
-          }
-        },
-        "startupProbe": {
-          "type": "object",
-          "description": "MySQL startup probe overrides",
-          "properties": {
-            "initialDelaySeconds": {
-              "type": "integer",
-              "description": "Initial delay before MySQL startup probe checks"
-            }
-          }
+          "const": false,
+          "description": "Must remain false; MySQL storage is unsupported."
         }
       }
     },
@@ -585,7 +551,6 @@
           "properties": {
             "sqlite": { "type": "string", "description": "Image used for SQLite backup (must have tar)" },
             "postgresql": { "type": "string", "description": "Image used for PostgreSQL backup (must have pg_dump)" },
-            "mysql": { "type": "string", "description": "Image used for MySQL backup (must have mysqldump)" },
             "uploader": { "type": "string", "description": "Image used for S3 upload (MinIO client)" }
           }
         },
@@ -619,8 +584,7 @@
             "password": { "type": "string" },
             "existingSecret": { "type": "string" },
             "existingSecretPasswordKey": { "type": "string" },
-            "postgresDumpArgs": { "type": "string" },
-            "mysqlDumpArgs": { "type": "string" }
+            "postgresDumpArgs": { "type": "string" }
           }
         }
       }

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -2,7 +2,7 @@
 # =============================================================================
 # n8n Helm Chart
 # =============================================================================
-# Workflow automation platform. Supports SQLite (default), PostgreSQL, MySQL,
+# Workflow automation platform. Supports SQLite (default), PostgreSQL,
 # and optional Redis-backed queue mode for scaling.
 # https://docs.n8n.io/
 # =============================================================================
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.35.3"
+  tag: "2.38.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -107,7 +107,7 @@ taskRunners:
 # Queue Mode (Redis)
 # =============================================================================
 # When enabled, n8n runs in queue mode using Redis as the message broker and a
-# shared non-SQLite database (PostgreSQL, MySQL, or external database).
+# shared non-SQLite database (PostgreSQL or external PostgreSQL).
 # This allows horizontal scaling with separate worker processes.
 # =============================================================================
 
@@ -161,17 +161,17 @@ encryptionKey:
 # =============================================================================
 # Database
 # =============================================================================
-# n8n supports SQLite (default), PostgreSQL, and MySQL.
+# n8n supports SQLite (default) and PostgreSQL.
 #
 # Mode detection (when mode is auto):
+# External and bundled PostgreSQL are mutually exclusive.
 # 1. database.external.host or database.external.existingSecret -> external
 # 2. postgresql.enabled -> PostgreSQL subchart
-# 3. mysql.enabled -> MySQL subchart
-# 4. Fallback -> SQLite (default, zero configuration)
+# 3. Fallback -> SQLite (default, zero configuration)
 # =============================================================================
 
 database:
-  # -- Database mode: auto | sqlite | external | postgresql | mysql
+  # -- Database mode: auto | sqlite | external | postgresql
   mode: auto
 
   sqlite:
@@ -179,7 +179,7 @@ database:
     file: /home/node/.n8n/database.sqlite
 
   external:
-    # -- Database vendor: postgres | mysql
+    # -- Database vendor: postgres (only supported external backend)
     vendor: postgres
 
     # -- External database hostname
@@ -239,36 +239,12 @@ postgresql:
           -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 
 # =============================================================================
-# MySQL Subchart
+# Legacy MySQL configuration
 # =============================================================================
 
 mysql:
-  # -- Deploy MySQL as a subchart
+  # -- Deprecated compatibility guard. Must remain false: n8n 2.x removed MySQL/MariaDB storage.
   enabled: false
-
-  # -- MySQL architecture (standalone or replication)
-  architecture: standalone
-
-  auth:
-    # -- Database name created on first run
-    database: n8n
-    # -- Database username created on first run
-    username: n8n
-    # -- Database password (auto-generated if empty)
-    password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
-
-  standalone:
-    persistence:
-      # -- Enable persistence for MySQL data
-      enabled: true
-      # -- PVC size for MySQL
-      size: 8Gi
-
-  startupProbe:
-    # -- Delay startup checks until the initial MySQL bootstrap has opened port 3306
-    initialDelaySeconds: 30
 
 # =============================================================================
 # Redis Subchart (for queue mode)
@@ -488,8 +464,6 @@ backup:
     sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18.4-alpine
-    # -- Image used for MySQL backup (must have mysqldump)
-    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 
@@ -534,7 +508,6 @@ backup:
     existingSecret: ""
     existingSecretPasswordKey: database-password
     postgresDumpArgs: ""
-    mysqlDumpArgs: "--single-transaction --quick --skip-lock-tables --no-tablespaces"
 
 # =============================================================================
 # Scheduling


### PR DESCRIPTION
n8n and its external runners now use 2.38.4. The chart rejects MySQL/MariaDB storage, which n8n removed in 2.0, and removes the unused MySQL dependency and backup paths. SQLite updates use Recreate, and the native Python toggle now controls the current N8N_PYTHON_ENABLED setting.

Resolves #1144

Companion site update: https://github.com/helmforgedev/site/pull/555

## Breaking chart contract

mysql.enabled=true, database.mode=mysql and non-PostgreSQL external vendors are rejected. Existing MySQL/MariaDB users must migrate their data with a compatible source release before applying this chart. Changing the database selector does not copy data. Preserve database backups, PVC recovery and encryption keys before retiring an old bundled MySQL installation. The MySQL workflow node remains supported.

SQLite updates briefly stop the main process before replacing it, avoiding simultaneous versions opening the same database. PostgreSQL deployments retain their rollout strategy. The Python toggle remains off by default and requires external runners when enabled; its previous environment variable no longer controlled n8n 2.x execution.

## Upstream evidence and risk

- Reviewed all stable release notes between 2.35.3 and [2.38.4](https://github.com/n8n-io/n8n/releases/tag/n8n%402.38.4): runner broker/shutdown changes, runner image glibc/libatomic fixes, encryption-key seeding, database pool recovery and queue execution fixes.
- Both docker.io/n8nio/n8n:2.38.4 and docker.io/n8nio/runners:2.38.4 manifests verified for amd64 and arm64. PostgreSQL 2.0.5 and Redis 2.0.1 dependencies are current.
- [Official 2.0 storage removal](https://github.com/n8n-io/n8n-docs/blob/main/docs/changelog/v20-breaking-changes.md) and tagged 2.38.4 database.config.ts confirm only sqlite/postgresdb storage. Tagged nodes.config.ts and Code.node.ts confirm the current Python control.

| Change | Chart impact | Runtime proof |
|---|---|---|
| Runner broker and image updates | Matching app/runner tags and current Python control | default JavaScript workflow; native Python scenario executes both languages |
| Encryption and database updates | Preserve generated key and stored credentials | 2.35.3 to 2.38.4 upgrades on SQLite and PostgreSQL/Redis queue; CLI decryption in isolated Jobs |
| SQLite schema lifecycle | Recreate main Deployment | Upgrade plus pod replacement retains workflow and credential |
| Unsupported MySQL storage | Reject legacy inputs; remove dependency, backup and env branches | Negative schema tests; live external PostgreSQL and bundled queue profiles |
| Queue operation | Main/worker runner compatibility | Published webhook executes Code node through Redis workers |

## Validation

Full make validate-chart passed all 14 layers: dependency integrity, strict lint, every CI render, 82 unit tests, strict kubeconform with real CRD schemas, Artifact Hub lint and four sequential k3d scenarios (default, external PostgreSQL, PostgreSQL/Redis queue, external native Python runners). All chart pods remained stable without restarts. Transient scheduling/readiness events recovered before validation. Standards and make preflight passed. Kubescape 4.0.13 MITRE/NSA/SOC2 score: 87.88%. Both SQLite and PostgreSQL/Redis queue upgrades from 2.35.3 preserved the encryption key, decrypted credential fixture and published workflow execution, including after main pod replacement.

The companion playground now includes PostgreSQL/Redis when enabling queue mode, preserves edited passwords, and emits valid structured Ingress/TLS values. Chromium, Firefox and WebKit tests passed; actual generated queue/production YAML rendered successfully and all 28 Kubernetes resources passed strict kubeconform. Site build and 156 local links/anchors passed.

Upgrade tooling uses explicit Ready main pods and closes HTTP connections between synchronous CLI operations. The initial fixture exposed a stale local MySQL archive and client-side selection/connection errors; final evidence uses rebuilt dependencies and explicit current-version pods. Other ingress, Gateway and Secret mappings receive static coverage. No automatic MySQL data migration or S3 restore is claimed. Chart version remains CI-managed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for native Python execution in external task runners.
  - Added runtime smoke testing for readiness, workflow execution, queue mode, and Python execution.

- **Updates**
  - Updated n8n images to version 2.38.4.
  - SQLite deployments now use safe recreate updates.
  - Database configuration now supports SQLite and PostgreSQL only; legacy MySQL/MariaDB configurations are rejected with migration guidance.

- **Documentation**
  - Updated database, backup, queue-mode, and upgrade guidance for the supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->