### PR TITLE
fix(changedetection): update to 0.60.3 with datastore migration guidance

### DIFF
--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -4,7 +4,7 @@ name: changedetection
 description: changedetection.io website change detection and monitoring with optional Playwright browser
 type: application
 version: 1.1.14
-appVersion: "0.55.8"
+appVersion: "0.60.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.55.8 (#754)"
+      description: "update changedetection.io to 0.60.3 and document datastore and restricted URL migration"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/changedetection/DESIGN.md
+++ b/charts/changedetection/DESIGN.md
@@ -1,7 +1,7 @@
 # changedetection.io Chart Design
 
 This chart packages changedetection.io as a practical single-instance
-Kubernetes workload with persistent SQLite storage and optional browser
+Kubernetes workload with persistent JSON datastore and optional browser
 rendering.
 
 ## Architecture
@@ -22,7 +22,7 @@ User or automation
 ## Design Choices
 
 - The workload is a `Deployment` with one replica and `Recreate` strategy
-  because changedetection.io stores runtime state in SQLite under
+  because changedetection.io stores runtime state in JSON files under
   `/datastore`.
 - Persistence is enabled by default so watches, history, and snapshots survive
   upgrades and pod rescheduling.
@@ -46,7 +46,7 @@ state and temporary files.
 
 ## Non-Goals
 
-- Horizontal scaling is not supported while upstream uses SQLite for runtime
+- Horizontal scaling is not supported while upstream uses a file-based datastore for runtime
   state.
 - The chart does not manage notification provider credentials directly. Use
   Kubernetes Secrets or External Secrets Operator.

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -11,7 +11,7 @@ Discord, Telegram, webhooks, and 90+ Apprise services.
 - **Website monitoring** — detect content changes on any URL
 - **90+ notification channels** — via built-in Apprise library
 - **Optional JavaScript rendering** — Playwright browser sidecar for dynamic sites
-- **SQLite storage** — zero external database dependencies
+- **JSON datastore** — zero external database dependencies
 - **Persistent storage** — snapshots and history on PVC
 - **Ingress support** — TLS with cert-manager
 - **Gateway API support** — optional HTTPRoute for platform Gateway deployments
@@ -66,7 +66,7 @@ from the application container when JavaScript rendering is used heavily.
 
 ## Persistence
 
-changedetection.io stores its SQLite database, snapshots, and watch history in
+changedetection.io stores its JSON settings and watch files, snapshots, and watch history in
 `/datastore`. Persistence is enabled by default:
 
 ```yaml
@@ -83,7 +83,7 @@ persistence:
   enabled: false
 ```
 
-Because SQLite is used, this chart intentionally deploys a single replica with
+Because the datastore is written by one application instance, this chart intentionally deploys a single replica with
 the `Recreate` strategy. Do not scale the workload horizontally unless the
 upstream application storage model changes.
 
