### PR TITLE
fix(elasticsearch): preserve credentials on 9.5.3 upgrade

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.1.7
-appVersion: "9.5.2"
+appVersion: "9.5.3"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump elasticsearch to 9.5.2 (#1044)"
+      description: "align Elasticsearch and bundled Kibana on 9.5.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.5.2` |
+| `image.tag` | Image tag | `9.5.3` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.5.2` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.5.3` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -311,13 +311,15 @@ Security posture acceptable.
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.5.2` is an upstream patch update from
-`9.5.1`. It improves settings and restore handling, index lifecycle reporting,
-ES|QL behavior during index deletion, and ingest concurrency. Review the
-[upstream Elasticsearch 9.5.2 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.2-release-notes)
-before upgrading production clusters, take a snapshot backup, and verify Kibana
-compatibility, plugins, ILM policies, and index templates in a staging
-environment before reusing existing PVCs.
+`docker.io/library/elasticsearch:9.5.3` updates translog shutdown cleanup,
+bulk indexing, authorization and vector-query handling. The optional bundled
+Kibana image is aligned to 9.5.3, including audit/session and saved-object fixes.
+Take a snapshot backup and verify plugins, ILM policies, index templates and
+existing vector indices in staging before reusing production PVCs.
+Generated credentials are retained during upgrades; changing a Kubernetes Secret
+alone does not rotate passwords already stored by Elasticsearch.
+See the [Elasticsearch release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.3-release-notes)
+and [Kibana release notes](https://www.elastic.co/docs/release-notes/kibana#kibana-9.5.3-release-notes).
 
 ## Resources Generated
 

--- a/charts/elasticsearch/docs/profile-dev.md
+++ b/charts/elasticsearch/docs/profile-dev.md
@@ -15,7 +15,7 @@ Common cases:
 
 - one Elasticsearch pod running all roles (master + data + ingest)
 - 2 GiB container memory, 1 GiB heap (auto-calculated)
-- no persistent storage by default (emptyDir — data is lost on pod restart)
+- a 10 GiB master PVC by default; set `master.persistence.enabled=false` for disposable emptyDir storage
 - security and TLS disabled for easy `curl` access
 - no PodDisruptionBudget
 - no coordinating or dedicated data nodes
@@ -31,19 +31,19 @@ Common cases:
 ## Environment requirements
 
 - single node with 2–4 GiB available memory
-- no persistent volume required (but optional via `master.persistence`)
+- a default StorageClass for the master PVC, unless persistence is explicitly disabled
 - `vm.max_map_count=262144` on the host (handled automatically by `sysctlInit.enabled=true`)
 
 ## Operational guidance
 
-The dev profile is the simplest configuration. It is appropriate when data loss
-is acceptable and speed of startup is more important than durability. If the
+The dev profile is the simplest configuration. Its PVC survives pod replacement,
+but a single node provides no replica or failover. If the
 workload becomes operationally important, migrate to `staging` or
 `production-ha` and take an Elasticsearch snapshot before switching.
 
 ## Common risks
 
-- using dev profile for data that must survive pod restarts (no persistence by default)
+- treating a single persistent node as highly available or disabling persistence for important data
 - treating `dev` as a staging baseline without testing multi-node behavior
 - forgetting that there is no replica for any shard — a yellow/red cluster from a shard replica issue is the primary mode of failure
 
@@ -52,7 +52,8 @@ workload becomes operationally important, migrate to `staging` or
 | Parameter | Description |
 |---|---|
 | `clusterProfile` | Must be `dev` |
-| `master.persistence.size` | PVC size (set to enable persistence) |
+| `master.persistence.enabled` | Enabled by default; set false for disposable storage |
+| `master.persistence.size` | PVC size, default 10Gi |
 | `master.heapSize` | Override heap (auto-calculated by default) |
 | `master.resources` | CPU/memory requests and limits |
 | `extraConfig` | Additional elasticsearch.yml settings |
@@ -66,7 +67,7 @@ clusterName: my-dev-cluster
 
 master:
   persistence:
-    size: 10Gi  # optional: add persistence
+    size: 10Gi  # default persistent storage size
 
 extraConfig:
   xpack.license.self_generated.type: basic

--- a/charts/elasticsearch/docs/security.md
+++ b/charts/elasticsearch/docs/security.md
@@ -85,6 +85,13 @@ security:
 
 ## Test with TLS enabled
 
+Generated account Secrets are preserved across upgrades. Elasticsearch stores
+account passwords in its security index after bootstrap; updating only the
+Kubernetes Secret does not rotate a live account. Use the supported password
+change API and synchronize the Secret deliberately when rotating credentials.
+TLS configuration uses the PEM `tls.key`, `tls.crt` and `ca.crt` files supplied
+by the chart's certificate paths.
+
 ```bash
 kubectl port-forward svc/<release>-elasticsearch 9200 -n <namespace>
 

--- a/charts/elasticsearch/scripts/runtime-smoke.mjs
+++ b/charts/elasticsearch/scripts/runtime-smoke.mjs
@@ -39,7 +39,8 @@ assert.equal(search.hits.hits[0]._id, 'fixture');
 request(index + '/_flush', 'POST');
 const kibana = pods.find(p => ready(p) && p.spec.containers.some(c => c.name === 'kibana'));
 if (kibana) {
-  const status = JSON.parse(k(['exec', kibana.metadata.name, '-c', 'kibana', '--', '/usr/share/kibana/node/bin/node', '-e', 'fetch("http://127.0.0.1:5601/api/status",{signal:AbortSignal.timeout(15000)}).then(async r=>{if(!r.ok)throw Error(String(r.status));console.log(JSON.stringify(await r.json()))}).catch(e=>{console.error(e.message);process.exit(1)})']));
+  const address = kibana.status.podIP.includes(':') ? `[${kibana.status.podIP}]` : kibana.status.podIP;
+  const status = JSON.parse(k(['exec', server.metadata.name, '-c', container.name, '--', 'curl', '-sf', '--max-time', '15', `http://${address}:5601/api/status`]));
   assert.equal(status.version.number, version);
   assert.equal(status.status.overall.level, 'available');
 }

--- a/charts/elasticsearch/scripts/runtime-smoke.mjs
+++ b/charts/elasticsearch/scripts/runtime-smoke.mjs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+
+const [context, namespace, release, version = '9.5.3', action = 'smoke'] = process.argv.slice(2);
+assert.ok(context?.startsWith('k3d-helmforge-') && namespace && release);
+const k = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 25000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(k(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const ready = p => !p.metadata.deletionTimestamp && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True');
+const server = pods.find(p => ready(p) && p.spec.containers.some(c => c.image.includes('/elasticsearch:')));
+assert.ok(server);
+const container = server.spec.containers.find(c => c.image.includes('/elasticsearch:'));
+const secure = container.env.some(e => e.name === 'xpack.security.enabled' && e.value === 'true');
+const curl = 'if [ "$1" = true ]; then curl -skf --max-time 20 -u "elastic:$ELASTIC_PASSWORD" -H "Content-Type: application/json" -X "$2" "https://localhost:9200$3" -d "$4"; else curl -sf --max-time 20 -H "Content-Type: application/json" -X "$2" "http://localhost:9200$3" -d "$4"; fi';
+const request = (route, method = 'GET', body) => JSON.parse(k(['exec', server.metadata.name, '-c', container.name, '--', 'sh', '-ec', curl, 'sh', String(secure), method, route, body ? JSON.stringify(body) : '']));
+assert.equal(request('/').version.number, version);
+if (secure) {
+  const code = k(['exec', server.metadata.name, '-c', container.name, '--', 'curl', '-sk', '--max-time', '10', '-o', '/dev/null', '-w', '%{http_code}', 'https://localhost:9200/']);
+  assert.equal(code, '401', 'Anonymous Elasticsearch access must be denied');
+}
+const health = request('/_cluster/health?wait_for_status=yellow&timeout=15s');
+assert.equal(health.timed_out, false);
+assert.ok(['green', 'yellow'].includes(health.status));
+const nodes = Object.values(request('/_nodes?filter_path=nodes.*.version').nodes);
+assert.ok(nodes.length > 0);
+for (const node of nodes) assert.equal(node.version, version);
+const index = '/helmforge-upstream-fixture';
+if (action !== 'verify') {
+  request(index, 'PUT', {settings: {number_of_shards: 1, number_of_replicas: 0}, mappings: {properties: {
+    message: {type: 'keyword'}, vector: {type: 'dense_vector', dims: 4, index: true, similarity: 'l2_norm', index_options: {type: 'hnsw'}},
+  }}});
+  request(index + '/_doc/fixture?refresh=wait_for', 'PUT', {message: 'HelmForge retained document', vector: [1, 0, 0, 0]});
+}
+assert.equal(request(index + '/_doc/fixture')._source.message, 'HelmForge retained document');
+const search = request(index + '/_search', 'POST', {knn: {field: 'vector', query_vector: [1, 0, 0, 0], k: 1, num_candidates: 10, filter: {exists: {field: 'message'}}}});
+assert.equal(search.hits.hits[0]._id, 'fixture');
+request(index + '/_flush', 'POST');
+const kibana = pods.find(p => ready(p) && p.spec.containers.some(c => c.name === 'kibana'));
+if (kibana) {
+  const status = JSON.parse(k(['exec', kibana.metadata.name, '-c', 'kibana', '--', '/usr/share/kibana/node/bin/node', '-e', 'fetch("http://127.0.0.1:5601/api/status",{signal:AbortSignal.timeout(15000)}).then(async r=>{if(!r.ok)throw Error(String(r.status));console.log(JSON.stringify(await r.json()))}).catch(e=>{console.error(e.message);process.exit(1)})']));
+  assert.equal(status.version.number, version);
+  assert.equal(status.status.overall.level, 'available');
+}
+if (action === 'smoke') request(index, 'DELETE');
+console.log(`PASS: Elasticsearch ${version}, ${nodes.length} healthy node(s), ${secure ? 'TLS and authenticated access with anonymous denial, ' : ''}document read/write, filtered vector search and flush${kibana ? '; bundled Kibana available at matching version' : ''}.`);

--- a/charts/elasticsearch/scripts/runtime-smoke.mjs
+++ b/charts/elasticsearch/scripts/runtime-smoke.mjs
@@ -41,7 +41,9 @@ const kibana = pods.find(p => ready(p) && p.spec.containers.some(c => c.name ===
 if (kibana) {
   const address = kibana.status.podIP.includes(':') ? `[${kibana.status.podIP}]` : kibana.status.podIP;
   const status = JSON.parse(k(['exec', server.metadata.name, '-c', container.name, '--', 'curl', '-sf', '--max-time', '15', `http://${address}:5601/api/status`]));
-  assert.equal(status.version.number, version);
+  // Unauthenticated status deliberately redacts version metadata.
+  const packageInfo = JSON.parse(k(['exec', kibana.metadata.name, '-c', 'kibana', '--', 'cat', '/usr/share/kibana/package.json']));
+  assert.equal(packageInfo.version, version);
   assert.equal(status.status.overall.level, 'available');
 }
 if (action === 'smoke') request(index, 'DELETE');

--- a/charts/elasticsearch/templates/configmap.yaml
+++ b/charts/elasticsearch/templates/configmap.yaml
@@ -36,10 +36,13 @@ data:
     {{ if eq (include "elasticsearch.security.enabled" .) "true" -}}
     xpack.security.transport.ssl.enabled: true
     xpack.security.transport.ssl.verification_mode: certificate
-    xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/tls.key
-    xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/ca.crt
+    xpack.security.transport.ssl.key: /usr/share/elasticsearch/config/certs/tls.key
+    xpack.security.transport.ssl.certificate: /usr/share/elasticsearch/config/certs/tls.crt
+    xpack.security.transport.ssl.certificate_authorities: ["/usr/share/elasticsearch/config/certs/ca.crt"]
     xpack.security.http.ssl.enabled: true
-    xpack.security.http.ssl.keystore.path: /usr/share/elasticsearch/config/certs/tls.key
+    xpack.security.http.ssl.key: /usr/share/elasticsearch/config/certs/tls.key
+    xpack.security.http.ssl.certificate: /usr/share/elasticsearch/config/certs/tls.crt
+    xpack.security.http.ssl.certificate_authorities: ["/usr/share/elasticsearch/config/certs/ca.crt"]
     {{- end }}
 
     {{- with .Values.extraConfig }}

--- a/charts/elasticsearch/templates/secret-credentials.yaml
+++ b/charts/elasticsearch/templates/secret-credentials.yaml
@@ -1,6 +1,11 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if eq (include "elasticsearch.security.enabled" .) "true" -}}
 {{- if and .Values.security.generatePasswords (not .Values.security.existingCredentialsSecret) -}}
+{{- $existing := lookup "v1" "Secret" (include "elasticsearch.namespace" .) (include "elasticsearch.credentialsSecretName" .) -}}
+{{- $data := dict -}}
+{{- if $existing -}}
+{{- $data = get $existing "data" | default dict -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +17,7 @@ metadata:
     helm.sh/resource-policy: "keep"
 type: Opaque
 data:
-  elastic-password: {{ randAlphaNum 24 | b64enc | quote }}
-  kibana-system-password: {{ randAlphaNum 24 | b64enc | quote }}
+  elastic-password: {{ if hasKey $data "elastic-password" }}{{ get $data "elastic-password" | quote }}{{ else }}{{ randAlphaNum 24 | b64enc | quote }}{{ end }}
+  kibana-system-password: {{ if hasKey $data "kibana-system-password" }}{{ get $data "kibana-system-password" | quote }}{{ else }}{{ randAlphaNum 24 | b64enc | quote }}{{ end }}
 {{- end }}
 {{- end }}

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.5.2
+          value: docker.io/library/kibana:9.5.3
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.5.2
+          value: docker.io/library/elasticsearch:9.5.3
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/tests/security_test.yaml
+++ b/charts/elasticsearch/tests/security_test.yaml
@@ -3,8 +3,23 @@ suite: elasticsearch - security and TLS
 templates:
   - templates/secret-credentials.yaml
   - templates/statefulset-master.yaml
+  - templates/configmap.yaml
 
 tests:
+  - it: configures PEM certificates without conflicting keystore settings
+    set:
+      security.enabled: true
+    template: templates/configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["elasticsearch.yml"]
+          pattern: 'xpack.security.transport.ssl.certificate: /usr/share/elasticsearch/config/certs/tls.crt'
+      - matchRegex:
+          path: data["elasticsearch.yml"]
+          pattern: 'xpack.security.http.ssl.certificate: /usr/share/elasticsearch/config/certs/tls.crt'
+      - notMatchRegex:
+          path: data["elasticsearch.yml"]
+          pattern: 'keystore.path|truststore.path'
   - it: security disabled should not create credentials secret
     set:
       clusterProfile: dev

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.5.2"
+          "default": "9.5.3"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.5.2"
+              "default": "9.5.3"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -32,7 +32,7 @@ commonLabels: {}
 # clusterProfile drives sensible defaults for the number of nodes, resources,
 # heap size, and anti-affinity rules. Values: dev | staging | production-ha
 #
-# dev          - Single node, ephemeral storage, no TLS (ideal for local dev)
+# dev          - Single node, 10Gi master PVC, no TLS (ideal for local dev)
 # staging      - 1 master + 2 data nodes, small PVCs, self-signed TLS
 # production-ha - 3 master + 3 data + 2 coordinating, large PVCs, cert-manager TLS
 #
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.5.2"
+  tag: "9.5.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -91,7 +91,7 @@ master:
     enabled: true
     # -- Storage class for master PVCs
     storageClass: ""
-    # -- Size of master PVCs. Profile default: dev disabled, staging=10Gi, production-ha=20Gi
+  # -- Size of master PVCs. Profile default: dev=10Gi, staging=10Gi, production-ha=20Gi
     size: null
 
 # =============================================================================
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.5.2"
+    tag: "9.5.3"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
Elasticsearch and the optional bundled Kibana image move together from 9.5.2 to 9.5.3. Generated account passwords are preserved on upgrades, and the generated configuration artifact is aligned with the PEM certificate format already used by the active StatefulSet environment.

Resolves #1132

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

Reviewed the complete [Elasticsearch 9.5.3 notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.3-release-notes) and [Kibana 9.5.3 notes](https://www.elastic.co/docs/release-notes/kibana#kibana-9.5.3-release-notes). Both official Docker manifests verified for amd64/arm64; no chart dependencies.

| Change | Impact | Validation |
|---|---|---|
| Generated password retention and PEM artifact consistency | Preserve stored account credentials and align TLS config with mounted files | Live authenticated upgrade and PEM configuration regression test |
| Translog shutdown cleanup, bulk indexing and vector-format fixes | Stateful node restarts and existing indices | Persisted documents/vector query across 9.5.2 to 9.5.3 and pod replacement |
| Authorization and audit-body handling | Existing TLS/authenticated topology must remain operational | Authenticated cluster health and index operations on multiple roles; no paid-license FLS claim |
| Kibana audit appender/HTTP2/session fixes | Keep bundled version aligned and verify Elasticsearch connectivity | Kibana status and effective version in bundled profile |

Validation passed: `make validate-chart CHART=elasticsearch K3D_SCENARIOS="default ci/production-ha-values.yaml ci/kibana-values.yaml" TIMEOUT=900` (13 layers, 100 unit tests), preflight, and the authenticated 9.5.2 to 9.5.3 persistent-index upgrade with a second node replacement. Kubescape v4.0.13: 83.33%. Default, authenticated multi-role and bundled Kibana profiles are selected; unchanged Gateway/ESO/S3 mappings receive static coverage. No S3 restore or licensed audit/FLS behavior is claimed.

The generated elasticsearch.yml ConfigMap is not mounted by the existing StatefulSets; the PEM edit aligns that artifact, while live TLS is configured by the already-correct environment. Kibana availability is verified through its redacted public status API and its effective version through the installed package. Transient startup probe warnings cleared without restarts. No secure Kibana login or paid audit/FLS coverage is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded Elasticsearch and Kibana to version 9.5.3.
  * Development profiles now use a 10 GiB persistent master volume by default.
  * Existing credential Secrets are preserved and reused during upgrades.
  * TLS configuration now uses PEM certificate files.
  * Added runtime smoke checks for cluster health, security, vector search, data retention, and Kibana availability.

* **Documentation**
  * Updated upgrade, persistence, credential, and TLS guidance, including password rotation recommendations.

* **Tests**
  * Updated version expectations and added coverage for PEM-based TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->