### PR TITLE
fix(langflow)!: align 1.12 encryption and migration lifecycle

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.1.4
-appVersion: "1.11.5"
+appVersion: "1.12.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump app to 1.11.5 (#1116)"
+      description: "upgrade 1.12.0 with valid generated encryption keys and explicit authentication"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,17 +1,55 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.5` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.12.0` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
-Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
-human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.5 adds security hardening and an opt-in
-multi-worker in-memory queue while keeping the default runtime contract unchanged. Advanced runtime settings can be supplied through `app.env` or
-`app.envFrom`.
+Langflow 1.12 adds authorization changes, database migrations and curated default
+component bundles. Advanced runtime settings can be supplied through `app.env` or
+`app.envFrom`. Review the migration notes below before upgrading existing data.
 
-The chart generates a strong Langflow secret key and initial superuser password on first install when `auth.existingSecret` and inline
+The chart generates a URL-safe Fernet encryption key and initial superuser password on first install when `auth.existingSecret` and inline
 credentials are empty. These values are reused on upgrades. Runtime probes use Langflow's `/health_check` endpoint so a pod is not marked ready
 until application services and the database are healthy.
+
+Authentication is required by default (`auth.autoLogin=false`). Automatic login
+is available only as an explicit development setting. The Deployment uses
+`Recreate` so old processes stop before a new version starts database migrations.
+
+## Upgrade to 1.12
+
+Before upgrading, stop writers, back up the database and encryption Secret, and
+export important flows. Start one replica for Alembic migrations; confirm health
+and flow execution before restoring the desired replica count. `Recreate` causes
+an upgrade maintenance window. Changing the database URL does not copy SQLite
+data to PostgreSQL. Do not run destructive migration repair against the only copy.
+
+Existing generated keys are preserved. Older chart releases generated 64-character
+alphanumeric keys, which are not valid Fernet keys. Audit the existing key before
+upgrading or enabling production preflight. Restore the original valid key when
+encrypted data depends on it; do not silently replace a key or discard credentials.
+If the old key is unusable, plan recovery of provider credentials and session
+invalidation before explicitly supplying a new key. New valid keys can be created
+with `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`
+in an environment with `cryptography` installed. Store the result in a Secret.
+
+The chart explicitly retains the official image's authenticated default. Only
+isolated development deployments should opt in with `auth.autoLogin=true`.
+
+The default image includes curated components and no longer installs PyTorch or
+every historical integration. Inventory flows that use removed bundles before
+upgrading; upstream offers `langflowai/langflow-all` for the extended profile.
+Pin and validate an appropriate supported image profile for those integrations.
+RBAC/provider policy and MCP authentication changes also require integration tests.
+
+External OpenTelemetry dashboards must account for the new HTTP semantic
+conventions: duration changes from milliseconds to seconds under
+`http.server.request.duration`, with renamed method/status/path attributes.
+The upstream `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup` setting provides migration
+compatibility when needed. This chart does not provision an OpenTelemetry collector.
+
+Sources: [1.12 release](https://github.com/langflow-ai/langflow/releases/tag/v1.12.0),
+[database migration guide](https://github.com/langflow-ai/langflow/blob/v1.12.0/docs/docs/Develop/database-migrations.mdx).
 
 ## Install
 

--- a/charts/langflow/ci/postgresql-values.yaml
+++ b/charts/langflow/ci/postgresql-values.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Real external PostgreSQL for database migration and encrypted credential checks.
+database:
+  mode: external
+  url: postgresql+psycopg://langflow:ci-langflow-database@langflow-postgresql:5432/langflow
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: langflow-postgresql
+    spec:
+      selector:
+        app: langflow-postgresql
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: langflow-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: langflow-postgresql
+      template:
+        metadata:
+          labels:
+            app: langflow-postgresql
+        spec:
+          securityContext:
+            fsGroup: 999
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.6-trixie
+              securityContext:
+                runAsUser: 999
+                runAsGroup: 999
+                allowPrivilegeEscalation: false
+              env:
+                - name: POSTGRES_DB
+                  value: langflow
+                - name: POSTGRES_USER
+                  value: langflow
+                - name: POSTGRES_PASSWORD
+                  value: ci-langflow-database
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              readinessProbe:
+                exec:
+                  command: [pg_isready, -U, langflow, -d, langflow]
+                periodSeconds: 5
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/charts/langflow/docs/database.md
+++ b/charts/langflow/docs/database.md
@@ -13,6 +13,11 @@ persistence:
 
 Do not scale SQLite mode horizontally.
 
+The Deployment uses Recreate during upgrades. Stop database writers, take a
+backup and start a single new instance to apply Alembic migrations before
+scaling out. Database migration failures require investigation and a tested
+restore plan; do not run destructive repair against the only data copy.
+
 ## External Database
 
 Use a PostgreSQL-compatible external database for production scaling:
@@ -30,3 +35,7 @@ database-url=postgresql://user:password@postgresql:5432/langflow
 ```
 
 The chart maps it to `LANGFLOW_DATABASE_URL`.
+
+Changing this URL initializes the target schema but does not copy data from
+SQLite. Export/import flows and plan credential recovery separately when
+changing database engines.

--- a/charts/langflow/docs/security.md
+++ b/charts/langflow/docs/security.md
@@ -2,6 +2,11 @@
 
 ## Secret Key
 
+New generated keys are URL-safe base64 encodings of 32 random bytes (Fernet).
+Existing keys are preserved. Older generated 64-character alphanumeric keys are
+not valid Fernet keys; audit them and plan recovery before upgrading. Never rotate
+a persisted encryption key without accounting for stored credentials.
+
 `LANGFLOW_SECRET_KEY` encrypts sensitive data and is also used for JWT signing in supported configurations.
 If it changes between restarts, encrypted stored credentials can become unusable.
 Use an existing Secret in production:
@@ -12,6 +17,10 @@ auth:
 ```
 
 ## Superuser
+
+The chart explicitly sets `LANGFLOW_AUTO_LOGIN=false`. Users must sign in with
+the configured or retained generated superuser credentials. `auth.autoLogin=true`
+is an opt-in for isolated development only.
 
 Set a superuser password when exposing Langflow beyond a trusted local lab:
 

--- a/charts/langflow/scripts/runtime-smoke.mjs
+++ b/charts/langflow/scripts/runtime-smoke.mjs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+
+const [context, namespace, release] = process.argv.slice(2);
+assert.ok(context?.startsWith('k3d-helmforge-') && namespace && release);
+const target = ['--context', context, '-n', namespace];
+const pods = JSON.parse(execFileSync('kubectl', [...target, 'get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'], {
+  encoding: 'utf8', timeout: 15000,
+})).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'langflow'));
+assert.ok(pod, 'Ready Langflow pod required');
+const output = execFileSync('kubectl', [...target, 'exec', '-i', pod.metadata.name, '-c', 'langflow', '--', 'python', '-', '1.12.0', 'create'], {
+  input: readFileSync(new URL('./runtime-smoke.py', import.meta.url)), encoding: 'utf8', timeout: 160000, stdio: ['pipe', 'pipe', 'pipe'],
+});
+console.log(output.trim());