@@ -243,7 +243,7 @@ probes:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/dgtlmoon/changedetection.io` | changedetection.io image repository |
-| `image.tag` | `0.55.8` | changedetection.io image tag |
+| `image.tag` | `0.60.3` | changedetection.io image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `changedetection.port` | `5000` | Application port |
 | `changedetection.baseUrl` | `""` | Public base URL |
@@ -283,17 +283,31 @@ probes:
 
 ## Upgrade Notes
 
-For this release the application image is updated to `0.55.8`. The upstream
-`0.55.6` release includes a security fix for an SSRF parser differential,
-notification and preview fixes, plus an `LLM_FEATURES_DISABLED` flag. The
-`0.55.8` release adds translation updates and fixes page title extraction,
-password-protected RSS feeds, URL fragments, restock tokens, and LLM handling. Review the upstream changelog
-before production rollout and test restores from the `/datastore` backup when
-upgrading long-lived instances.
+Version 0.60.3 includes the intervening watch/tag loading, XML parsing,
+CSRF/XSS protections, browser and UTF-8 backup fixes since 0.55.8.
+Back up the complete `/datastore` before upgrading: `changedetection.json`,
+watch/tag directories and snapshots belong together. Restore that backup with
+its matching old image for rollback; reverting only the tag does not reverse
+storage migrations.
+
+Upstream consistently blocks private, loopback and other restricted target
+addresses by default. Existing internal-site monitors may need an explicit opt-in:
+
+```yaml
+changedetection:
+  extraEnv:
+    - name: ALLOW_IANA_RESTRICTED_ADDRESSES
+      value: "true"
+```
+
+Use that setting only when internal monitoring is intended and application access
+is controlled. The chart keeps the upstream restriction enabled by default.
+`PLAYWRIGHT_BYPASS_CSP` defaults to `true` upstream; set it to `false` through
+`changedetection.extraEnv` when the remote browser does not support CSP bypass.
 
 ## Limitations
 
-- **Single instance only** — SQLite does not support concurrent writers
+- **Single instance only** — the JSON datastore requires a single application writer
 - **Storage grows** — each snapshot consumes disk space; plan PVC size accordingly
 - **Browser rendering costs more** — enabling the browser sidecar increases CPU
   and memory consumption
@@ -317,7 +331,7 @@ Local details:
 | SOC2 | 80.00% |
 
 The remaining findings are expected for this workload profile: changedetection.io
-needs a writable datastore for SQLite and snapshots, NetworkPolicy is supplied by
+needs a writable datastore for JSON files and snapshots, NetworkPolicy is supplied by
 the platform layer, and ServiceAccount token hardening remains configurable by
 cluster policy.
 

--- a/charts/changedetection/ci/browser-values.yaml
+++ b/charts/changedetection/ci/browser-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Local deterministic runtime fixture; production keeps restricted URLs blocked.
+browser:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+changedetection:
+  fetchWorkers: 2
+  extraEnv:
+    - name: ALLOW_IANA_RESTRICTED_ADDRESSES
+      value: "true"
+persistence:
+  size: 1Gi

--- a/charts/changedetection/ci/default-values.yaml
+++ b/charts/changedetection/ci/default-values.yaml
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: default values with SQLite datastore
+# CI: default values with JSON settings and watch datastore

--- a/charts/changedetection/docs/production.md
+++ b/charts/changedetection/docs/production.md
@@ -16,7 +16,7 @@ persistence:
   storageClass: fast-retain
 ```
 
-Back up the PVC before upgrades. The application stores its SQLite database and
+Back up the PVC before upgrades. The application stores its JSON settings and watch files and
 snapshot data under `/datastore`.
 
 ## Routing

--- a/charts/changedetection/scripts/runtime-smoke.mjs
+++ b/charts/changedetection/scripts/runtime-smoke.mjs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+const [context, namespace, release, version = '0.60.3', action = 'smoke'] = process.argv.slice(2);
+const run = (args, input) => execFileSync('kubectl', ['--context', context, '-n', namespace, ...args], { encoding: 'utf8', input, timeout: 360000, maxBuffer: 4 * 1024 * 1024 });
+const pods = JSON.parse(run(['get', 'pods', '-l', `app.kubernetes.io/instance=${release}`, '-o', 'json']));
+const pod = pods.items.find(p => !p.metadata.deletionTimestamp && p.status.conditions?.some(c => c.type === 'Ready' && c.status === 'True'));
+if (!pod) throw new Error('No Ready changedetection pod');
+const app = pod.spec.containers.find(c => c.name === 'changedetection');
+if (!app?.image.endsWith(`:${version}`)) throw new Error('Unexpected application image');
+const browser = pod.spec.containers.some(c => c.name === 'browser');
+console.log(run(['exec', '-i', pod.metadata.name, '-c', 'changedetection', '--', 'python', '-', action, String(browser), version], readFileSync(new URL('./runtime-smoke.py', import.meta.url), 'utf8')).trim());

--- a/charts/changedetection/scripts/runtime-smoke.py
+++ b/charts/changedetection/scripts/runtime-smoke.py
@@ -24,7 +24,7 @@ def api(route, data=None, method=None, auth=True):
     req = urllib.request.Request(base + '/api/v1' + route, data=json.dumps(data).encode() if data is not None else None, headers=headers, method=method)
     with urllib.request.urlopen(req, timeout=45) as response:
         body = response.read().decode()
-        return json.loads(body) if 'json' in response.headers.get('Content-Type', '') else body
+        return json.loads(body) if body and 'json' in response.headers.get('Content-Type', '') else body
 
 try:
     api('/watch', auth=False)

