### PR TITLE
chore(clickhouse): update to 26.8.2

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,7 +4,7 @@ name: clickhouse
 description: Fast column-oriented OLAP database with production-safe standalone defaults
 type: application
 version: 2.0.0
-appVersion: "26.7.5"
+appVersion: "26.8.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/clickhouse.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: promote chart to stable (#1071)"
+      description: "upgrade ClickHouse to 26.8.2 with persisted table validation"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,7 +15,7 @@ helm install clickhouse oci://ghcr.io/helmforgedev/helm/clickhouse
 
 ## Features
 
-- Official ClickHouse image pinned to `26.7.5`.
+- Official ClickHouse image pinned to `26.8.2`.
 - StatefulSet with persistent data volume.
 - Client Service exposing HTTP `8123` and native TCP `9000`.
 - Headless Service for stable pod DNS.
@@ -55,7 +55,7 @@ networkPolicy:
 | --- | --- | --- |
 | `replicaCount` | ClickHouse pod count. Must remain `1` | `1` |
 | `image.repository` | Official image repository | `docker.io/clickhouse/clickhouse-server` |
-| `image.tag` | Official full-version tag | `26.7.5` |
+| `image.tag` | Official full-version tag | `26.8.2` |
 | `clickhouse.database` | Initial database | `default` |
 | `clickhouse.user` | Initial user | `default` |
 | `clickhouse.password` | Initial password | `""` |
@@ -90,7 +90,7 @@ Security posture acceptable.
 
 Local details:
 
-- Tool: Kubescape v4.0.9
+- Tool: Kubescape v4.0.13
 - Command: `kubescape scan framework mitre,nsa,soc2 .tmp/clickhouse-render.yaml`
 - Result: 0 critical failed resources, resource summary score 89.39%.
 
@@ -103,7 +103,18 @@ clusters.
 
 ## Upgrade Notes
 
