### PR TITLE
chore(minecraft): bump server and backup images to 2026.9.0

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.5.2
-appVersion: "2026.8.2"
+appVersion: "2026.9.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump server image to 2026.8.2 (#1052)"
+      description: "bump server and backup images to 2026.9.0; pin Forge Java 17"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/DESIGN.md
+++ b/charts/minecraft/DESIGN.md
@@ -5,7 +5,7 @@
 This chart deploys Minecraft Java Edition servers using the official community-standard
 `docker.io/itzg/minecraft-server` image. It supports vanilla, Paper, Forge, Fabric, Quilt, Geyser/Floodgate cross-play,
 RCON operations, persistent worlds, metrics, External Secrets, and S3-compatible backups.
-The 2026.8.2 runtime also exposes IPv6 stack preference, a replaceable process
+The 2026.9.0 runtime also exposes IPv6 stack preference, a replaceable process
 runner, and layered generic packs distributed as OCI artifacts.
 
 ## Architecture

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -257,8 +257,16 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.8.2` fixes Modrinth packs that require
-server-side mods, corrects `STOP_SERVER_DELAY_COMMAND`, and updates the bundled
+The 2026.9.0 image stops startup after failed custom-server, BuildTools, Sponge,
+modpack or FTB installer downloads instead of continuing with incomplete artifacts.
+It also rejects archive path traversal, fixes Forge/NeoForge reinstall defaults,
+FTB Fabric detection, percentage-memory arithmetic and CurseForge pruning.
+Confirm modpack downloads and installer success before rolling out. The dated
+image pins the container distribution, not the game: pin `server.version`
+separately to keep an image update from downloading a newer Minecraft release.
+
+Earlier image releases fixed Modrinth packs that require
+server-side mods, corrected `STOP_SERVER_DELAY_COMMAND`, and updated the bundled
 Minecraft helper tools. It retains native `PREFER_IPv6` and custom
 `SERVER_RUNNER` support. Configure the
 first two features with `server.preferIPv6` and `server.runner`.

--- a/charts/minecraft/ci/forge-values.yaml
+++ b/charts/minecraft/ci/forge-values.yaml
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: Forge modded server
+image:
+  tag: "2026.9.0-java17"
+
 server:
   eula: true
   type: FORGE

--- a/charts/minecraft/scripts/runtime-smoke.mjs
+++ b/charts/minecraft/scripts/runtime-smoke.mjs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+
+const [context, namespace, release] = process.argv.slice(2);
+assert.ok(context?.startsWith('k3d-helmforge-') && namespace && release);
+const run = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(run(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'minecraft'));
+assert.ok(pod, 'Ready Minecraft server required');
+const container = pod.spec.containers.find(c => c.name === 'minecraft');
+assert.match(container.image, /:2026\.9\.0(?:-java17)?$/);
+const exec = args => run(['exec', pod.metadata.name, '-c', 'minecraft', '--', ...args]);
+exec(['mc-health']);
+if (container.env.some(e => e.name === 'ENABLE_RCON' && e.value === 'true')) {
+  assert.match(exec(['rcon-cli', 'list']), /players online/i);
+  assert.match(exec(['rcon-cli', 'save-all', 'flush']), /Saved the game/i);
+}
+if (container.env.some(e => e.name === 'TYPE' && e.value === 'FORGE')) {
+  assert.match(exec(['sh', '-c', 'java -version 2>&1']), /version "17\./);
+  assert.match(run(['logs', pod.metadata.name, '-c', 'minecraft', '--tail=500']), /forge|fml/i);
+}
+console.log('PASS: Minecraft 2026.9.0 image, game health, authenticated RCON player list and world flush; Forge profile verifies Java 17 and loader startup.');

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.8.2
+          value: docker.io/itzg/minecraft-server:2026.9.0
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.8.2
+          value: docker.io/itzg/minecraft-server:2026.9.0
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.8.2
+          value: docker.io/itzg/minecraft-server:2026.9.0
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.8.2
+          value: docker.io/itzg/minecraft-server:2026.9.0
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.8.2"
+          "default": "2026.9.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -645,7 +645,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.8.2"
+              "default": "docker.io/itzg/minecraft-server:2026.9.0"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.8.2"
+  tag: "2026.9.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -387,7 +387,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.8.2
+    worker: docker.io/itzg/minecraft-server:2026.9.0
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
Minecraft server and backup worker images now use 2026.9.0. Forge 1.20.4 CI selects the dated Java 17 variant; the companion site corrects the Java compatibility table and floating Forge example.

Resolves #1142

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

- Reviewed the full [2026.9.0 release](https://github.com/itzg/docker-minecraft-server/releases/tag/2026.9.0), directly following 2026.8.2.
- Verified the official server manifest for amd64, arm64 and riscv64, plus dated java17/java21 variants. No chart dependencies.
- Minecraft [1.20.5 introduced Java 21](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-20-5); [26.1 introduced Java 25](https://www.minecraft.net/en-us/article/minecraft-java-edition-26-1). The chart's existing game selector remains unchanged; pin server.version separately when upgrading production container images.

| Upstream change | Chart impact | Validation |
|---|---|---|
| Forge/NeoForge reinstall defaults and installer failure handling | Forge startup must complete with a compatible JVM | Forge 1.20.4 on dated Java 17; real game health and RCON |
| Failed downloads/archive extraction now stop startup; zip traversal rejected | Broken pack URLs fail visibly instead of creating incomplete servers | Upgrade guidance; default Vanilla and Forge download/install paths |
| FTB Fabric detection, required-mod filtering and CurseForge pruning | Pack contents and loader compatibility need staging | Documented pack-specific migration review; no claim of every private/third-party pack validation |
| Helper/runner and percentage-memory fixes | Server start/stop, RCON and saved world behavior | Default game health; image upgrade and world recovery fixture |

## Validation

Full make validate-chart passed all 12 layers: strict Helm lint, every CI render, unit tests, strict kubeconform with real CRD schemas, Artifact Hub lint, and sequential default/Forge k3d scenarios. Both servers passed real game health, authenticated RCON list/save flush and zero restarts. Startup probe warnings recovered before readiness. Standards and make preflight passed. Kubescape 4.0.13 MITRE/NSA/SOC2 score: 78.79%.

The 2026.8.2 to 2026.9.0 upgrade fixture pinned Minecraft 1.21.11, retained the generated RCON key and saved world gamerule, created a flushed local archive, changed the live value, restored the archive offline and verified the original saved value after pod replacement. The initial test command used pre-1.21.11 gamerule syntax; the corrected fixture uses namespaced IDs and explicitly rejects RCON error replies. Final complete run passed.

Site production build, 156 local links/anchors and focused Chromium/Firefox/WebKit tests passed. The Minecraft playground now uses the verified 2026.9.0 tag, correcting a calendar-tag replacement in the earlier Cloudflared site change.

All CI values receive static coverage. Gateway, ServiceMonitor and ExternalSecret mappings are unchanged. S3 transport and arbitrary modpacks are not claimed as runtime-tested. Chart version remains CI-managed.