--- a/charts/changedetection/scripts/runtime-smoke.py
+++ b/charts/changedetection/scripts/runtime-smoke.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise only an owned fixture watch in an isolated validation namespace."""
+import http.server
+import json
+import os
+import pathlib
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+action, browser, version = sys.argv[1:]
+browser = browser == "true"
+settings_path = pathlib.Path('/datastore/changedetection.json')
+settings = json.loads(settings_path.read_text())
+token = settings['settings']['application']['api_access_token']
+base = 'http://127.0.0.1:' + os.getenv('PORT', '5000')
+
+def api(route, data=None, method=None, auth=True):
+    headers = {'Content-Type': 'application/json'}
+    if auth:
+        headers['x-api-key'] = token
+    req = urllib.request.Request(base + '/api/v1' + route, data=json.dumps(data).encode() if data is not None else None, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=45) as response:
+        body = response.read().decode()
+        return json.loads(body) if 'json' in response.headers.get('Content-Type', '') else body
+
+try:
+    api('/watch', auth=False)
+    raise AssertionError('Anonymous API access unexpectedly accepted')
+except urllib.error.HTTPError as error:
+    assert error.code == 403, error.code
+
+marker = pathlib.Path('/datastore/helmforge-runtime-fixture.json')
+state = json.loads(marker.read_text()) if action == 'verify' else {}
+generation = str(time.time_ns())
+expected = 'HelmForge-rendered-' + generation
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = ('<html><body><p>fixture</p><script>document.body.innerText=' + json.dumps(expected) + ';</script></body></html>').encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+server = http.server.ThreadingHTTPServer(('0.0.0.0', 18080), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+try:
+    if action == 'verify':
+        uuid = state['uuid']
+        old = api('/watch/' + uuid + '/history')
+        assert state['history'] in old, 'Persisted snapshot missing'
+        assert api('/watch/' + uuid)['title'] == 'HelmForge persistencia Unicode'
+    else:
+        if action == 'smoke':
+            assert not api('/watch'), 'Default sample watches should be disabled'
+        url = 'http://127.0.0.1:18080/caf\u00e9' if browser else 'https://helmforge.dev/'
+        uuid = api('/watch', {'url': url, 'title': 'HelmForge persistencia Unicode', 'fetch_backend': 'html_webdriver' if browser else 'html_requests', 'time_between_check': {'minutes': 60}})['uuid']
+    api('/watch/' + uuid + '?recheck=1')
+    deadline = time.monotonic() + 150
+    while time.monotonic() < deadline:
+        history = api('/watch/' + uuid + '/history')
+        if history:
+            snapshot = api('/watch/' + uuid + '/history/latest')
+            if (expected in snapshot if browser else 'HelmForge' in snapshot):
+                break
+        time.sleep(3)
+    else:
+        watch = api('/watch/' + uuid)
+        raise AssertionError('No expected fetched snapshot: ' + str(watch.get('last_error')))
+    if not browser and version == '0.60.3':
+        from changedetectionio.validate_url import validate_fetch_url
+        assert not validate_fetch_url('http://127.0.0.1:18080/')[0], 'Restricted URL accepted by default'
+    if action != 'smoke':
+        marker.write_text(json.dumps({'uuid': uuid, 'history': list(history)[0]}))
+    if browser and version == '0.60.3':
+        import io
+        import re
+        import requests
+        import zipfile
+        session = requests.Session()
+        page = session.get(base + '/backups/create', timeout=30)
+        page.raise_for_status()
+        csrf = re.search(r'name="csrf_token"[^>]*value="([^"]+)"', page.text)
+        assert csrf, 'Backup CSRF token missing'
+        response = session.post(base + '/backups/request-backup', data={'csrf_token': csrf[1]}, timeout=30)
+        response.raise_for_status()
+        deadline = time.monotonic() + 45
+        while time.monotonic() < deadline:
+            response = session.get(base + '/backups/download/latest', timeout=30)
+            if response.status_code == 200:
+                with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+                    urls = archive.read('url-list.txt').decode('utf-8')
+                    assert 'caf' in urls and ('\u00e9' in urls or '%C3%A9' in urls), urls
+                    assert 'changedetection.json' in archive.namelist()
+                break
+            time.sleep(2)
+        else:
+            raise AssertionError('Backup ZIP was not created')
+        print('PASS: application backup ZIP contains UTF-8 URL list and settings; restore is not claimed.')
+    if action == 'smoke':
+        api('/watch/' + uuid, method='DELETE')
+    print('PASS: changedetection ' + version + ', authenticated API, anonymous denial, ' + ('JavaScript rendering' if browser else 'HTTP fetch and restricted-address policy') + ', snapshot history' + (' retained after upgrade/replacement' if action == 'verify' else '') + '.')
+finally:
+    server.shutdown()

--- a/charts/changedetection/scripts/runtime-smoke.py
+++ b/charts/changedetection/scripts/runtime-smoke.py
@@ -75,7 +75,11 @@ try:
         raise AssertionError('No expected fetched snapshot: ' + str(watch.get('last_error')))
     if not browser and version == '0.60.3':
         from changedetectionio.validate_url import validate_fetch_url
-        assert not validate_fetch_url('http://127.0.0.1:18080/')[0], 'Restricted URL accepted by default'
+        try:
+            validate_fetch_url('http://127.0.0.1:18080/')
+            raise AssertionError('Restricted URL accepted by default')
+        except ValueError as error:
+            assert 'private/reserved IP address' in str(error), str(error)
     if action != 'smoke':
         marker.write_text(json.dumps({'uuid': uuid, 'history': list(history)[0]}))
     if browser and version == '0.60.3':

--- a/charts/changedetection/templates/NOTES.txt
+++ b/charts/changedetection/templates/NOTES.txt
@@ -65,7 +65,7 @@ Datastore persistence is enabled.
 PVC: {{ include "changedetection.dataClaimName" . }}
 Mount path: /datastore
 
-Back up this PVC before upgrades. It stores the SQLite database, watch state,
+Back up this PVC before upgrades. It stores the JSON settings and watch files, watch state,
 snapshots, and any Python user packages installed through EXTRA_PACKAGES.
 {{- else }}
 Datastore persistence is disabled. /datastore uses emptyDir and all watches,

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.8"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.60.3"
 
   - it: should expose port 5000
     asserts:
@@ -140,7 +140,7 @@ tests:
           value: initialize-datastore
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.8"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.60.3"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "include_default_watches=False"

--- a/charts/changedetection/values.schema.json
+++ b/charts/changedetection/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/dgtlmoon/changedetection.io" },
-        "tag": { "type": "string", "default": "0.55.8" },
+        "tag": { "type": "string", "default": "0.60.3" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- changedetection.io container image
   repository: ghcr.io/dgtlmoon/changedetection.io
   # -- Image tag
-  tag: "0.55.8"
+  tag: "0.60.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -69,7 +69,7 @@ browser:
 # =============================================================================
 
 persistence:
-  # -- Enable persistence for /datastore (SQLite + snapshots)
+  # -- Enable persistence for /datastore (JSON settings + snapshots)
   enabled: true
   # -- Storage size
   size: 10Gi


### PR DESCRIPTION
ChangeDetection advances from 0.55.8 to 0.60.3, covering the intervening release notes and preserving the single-writer datastore deployment.

Resolves #1128

Companion site update: https://github.com/helmforgedev/site/pull/555

## Upstream evidence and risk

Official [release history](https://github.com/dgtlmoon/changedetection.io/releases) and [complete comparison](https://github.com/dgtlmoon/changedetection.io/compare/0.55.8...0.60.3) reviewed. Official GHCR manifest includes amd64/arm64/arm. No subchart dependencies.

| Change | Chart impact | Validation |
|---|---|---|
| Watch/tag JSON loading and thread-safe XML parsing | Retain datastore and snapshots across upgrade | Persisted watch/history and rechecks before/after upgrade and pod replacement |
| Stronger private-address URL validation and CSRF/XSS fixes | Document internal-monitoring opt-in without weakening default | Default rejects restricted targets; isolated browser CI explicitly enables local fixture |
| Playwright CSP control and browser-step fixes | Preserve optional browser compatibility | Actual JavaScript-rendered watch through browser sidecar |
| UTF-8 backup URL lists | Preserve Unicode watch data | Inspect generated backup ZIP and Unicode URL list |
| Python 3.10 support removed | Official image supplies runtime | Verify effective application image and API |

Validation passed: `make validate-chart CHART=changedetection K3D_SCENARIOS="default ci/browser-values.yaml" TIMEOUT=900` (12 layers, 42 unit tests), preflight, and a 0.55.8 to 0.60.3 persistent watch/history upgrade followed by pod replacement. Actual JavaScript rechecks and application backup ZIP UTF-8 URL lists passed. Default authenticated API/HTTP fetch and restricted-address rejection passed. Kubescape v4.0.13: 87.88%. Site build and 156 local links/anchors passed. Default and browser profiles selected; unchanged ingress/Gateway/ESO contracts receive static coverage.

The unchanged pinned browserless/chromium:v2.46.0 sidecar worked against both application versions. Backup archive contents were verified; backup restoration is not claimed. The chart and site now correctly describe JSON settings/watch/tag files instead of SQLite.