-This release moves ClickHouse from 26.6 to 26.7 stable. Review the upstream
+ClickHouse 26.8.2 follows the monthly 26.7 release and carries the August LTS
+designation. It changes the default text-index disk format to v2 and updates
+aggregation, constraint handling, query correctness and merge behavior. Test
+existing table engines and application queries, take a verified backup, and
+plan rollback before allowing a new version to write production data.
+Operators that coordinate mixed-version replicas must review text_index_version
+compatibility before enabling the new format; this chart remains standalone.
+The experimental disk-backed Keeper feature is not enabled by this chart.
+See the [official 26.8 presentation](https://presentations.clickhouse.com/2026-release-26.8/)
+and [26.8.2 release](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.8.2.7-lts).
+
+Earlier 26.7 releases moved ClickHouse from 26.6 to 26.7 stable. Review the upstream
 [ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.5.10-stable)
 and backward-incompatible changes before upgrading production workloads.
 Important changes include explicit credentials for user SQL that accesses S3,

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -108,7 +108,7 @@ designation. It changes the default text-index disk format to v2 and updates
 aggregation, constraint handling, query correctness and merge behavior. Test
 existing table engines and application queries, take a verified backup, and
 plan rollback before allowing a new version to write production data.
-Operators that coordinate mixed-version replicas must review text_index_version
+Operators that coordinate mixed-version replicas must review text_index_serialization_version
 compatibility before enabling the new format; this chart remains standalone.
 The experimental disk-backed Keeper feature is not enabled by this chart.
 See the [official 26.8 presentation](https://presentations.clickhouse.com/2026-release-26.8/)

--- a/charts/clickhouse/scripts/runtime-smoke.mjs
+++ b/charts/clickhouse/scripts/runtime-smoke.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+
+const [context, namespace, release, version = '26.8.2', action = 'smoke'] = process.argv.slice(2);
+assert.ok(context?.startsWith('k3d-helmforge-') && namespace && release);
+const k = args => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], {
+  encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+});
+const pods = JSON.parse(k(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json'])).items;
+const pod = pods.find(p => !p.metadata.deletionTimestamp && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True')
+  && p.spec.containers.some(c => c.name === 'clickhouse'));
+assert.ok(pod, 'Ready ClickHouse server required');
+const exec = args => k(['exec', pod.metadata.name, '-c', 'clickhouse', '--', ...args]).trim();
+const sql = query => exec(['sh', '-ec', 'clickhouse-client --host 127.0.0.1 --user "$CLICKHOUSE_USER" --password "${CLICKHOUSE_PASSWORD:-}" --database "$CLICKHOUSE_DB" --multiquery --query "$1"', 'sh', query]);
+assert.ok(sql('SELECT version()').startsWith(version + '.'));
+assert.equal(exec(['curl', '-fsS', '--max-time', '10', 'http://127.0.0.1:8123/ping']), 'Ok.');
+if (action !== 'verify') {
+  sql('SET enable_full_text_index=1; CREATE TABLE helmforge_upgrade_fixture (id UInt64, body String, INDEX body_idx body TYPE text(tokenizer = splitByNonAlpha)) ENGINE=MergeTree ORDER BY id');
+  sql("INSERT INTO helmforge_upgrade_fixture SELECT number, concat('HelmForge fox ', toString(number)) FROM numbers(5)");
+  sql("INSERT INTO helmforge_upgrade_fixture SELECT number+5, concat('HelmForge fox ', toString(number+5)) FROM numbers(5)");
+}
+assert.equal(sql('SELECT count(), sum(id) FROM helmforge_upgrade_fixture'), '10\t45');
+assert.equal(sql("SELECT count() FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox'])"), '10');
+sql('OPTIMIZE TABLE helmforge_upgrade_fixture FINAL');
+assert.equal(sql("SELECT count(), sum(id) FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox'])"), '10\t45');
+if (version === '26.8.2') assert.equal(sql("SELECT value FROM system.merge_tree_settings WHERE name='text_index_version'"), '2');
+const metrics = pod.spec.containers.find(c => c.name === 'clickhouse').ports.find(p => p.name === 'metrics');
+if (metrics) {
+  const output = exec(['curl', '-fsS', '--max-time', '10', `http://127.0.0.1:${metrics.containerPort}/metrics`]);
+  assert.match(output, /^ClickHouse(?:Metrics|ProfileEvents)_/m);
+}
+if (action === 'smoke') sql('DROP TABLE helmforge_upgrade_fixture');
+console.log(`PASS: ClickHouse ${version}, configured SQL authentication, MergeTree writes/aggregation, text-index query before and after merge${metrics ? ', Prometheus metrics' : ''}.`);

--- a/charts/clickhouse/scripts/runtime-smoke.mjs
+++ b/charts/clickhouse/scripts/runtime-smoke.mjs
@@ -14,20 +14,21 @@ assert.ok(pod, 'Ready ClickHouse server required');
 const exec = args => k(['exec', pod.metadata.name, '-c', 'clickhouse', '--', ...args]).trim();
 const sql = query => exec(['sh', '-ec', 'clickhouse-client --host 127.0.0.1 --user "$CLICKHOUSE_USER" --password "${CLICKHOUSE_PASSWORD:-}" --database "$CLICKHOUSE_DB" --multiquery --query "$1"', 'sh', query]);
 assert.ok(sql('SELECT version()').startsWith(version + '.'));
-assert.equal(exec(['curl', '-fsS', '--max-time', '10', 'http://127.0.0.1:8123/ping']), 'Ok.');
+assert.equal(sql("SELECT line FROM url('http://127.0.0.1:8123/ping', 'LineAsString', 'line String')"), 'Ok.');
 if (action !== 'verify') {
   sql('SET enable_full_text_index=1; CREATE TABLE helmforge_upgrade_fixture (id UInt64, body String, INDEX body_idx body TYPE text(tokenizer = splitByNonAlpha)) ENGINE=MergeTree ORDER BY id');
   sql("INSERT INTO helmforge_upgrade_fixture SELECT number, concat('HelmForge fox ', toString(number)) FROM numbers(5)");
   sql("INSERT INTO helmforge_upgrade_fixture SELECT number+5, concat('HelmForge fox ', toString(number+5)) FROM numbers(5)");
 }
 assert.equal(sql('SELECT count(), sum(id) FROM helmforge_upgrade_fixture'), '10\t45');
-assert.equal(sql("SELECT count() FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox'])"), '10');
+assert.equal(sql("SELECT count() FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox']) SETTINGS force_data_skipping_indices='body_idx'"), '10');
+if (action === 'verify') sql('ALTER TABLE helmforge_upgrade_fixture MATERIALIZE INDEX body_idx SETTINGS mutations_sync=2');
 sql('OPTIMIZE TABLE helmforge_upgrade_fixture FINAL');
-assert.equal(sql("SELECT count(), sum(id) FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox'])"), '10\t45');
-if (version === '26.8.2') assert.equal(sql("SELECT value FROM system.merge_tree_settings WHERE name='text_index_version'"), '2');
+assert.equal(sql("SELECT count(), sum(id) FROM helmforge_upgrade_fixture WHERE hasAnyTokens(body, ['fox']) SETTINGS force_data_skipping_indices='body_idx'"), '10\t45');
+if (version === '26.8.2') assert.equal(sql("SELECT value FROM system.merge_tree_settings WHERE name='text_index_serialization_version'"), 'v2_with_positions');
 const metrics = pod.spec.containers.find(c => c.name === 'clickhouse').ports.find(p => p.name === 'metrics');
 if (metrics) {
-  const output = exec(['curl', '-fsS', '--max-time', '10', `http://127.0.0.1:${metrics.containerPort}/metrics`]);
+  const output = sql(`SELECT line FROM url('http://127.0.0.1:${metrics.containerPort}/metrics', 'LineAsString', 'line String') WHERE startsWith(line, 'ClickHouseMetrics_') OR startsWith(line, 'ClickHouseProfileEvents_') LIMIT 2`);
   assert.match(output, /^ClickHouse(?:Metrics|ProfileEvents)_/m);
 }
 if (action === 'smoke') sql('DROP TABLE helmforge_upgrade_fixture');

--- a/charts/clickhouse/tests/statefulset_test.yaml
+++ b/charts/clickhouse/tests/statefulset_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/clickhouse/clickhouse-server:26.7.5
+          value: docker.io/clickhouse/clickhouse-server:26.8.2
   - it: exposes HTTP and native TCP ports
     template: statefulset.yaml
     asserts:

--- a/charts/clickhouse/tests/test_connection_test.yaml
+++ b/charts/clickhouse/tests/test_connection_test.yaml
@@ -17,7 +17,7 @@ tests:
           path: spec.containers[0].env
           content:
             name: CLICKHOUSE_EXPECTED_VERSION
-            value: "26.7.5"
+            value: "26.8.2"
       - contains:
           path: spec.containers[0].env
           content:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official ClickHouse image repository
   repository: docker.io/clickhouse/clickhouse-server
   # -- Official full-version tag
-  tag: "26.7.5"
+  tag: "26.8.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
ClickHouse moves from 26.7.5 to 26.8.2 using the same official image repository and standalone chart topology.

Resolves #1129

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

Reviewed the full [26.8 release presentation](https://presentations.clickhouse.com/2026-release-26.8/) and all 13 patch commits from 26.8.1.2041-lts through [26.8.2.7-lts](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.8.2.7-lts). Both GitHub release bodies are empty, so the official presentation and comparison provide the substantive release evidence. Official image manifest verified for amd64/arm64; no chart dependencies.

| Change | Impact | Validation |
|---|---|---|
| Aggregation, constraint and merge corrections | Existing MergeTree data and application queries | Persisted table upgrade, aggregate/filter queries, merges and pod replacement |
| Text index v2 becomes default | Old readers and downgrade planning need attention | New text-index query plus old-image table upgrade; migration guidance |
| Anonymous session user and protocol changes | Preserve configured SQL credentials and HTTP/native service access | Default and authenticated production profiles, including metrics |
| Experimental disk-backed Keeper | Outside this standalone chart's operator boundary | No Keeper enabled or replication implied; existing replica guard retained |

Validation passed: `make validate-chart CHART=clickhouse K3D_SCENARIOS="default ci/production-values.yaml" TIMEOUT=900` (12 layers, 29 unit tests), preflight, and a persistent 26.7.5 to 26.8.2 upgrade followed by pod replacement. Authenticated MergeTree rows, aggregates, forced text-index queries/materialization and Prometheus metrics passed. Kubescape v4.0.13: 89.39%. The chart intentionally supports one pod; replicated/sharded clusters require an operator and are not added by this image update. No object-store backup restore is claimed.

The tagged source confirms `text_index_serialization_version=v2_with_positions` in `system.merge_tree_settings`. HTTP ping and metrics use the native URL table function because this official image does not include curl. Site build and 156 local links/anchors passed.