--- a/charts/langflow/scripts/runtime-smoke.py
+++ b/charts/langflow/scripts/runtime-smoke.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise the local Langflow API without a model provider or external credentials."""
+import base64
+import gzip
+import hashlib
+import importlib.metadata
+import json
+import os
+import signal
+import sqlite3
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.cookiejar import CookieJar
+
+from cryptography.fernet import Fernet
+
+signal.alarm(140)
+expected, action, *saved = sys.argv[1:]
+assert importlib.metadata.version("langflow") == expected
+base = "http://127.0.0.1:" + os.environ.get("LANGFLOW_PORT", "7860")
+client = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(CookieJar()))
+
+
+def request(route, body=None, form=False):
+    headers = {"Connection": "close"}
+    data = None
+    if body is not None:
+        data = (urllib.parse.urlencode(body) if form else json.dumps(body)).encode()
+        headers["Content-Type"] = "application/x-www-form-urlencoded" if form else "application/json"
+    with client.open(urllib.request.Request(base + route, data=data, headers=headers), timeout=35) as response:
+        payload = response.read()
+        if response.headers.get("Content-Encoding") == "gzip":
+            payload = gzip.decompress(payload)
+        return json.loads(payload)
+
+
+request("/health_check")
+if os.environ.get("LANGFLOW_AUTO_LOGIN", "true").lower() == "false":
+    try:
+        request("/api/v1/flows/")
+    except urllib.error.HTTPError as error:
+        assert error.code in (401, 403), error.code
+    else:
+        raise AssertionError("Anonymous flow access must be rejected")
+request("/api/v1/login", {
+    "username": os.environ["LANGFLOW_SUPERUSER"],
+    "password": os.environ["LANGFLOW_SUPERUSER_PASSWORD"],
+}, form=True)
+
+secret = os.environ["LANGFLOW_SECRET_KEY"]
+key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest()) if len(secret) < 32 else (secret + "=" * (-len(secret) % 4)).encode()
+fernet = Fernet(key)
+fixture = "HelmForge retained credential 42"
+variable_name = "HELMFORGE_RUNTIME_SECRET"
+
+if action == "create":
+    palette = request("/api/v1/all")
+    components = {name: value for group in palette.values() if isinstance(group, dict) for name, value in group.items()}
+    nodes = []
+    for kind in ("ChatInput", "ChatOutput"):
+        component = components[kind]
+        component["template"]["should_store_message"]["value"] = False
+        node_id = kind + "-fixture"
+        nodes.append({"id": node_id, "data": {"id": node_id, "type": kind, "node": component}})
+    edge = {"source": "ChatInput-fixture", "target": "ChatOutput-fixture", "data": {
+        "sourceHandle": {"dataType": "ChatInput", "id": "ChatInput-fixture", "name": "message", "output_types": ["Message"]},
+        "targetHandle": {"fieldName": "input_value", "id": "ChatOutput-fixture", "inputTypes": ["Data", "DataFrame", "Message"], "type": "other"},
+    }}
+    flow = request("/api/v1/flows/", {"name": "HelmForge retained echo", "data": {"nodes": nodes, "edges": [edge]}, "is_component": False})
+    flow_id = flow["id"]
+    request("/api/v1/variables/", {"name": variable_name, "value": fixture, "type": "Credential", "default_fields": []})
+else:
+    flow_id = saved[0]
+    assert request("/api/v1/flows/" + flow_id)["name"] == "HelmForge retained echo"
+
+result = request("/api/v1/run/session/" + flow_id, {"input_value": "HelmForge echo 42", "input_type": "chat", "output_type": "chat"})
+assert result["outputs"][0]["outputs"][0]["results"]["message"]["text"] == "HelmForge echo 42", "Echo output must match the supplied message"
+
+url = os.environ.get("LANGFLOW_DATABASE_URL", "")
+if url.startswith("postgres"):
+    import psycopg
+    with psycopg.connect(url.replace("postgresql+psycopg://", "postgresql://")) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT value FROM variable WHERE name = %s", (variable_name,))
+            cipher = cursor.fetchone()[0]
+else:
+    db_path = os.path.join(os.environ["LANGFLOW_CONFIG_DIR"], "langflow.db")
+    with sqlite3.connect(db_path) as connection:
+        cipher = connection.execute("SELECT value FROM variable WHERE name = ?", (variable_name,)).fetchone()[0]
+assert cipher != fixture
+assert fernet.decrypt(cipher.encode()).decode() == fixture, "Persisted credential must decrypt with the retained key"
+print(json.dumps({"status": "PASS", "version": expected, "flowId": flow_id, "proof": "health, authentication, stored echo flow execution and persisted credential decryption"}))

--- a/charts/langflow/templates/deployment.yaml
+++ b/charts/langflow/templates/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "langflow.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "langflow.selectorLabels" . | nindent 6 }}
@@ -64,6 +66,8 @@ spec:
               value: "true"
             - name: LANGFLOW_OPEN_BROWSER
               value: "false"
+            - name: LANGFLOW_AUTO_LOGIN
+              value: {{ .Values.auth.autoLogin | quote }}
             - name: LANGFLOW_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/langflow/templates/secret.yaml
+++ b/charts/langflow/templates/secret.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- include "langflow.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ .Values.auth.secretKeyKey }}: {{ if $secretKey }}{{ $secretKey | quote }}{{ else }}{{ randAlphaNum 64 | quote }}{{ end }}
+  {{ .Values.auth.secretKeyKey }}: {{ if $secretKey }}{{ $secretKey | quote }}{{ else }}{{ randBytes 32 | replace "+" "-" | replace "/" "_" | quote }}{{ end }}
   {{ .Values.auth.superuserKey }}: {{ default "langflow" .Values.auth.superuser | quote }}
   {{ .Values.auth.superuserPasswordKey }}: {{ if $superuserPassword }}{{ $superuserPassword | quote }}{{ else }}{{ randAlphaNum 32 | quote }}{{ end }}
 {{- end }}

--- a/charts/langflow/tests/security_database_test.yaml
+++ b/charts/langflow/tests/security_database_test.yaml
@@ -4,13 +4,36 @@ templates:
   - templates/deployment.yaml
   - templates/secret.yaml
 tests:
+  - it: stops old instances before starting migrations and requires login
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFLOW_AUTO_LOGIN
+            value: "false"
+        template: templates/deployment.yaml
+  - it: allows explicit development automatic login
+    set:
+      auth.autoLogin: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFLOW_AUTO_LOGIN
+            value: "true"
+        template: templates/deployment.yaml
   - it: generates required credentials and wires them by default
     asserts:
       - isKind:
           of: Secret
         template: templates/secret.yaml
-      - isNotEmpty:
+      - matchRegex:
           path: stringData.secret-key
+          pattern: "^[A-Za-z0-9_-]{43}=$"
         template: templates/secret.yaml
       - equal:
           path: stringData.superuser

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.11.5
+          value: docker.io/langflowai/langflow:1.12.0
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.11.5" },
+        "tag": { "type": "string", "default": "1.12.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -32,6 +32,7 @@
     "auth": {
       "type": "object",
       "properties": {
+        "autoLogin": { "type": "boolean", "default": false, "description": "Development-only automatic login. Keep false in production." },
         "secretKey": { "type": "string", "default": "" },
         "superuser": { "type": "string", "default": "" },
         "superuserPassword": { "type": "string", "default": "" },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.11.5"
+  tag: "1.12.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 
@@ -37,7 +37,9 @@ app:
   extraEnv: []
 
 auth:
-  # -- Langflow secret key used for sensitive data encryption and JWT signing. Generated and preserved when empty.
+  # -- Development-only automatic login. Keep false for authenticated deployments.
+  autoLogin: false
+  # -- Langflow secret key used for sensitive data encryption and JWT signing. Generated as a URL-safe Fernet key and preserved when empty.
   secretKey: ""
   # -- Initial superuser username. Defaults to langflow when empty.
   superuser: ""


### PR DESCRIPTION
Langflow 1.12.0 updates database migrations, authorization and the default image component bundles. New generated encryption keys use valid Fernet encoding, automatic login becomes an explicit development-only option, and the Deployment stops old pods before starting a new version.

Resolves #1139

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

Reviewed all [1.12.0 release notes](https://github.com/langflow-ai/langflow/releases/tag/v1.12.0), the tagged database migration and Docker image profile guides, production secret-key validation PR #14499, RBAC #14215, distribution #14230, migration guidance #14441, HTTP telemetry #14756 and removed bundle extra #13869. Official langflowai/langflow:1.12.0 manifest verified for amd64/arm64; no chart dependencies.

| Change | Impact | Planned proof |
|---|---|---|
| Startup Alembic migrations | Stop old processes; preserve DB path and key; start one instance before scaling | SQLite and PostgreSQL persistent upgrade fixtures, flow execution and credential decryption |
| Fernet production preflight | Old randAlphaNum64 is invalid; generate URL-safe 32-byte keys only on new install | Real encryption/decryption, preserved existing keys, negative key audit |
| RBAC/auth changes; image AUTO_LOGIN=false overrides the library default | Preserve the official authenticated default explicitly; development opt-in | Anonymous denial and authenticated flow/credential APIs |
| Curated default bundles; no default torch | Removed integrations need migration review or supported extended image | No-provider echo flow on the official default image |
| HTTP semantic conventions use seconds/new attributes | External collector/dashboard migration notes | Document telemetry conversion; no new in-chart collector promised |

Implemented new URL-safe 32-byte Fernet key generation with existing-key preservation, explicit auth.autoLogin=false (matching both official image OCI configs), Recreate deployment and a real PostgreSQL CI fixture. The library default is true, but it is already overridden by the official image; this change does not claim to fix an existing anonymous-login exposure.

Breaking operational behavior: Recreate introduces an upgrade maintenance window. Stop writers and run one instance through migrations before scaling out. Existing invalid 64-character generated keys are preserved, not silently repaired; operators must audit/recover credentials and explicitly supply a valid key as needed. The upgrade fixture starts with a valid key and does not claim automatic recovery of unusable legacy keys.

Full make validate-chart passed all 13 layers, including all static CI scenarios, 23 unit tests, strict kubeconform, Artifact Hub lint and default/real PostgreSQL/explicit-credential k3d installations. All pods were stable without restarts; transient startup probes recovered. Both SQLite and PostgreSQL 1.11.5 to 1.12.0 upgrades preserved the generated valid Fernet key, authenticated stored echo flow execution and decrypted database credential through pod replacement. The smoke client handles the component API gzip response; a first fixture naming error was corrected before the final complete upgrade runs. Unit tests, standards and make preflight passed. Kubescape 4.0.13 score: 75.76% overall (MITRE 100%, NSA 65%, SOC2 80%). The site build, 156 links and all three browser tests passed.
