### PR TITLE
feat(text-embeddings-inference)!: add production embedding api

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What HelmForge Provides
 
-HelmForge is a catalog of 110 Helm charts built around a consistent operating contract:
+HelmForge is a catalog of 111 Helm charts built around a consistent operating contract:
 official upstream images, pinned versions, explicit values, reproducible validation, and signed releases.
 
 Use HelmForge when you want charts that stay close to upstream applications while still behaving like a

--- a/charts/text-embeddings-inference/.helmignore
+++ b/charts/text-embeddings-inference/.helmignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/charts/text-embeddings-inference/Chart.yaml
+++ b/charts/text-embeddings-inference/Chart.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: text-embeddings-inference
+description: >-
+  Native text embeddings with pinned model identity, protected inference, private metrics and explicit CPU/GPU cache
+  contracts.
+type: application
+version: 0.1.0
+appVersion: 1.9.3
+kubeVersion: '>=1.30.0-0'
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - embeddings
+  - huggingface
+  - inference
+  - kubernetes
+home: https://helmforge.dev/docs/charts/text-embeddings-inference
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/text-embeddings-inference
+  - https://github.com/huggingface/text-embeddings-inference
+icon: https://helmforge.dev/icons/charts/text-embeddings-inference.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Add protected native text embeddings and reproducible model serving"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/huggingface/text-embeddings-inference
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/text-embeddings-inference

--- a/charts/text-embeddings-inference/DESIGN.md
+++ b/charts/text-embeddings-inference/DESIGN.md
@@ -1,0 +1,39 @@
+# Text Embeddings Inference design
+
+## Architecture
+
+Clients reach a ClusterIP Service and unprivileged NGINX. NGINX proxies inference to native TEI on loopback.
+An optional separate metrics Service reaches a metrics-only NGINX listener. Both containers run as UID/GID 1000
+with read-only root filesystems and writable temporary directories. The Pod has no Kubernetes API credential.
+
+## Native behavior and security boundary
+
+TEI 1.9.3 serves unauthenticated metrics on its HTTP API listener. A declared Prometheus port does not create
+a private HTTP exporter in this image. The proxy is therefore a required boundary, not an optional exporter.
+Public paths deny metrics and API documentation, and NetworkPolicy separately authorizes metrics clients.
+The native process retains its official entrypoint, which is essential to CUDA architecture selection.
+
+Native INFO startup logging serializes the API key. LOG_LEVEL is fixed at warn and reserved against override.
+Credentials are environment references to Kubernetes Secrets; generated keys use lookup during live upgrades.
+Declarative render-only installations should use externally managed Secrets.
+
+## Reproducibility and persistence
+
+Image digests and Hub commit revisions are independent pins. The default CPU ONNX model is small enough for
+the automated cluster and produces meaningful semantic embeddings. Model cache is reproducible, not business data.
+RWO cache is restricted to a single Recreate replica. Multiple replicas use independent caches or an explicitly
+compatible existing local-model volume. Offline mode selects the local directory, not an environment hint.
+
+## Availability tradeoffs
+
+Recreate is intentionally the default because a model change can alter vector meaning without an HTTP failure.
+RollingUpdate is opt-in for compatible contracts. Model/index migrations use distinct releases and indexes.
+CPU HPA targets inference CPU only; no unvalidated GPU utilization scaler is included. PDB validation prevents
+a singleton budget from obstructing voluntary maintenance. Neither PDB nor graceful termination provides durability.
+
+## Scope and evidence
+
+The chart serves HTTP embedding models. It has no database, vector store, durable work queue, model training,
+tenant authorization or gRPC server. Native API tests verify actual vectors and identity rather than a TCP socket.
+The CPU matrix verifies existing/ESO credentials, cache, local offline artifacts, metrics and scaling. CUDA
+manifests preserve upstream setup and request devices, but hardware-specific inference is outside the local lab.

--- a/charts/text-embeddings-inference/README.md
+++ b/charts/text-embeddings-inference/README.md
@@ -155,7 +155,8 @@ when hostname restrictions are required. Local mode denies egress unless `extraE
 Policy enforcement requires a compatible CNI. Custom peer rules replace the default same-namespace rule.
 
 `service.ipFamilyPolicy` and `service.ipFamilies` configure API and metrics Services. RequireDualStack needs a
-dual-stack cluster; PreferDualStack may fall back. Both proxy listeners support IPv4 and IPv6.
+dual-stack cluster; PreferDualStack may fall back. IPv4 sockets are the default. Set `proxy.ipv6: true` for IPv6 or dual-stack Services;
+the chart rejects incompatible listener/Service settings. Keep it false when kernel IPv6 support is disabled.
 
 ## Observability
 
@@ -164,7 +165,7 @@ The private listener on 9464 serves only native `/metrics`. It exposes TEI reque
 inference duration histograms. Public `/metrics`, `/docs` and `/api-doc` paths return 404.
 Configure Prometheus selectors to discover the ServiceMonitor and network peers to permit actual scraping.
 
-The optional built-in PrometheusRule reports a down scrape target; it is not a semantic quality or latency SLO.
+The optional built-in PrometheusRule reports a down or absent scrape target; it is not a semantic quality or latency SLO.
 Add workload-specific recording and alert rules through `additionalRules`. Inspect native metrics for the pinned
 release before writing queries. Metrics may disclose model/workload metadata and belong in the trusted network.
 

--- a/charts/text-embeddings-inference/README.md
+++ b/charts/text-embeddings-inference/README.md
@@ -1,0 +1,216 @@
+# Text Embeddings Inference
+
+Deploy Hugging Face [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference)
+as an authenticated HTTP embedding API with immutable model provenance and private native metrics.
+
+## Features
+
+- Official TEI 1.9.3 CPU image pinned by digest; optional pinned CUDA example.
+- BGE-small English model pinned to an immutable revision, with 384-dimensional embeddings.
+- Native `/embed` and OpenAI-compatible `/v1/embeddings` endpoints.
+- Generated API Secret retained across Helm upgrades, existing Secrets and External Secrets Operator.
+- Loopback-only inference process behind unprivileged NGINX; public metrics and Swagger paths blocked.
+- Private native Prometheus endpoint, ServiceMonitor, PrometheusRule and explicit monitoring peers.
+- Non-root containers, read-only filesystems, dropped capabilities, seccomp and no Kubernetes API token.
+- Immutable Hub downloads or a complete read-only local model PVC with denied outbound traffic.
+- Independent model replicas, CPU container HPA, disruption budgets and topology spreading.
+- Ingress, Gateway API HTTPRoute, dual-stack Services and NetworkPolicy.
+
+## Installation
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install embeddings helmforge/text-embeddings-inference \
+  --namespace embeddings --create-namespace
+```
+
+Alternatively, use the OCI repository:
+
+```bash
+helm install embeddings oci://ghcr.io/helmforgedev/helm/text-embeddings-inference \
+  --namespace embeddings --create-namespace
+```
+
+The pinned image requires Linux amd64. CPU requests and limits are starting points for the default small model;
+benchmark realistic sequence lengths, concurrent clients and latency objectives before sizing production.
+The chart does not deploy a database or vector index.
+
+## Quick start
+
+```bash
+kubectl -n embeddings port-forward service/embeddings-text-embeddings-inference 8080:80
+```
+
+In another terminal, retrieve the generated credential into a shell variable without printing it:
+
+```bash
+TEI_API_KEY="$(kubectl -n embeddings get secret embeddings-text-embeddings-inference-auth \
+  -o jsonpath='{.data.api-key}' | base64 --decode)"
+curl --fail-with-body http://localhost:8080/embed \
+  -H @- -H 'Content-Type: application/json' \
+  -d '{"inputs":["A cat sits on the mat."],"normalize":true}' <<EOF
+Authorization: Bearer ${TEI_API_KEY}
+EOF
+unset TEI_API_KEY
+```
+
+The bearer header is read from standard input; the key is not exported to the curl process environment.
+Helm NOTES never print the credential. Native `/health` is intentionally unauthenticated.
+
+## Model and vector contract
+
+The default model is `BAAI/bge-small-en-v1.5`, revision `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a`.
+The CPU image loads its ONNX artifacts. `/info` identifies the model, revision, dtype, pooling and actual limits.
+`model.servedName` changes the exposed model name; it does not download or select another model.
+
+Pin `model.revision` to a full lowercase 40-character commit for Hub models. Changing the model, revision,
+pooling, prompt, normalization or embedding dimension can invalidate an existing vector index. Create a separate
+release and index, re-embed the corpus, compare retrieval quality and switch clients deliberately.
+Rolling two incompatible models behind one Service can silently mix embedding spaces.
+
+The default model produces embeddings, not reranking scores. A `/rerank` request against it returns 424.
+Other upstream model families need compatible artifacts and their own acceptance tests; the supplied runtime
+matrix validates the default embedding model. This chart deploys the HTTP image, not the separate gRPC variant.
+
+## Authentication and secrets
+
+Authentication is enabled by default. A generated Secret is reused through Helm `lookup` during upgrades.
+For declarative renderers without live lookup, use `auth.existingSecret` to avoid random credentials on each render.
+The Secret must contain `auth.secretKey` (default `api-key`). Disabling authentication is suitable only for a
+deliberately restricted trust boundary. The native key is shared across API clients, without per-user authorization.
+
+Private or gated Hub models can independently reference `model.hubToken.existingSecret`, key `token` by default.
+Accept the upstream model terms and grant the token only the required repository access.
+Neither token is embedded in the ConfigMap or command-line arguments.
+
+The pinned native release logs parsed arguments at INFO, including API credentials. The chart fixes
+`LOG_LEVEL=warn` and rejects overriding it with `extraEnv`; warning and error logs remain available.
+Native process environment access is still privileged secret access. Rotation of an existing Secret requires
+a Pod restart because environment variables are read at startup. Changing `auth.secretKey` is a credential change.
+
+External Secrets uses the canonical `externalSecrets.items[]` contract. Point `auth.existingSecret` and/or
+`model.hubToken.existingSecret` at the corresponding target Secrets. Install ESO and your SecretStore separately.
+See [secret operations](docs/security.md).
+
+## Storage and offline operation
+
+Each Pod defaults to a 5Gi ephemeral download cache. Replacement may download the pinned model again.
+`cache.persistence.enabled` creates or references a RWO PVC and requires one replica, Recreate and no HPA.
+This cache is reproducible model data; the chart does not provide database backup jobs.
+
+For offline operation, set `model.source: local` and `model.local.existingClaim` to a PVC containing the complete
+model directory. It mounts read-only at `/models`; optional `subPath` selects a directory. Preserve provenance
+and hashes outside the mutable volume. The correct weight format depends on the selected image backend.
+Setting an offline environment flag alone does not guarantee that missing artifacts will not trigger downloads.
+
+Local mode with default network isolation permits no outbound traffic. It must not need Hub DNS or HTTPS.
+Multi-replica local models require storage access modes and node placement that permit every scheduled reader.
+See [model lifecycle](docs/models.md) for seeding, rollback and index migration.
+
+## Resource and admission limits
+
+The default native limits are 64 concurrent requests, 2048 batch tokens, eight batch requests, 16 client batch
+items and 1048576 payload bytes. The CPU backend forces exactly eight batch requests in this pinned image; other CPU values are rejected.
+The proxy also enforces the payload byte limit. Token limits and payload bytes are different controls.
+Requests beyond the client batch limit return 422; oversized bodies return 413. Inputs beyond the model's token
+length fail unless truncation is enabled. Explicit client truncation can override the default behavior.
+
+`inference.threads` controls Rayon, OpenMP and MKL thread budgets; tokenization workers are configured separately.
+Increasing concurrency does not create more model memory. Large batches and sequence lengths can exhaust RAM
+or VRAM. Admission limits are not per-client quotas or a durable queue. Apply edge rate limiting if needed.
+
+## Availability and scaling
+
+Recreate is the default strategy. It avoids concurrent old/new model instances but causes an update interruption.
+For compatible models and independent ephemeral caches, use multiple replicas with RollingUpdate and sufficient
+capacity for surge Pods. Every replica loads a complete model. Readiness checks execute native model health.
+
+CPU HPA measures only container `tei`, not NGINX, and requires metrics-server and CPU requests. It is rejected
+for GPU deployments. The production example uses two minimum replicas and a disruption budget allowing one
+unavailable Pod. A PDB covers voluntary disruption, not a failed node or an application rollout.
+
+The termination grace period must exceed the proxy read timeout (150 and 120 seconds by default). Native
+shutdown is graceful, but Pod failure can lose in-memory requests. Clients need bounded retries and deadlines.
+Do not claim zero downtime from readiness or grace periods alone.
+
+## GPU deployment
+
+[The CUDA example](examples/cuda.yaml) pins the official CUDA image and requests NVIDIA GPUs through the device
+plugin. The native image entrypoint is preserved so upstream architecture selection and library setup execute.
+Use compatible NVIDIA drivers, runtime and hardware, and benchmark the selected model on that hardware.
+GPU manifest rendering and resource allocation are tested; GPU inference and throughput are not validated in
+the CPU-only development cluster. No GPU performance claim is made.
+
+## Networking
+
+The Service exposes HTTP on port 80. NGINX listens on 8080; native TEI binds only to `127.0.0.1:8081`.
+Do not expose the native process directly: upstream metrics share its HTTP listener and are unauthenticated.
+Ingress and HTTPRoute terminate at the controlled public Service. Configure existing TLS infrastructure and
+explicit ingress-controller peers. The chart does not create a Gateway or certificates.
+
+NetworkPolicy allows same-namespace clients by default. Hub mode permits DNS and public HTTPS model downloads,
+excluding private address ranges. CNI policies cannot filter by domain; use an egress proxy and explicit rules
+when hostname restrictions are required. Local mode denies egress unless `extraEgress` explicitly permits it.
+Policy enforcement requires a compatible CNI. Custom peer rules replace the default same-namespace rule.
+
+`service.ipFamilyPolicy` and `service.ipFamilies` configure API and metrics Services. RequireDualStack needs a
+dual-stack cluster; PreferDualStack may fall back. Both proxy listeners support IPv4 and IPv6.
+
+## Observability
+
+Enable `metrics.enabled`, explicit `metrics.ingressFrom` and optionally `metrics.serviceMonitor.enabled`.
+The private listener on 9464 serves only native `/metrics`. It exposes TEI request counts, success counters and
+inference duration histograms. Public `/metrics`, `/docs` and `/api-doc` paths return 404.
+Configure Prometheus selectors to discover the ServiceMonitor and network peers to permit actual scraping.
+
+The optional built-in PrometheusRule reports a down scrape target; it is not a semantic quality or latency SLO.
+Add workload-specific recording and alert rules through `additionalRules`. Inspect native metrics for the pinned
+release before writing queries. Metrics may disclose model/workload metadata and belong in the trusted network.
+
+## Configuration reference
+
+Every supported option and default is documented in [values.yaml](values.yaml), with validation in
+[values.schema.json](values.schema.json). The [site guide](https://helmforge.dev/docs/charts/text-embeddings-inference)
+includes the complete values reference. Unsafe storage, model revision, monitoring and scaling combinations fail
+before Kubernetes resources are installed. `extraEnv` cannot override chart-owned model, auth or budget settings.
+
+## Examples and operations
+
+- [Simple CPU deployment](examples/simple.yaml)
+- [Staging deployment](examples/staging.yaml)
+- [Production CPU replicas](examples/production.yaml)
+- [Private native monitoring](examples/metrics.yaml)
+- [Local offline model](examples/offline.yaml)
+- [External Secrets](examples/external-secrets.yaml)
+- [CUDA GPU resources](examples/cuda.yaml)
+- [Model lifecycle](docs/models.md), [security](docs/security.md), [operations](docs/operations.md)
+- [Design decisions](DESIGN.md)
+
+## Validation
+
+Run `make validate-chart CHART=text-embeddings-inference` from helmforge-ops. The matrix covers native model
+identity, finite normalized semantic vectors, OpenAI output equivalence, rejected requests, authentication,
+credential retention, network isolation, real Prometheus, persistent cache, offline model inference, replicas,
+CPU HPA and Pod replacement. GPU hardware and alternative model families require separate validation.
+
+## Security Scan
+
+### Security Scan: `text-embeddings-inference`
+
+| Framework | Score |
+| --- | --- |
+| MITRE + NSA + SOC2 | **98.48485%** |
+
+> Security posture acceptable.
+
+Measured with Kubescape 4.0.13 against default manifests, without suppressed controls. This assesses
+Kubernetes configuration; it does not certify upstream application or model security.
+
+The unsuppressed C-0012 finding matches `MAX_BATCH_TOKENS=2048` and `TOKENIZATION_WORKERS=2`
+by the word token. These are numeric inference settings, not credentials. API and Hub credentials use Secret references.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md). Report model compatibility and runtime evidence with deployment
+details while keeping credentials and private input text out of issues and logs.

--- a/charts/text-embeddings-inference/ci/auth-disabled-values.yaml
+++ b/charts/text-embeddings-inference/ci/auth-disabled-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-anonymous
+auth:
+  enabled: false

--- a/charts/text-embeddings-inference/ci/cache-values.yaml
+++ b/charts/text-embeddings-inference/ci/cache-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-cache
+cache:
+  persistence:
+    enabled: true
+    size: 1Gi

--- a/charts/text-embeddings-inference/ci/default-values.yaml
+++ b/charts/text-embeddings-inference/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-default

--- a/charts/text-embeddings-inference/ci/dual-stack-values.yaml
+++ b/charts/text-embeddings-inference/ci/dual-stack-values.yaml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 fullnameOverride: tei-dual
+proxy:
+  ipv6: true
 service:
   ipFamilyPolicy: RequireDualStack
   ipFamilies:

--- a/charts/text-embeddings-inference/ci/dual-stack-values.yaml
+++ b/charts/text-embeddings-inference/ci/dual-stack-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-dual
+service:
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/text-embeddings-inference/ci/existing-secret-values.yaml
+++ b/charts/text-embeddings-inference/ci/existing-secret-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-existing
+auth:
+  existingSecret: tei-api

--- a/charts/text-embeddings-inference/ci/external-secrets-values.yaml
+++ b/charts/text-embeddings-inference/ci/external-secrets-values.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-eso
+auth:
+  existingSecret: tei-eso-api
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: tei-eso-api
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        data:
+          - secretKey: api-key
+            remoteRef:
+              key: test/password

--- a/charts/text-embeddings-inference/ci/fixtures/existing-secret-values.yaml
+++ b/charts/text-embeddings-inference/ci/fixtures/existing-secret-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tei-api
+type: Opaque
+stringData:
+  api-key: helmforge-tei-fixture-api-key

--- a/charts/text-embeddings-inference/ci/fixtures/metrics-values.yaml
+++ b/charts/text-embeddings-inference/ci/fixtures/metrics-values.yaml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Requires the Prometheus Operator in the HelmForge lab. Namespace-local test stack.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tei-monitor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tei-monitor
+rules:
+  - apiGroups: [""]
+    resources: [services, endpoints, pods]
+    verbs: [get, list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tei-monitor
+subjects:
+  - kind: ServiceAccount
+    name: tei-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tei-monitor
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: tei-monitor
+  labels:
+    helmforge.dev/runtime-fixture: "true"
+spec:
+  version: v3.14.0
+  image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+  replicas: 1
+  serviceAccountName: tei-monitor
+  serviceMonitorSelector:
+    matchLabels:
+      app.kubernetes.io/name: text-embeddings-inference
+  ruleSelector:
+    matchLabels:
+      app.kubernetes.io/name: text-embeddings-inference
+  scrapeInterval: 15s
+  scrapeTimeout: 10s
+  evaluationInterval: 15s
+  retention: 1h
+  podMetadata:
+    labels:
+      app: tei-monitor
+      helmforge.dev/runtime-fixture: "true"
+  resources:
+    requests: {cpu: 100m, memory: 128Mi}
+    limits: {cpu: "1", memory: 512Mi}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
+  storage:
+    emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tei-monitor
+spec:
+  selector:
+    prometheus: tei-monitor
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090

--- a/charts/text-embeddings-inference/ci/fixtures/offline-values.yaml
+++ b/charts/text-embeddings-inference/ci/fixtures/offline-values.yaml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tei-local-model
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tei-seed-model
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        helmforge.dev/runtime-fixture: 'true'
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: download
+          image: >-
+            ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.3@sha256:ad950d30878eceb72aaf32024d26fa2b1d04a75304fa0b4776b49aa1941fea07
+          command:
+            - /bin/sh
+            - '-ec'
+            - >
+              set -eu
+
+              modelBase=https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+
+              mkdir -p /model/onnx /model/1_Pooling
+
+              for artifact in config.json tokenizer.json tokenizer_config.json config_sentence_transformers.json
+              sentence_bert_config.json 1_Pooling/config.json onnx/model.onnx; do
+                curl --fail --silent --show-error --location --retry 3 --max-time 300 "$modelBase/$artifact" --output "/model/$artifact"
+              done
+
+              printf '828e1496d7fabb79cfa4dcd84fa38625c0d3d21da474a00f08db0f559940cf35  /model/onnx/model.onnx\n' |
+              sha256sum -c -
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: '1'
+              memory: 256Mi
+          volumeMounts:
+            - name: model
+              mountPath: /model
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: model
+          persistentVolumeClaim:
+            claimName: tei-local-model
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi

--- a/charts/text-embeddings-inference/ci/gateway-api-values.yaml
+++ b/charts/text-embeddings-inference/ci/gateway-api-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-gateway
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: shared-gateway
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - embeddings.example.com

--- a/charts/text-embeddings-inference/ci/ingress-values.yaml
+++ b/charts/text-embeddings-inference/ci/ingress-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-ingress
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: embeddings.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: embeddings-tls
+      hosts:
+        - embeddings.example.com

--- a/charts/text-embeddings-inference/ci/limits-values.yaml
+++ b/charts/text-embeddings-inference/ci/limits-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-limits
+model:
+  servedName: helmforge-bge-384
+  pooling: cls
+  defaultPrompt: 'Represent this sentence: '
+inference:
+  maxConcurrentRequests: 16
+  maxBatchTokens: 1024
+  maxBatchRequests: 8
+  maxClientBatchSize: 4
+  payloadLimit: 65536
+  autoTruncate: true
+  threads: 1
+  tokenizationWorkers: 1

--- a/charts/text-embeddings-inference/ci/metrics-values.yaml
+++ b/charts/text-embeddings-inference/ci/metrics-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-metrics
+metrics:
+  enabled: true
+  ingressFrom:
+    - podSelector:
+        matchLabels:
+          app: tei-monitor
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    scrapeTimeout: 10s
+  prometheusRule:
+    enabled: true

--- a/charts/text-embeddings-inference/ci/offline-values.yaml
+++ b/charts/text-embeddings-inference/ci/offline-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-offline
+model:
+  source: local
+  servedName: bge-small-en-v1.5-offline
+  local:
+    existingClaim: tei-local-model
+networkPolicy:
+  allowHubDownloads: false

--- a/charts/text-embeddings-inference/ci/production-values.yaml
+++ b/charts/text-embeddings-inference/ci/production-values.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: tei-production
+replicaCount: 2
+rollout:
+  strategy: RollingUpdate
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: text-embeddings-inference

--- a/charts/text-embeddings-inference/docs/models.md
+++ b/charts/text-embeddings-inference/docs/models.md
@@ -1,0 +1,47 @@
+# Model lifecycle
+
+## Immutable Hub models
+
+Select a model supported by the pinned TEI backend, review its license and pin a full commit revision.
+The default CPU backend needs the ONNX directory as well as tokenizer/configuration files. A repository that
+works in another serving engine is not automatically compatible. Inspect `/info` after installation and submit
+representative input to `/embed` before directing index-writing clients to the new endpoint.
+
+Hub downloads require DNS and HTTPS, including artifact delivery hosts. The default policy allows public HTTPS
+because CNI NetworkPolicy cannot express domain names. For gated models, create a separate minimal-scope Hub
+token Secret and reference it through `model.hubToken`. Never use the inference API key as a Hub credential.
+
+## Offline local model
+
+Prepare a PVC with the complete model directory using a controlled artifact pipeline. Record repository, commit,
+artifact hashes, license and image backend. For the default CPU model the directory includes `onnx/model.onnx`,
+`config.json`, `tokenizer.json`, tokenizer/sentence configuration and pooling metadata. Verify the complete
+bundle against the selected revision, rather than copying an arbitrary warm cache directory.
+
+Set `model.source: local`, `model.local.existingClaim` and optionally `model.local.subPath`. Files are mounted
+read-only at `/models`. The application cache and temporary directories remain writable for native startup.
+With network isolation enabled and no `extraEgress`, the deployed Pod cannot download missing files. Test startup
+and actual inference under that restriction. The CI fixture seeds the pinned public model before applying the
+application policy; the workload then serves requests and restarts with outbound traffic denied.
+
+## Cache ownership and capacity
+
+The Pod uses fsGroup 1000. The storage driver must support appropriate volume ownership and permissions.
+No root init container is required by the default chart. Reserve capacity for all artifacts and replacement
+downloads. A small model cache does not bound in-memory model or batch allocations.
+
+Persistent cache uses RWO storage, one replica and Recreate. Claim deletion depends on ownership: a chart-created
+PVC is a release resource and may be deleted on uninstall. Use an existing claim or an explicit retention policy
+when retaining downloaded artifacts is operationally necessary. Cache retention is not vector-index backup.
+
+## Vector-index migration
+
+1. Record the old model revision, prompts, pooling, dimensions and normalization used by indexing and queries.
+2. Deploy the new contract under a separate release and endpoint.
+3. Validate dimensions, stable outputs, retrieval quality and realistic resource use.
+4. Re-embed source documents into a separate vector index with provenance metadata.
+5. Switch indexing and query clients together; retain the old release/index for rollback.
+
+Helm rollback can restore a Deployment but cannot translate vectors already written with a different model.
+Rollback must restore the corresponding index and client settings. Do not mix incompatible models behind a
+rolling Service and rely on HTTP health to detect semantic corruption.

--- a/charts/text-embeddings-inference/docs/operations.md
+++ b/charts/text-embeddings-inference/docs/operations.md
@@ -18,7 +18,7 @@ Install Prometheus Operator CRDs before enabling ServiceMonitor or PrometheusRul
 ServiceMonitor labels and namespace. A ServiceMonitor object alone does not prove a successful scrape.
 
 Inspect `up` for the metrics endpoint and native `te_request_count`, `te_request_success` and inference-duration
-histograms after real requests. The default alert detects a down target; define latency/error SLOs from measured
+histograms after real requests. The default alert detects a down or absent target; define latency/error SLOs from measured
 traffic and the exact release's metric labels. Restrict access to monitoring metadata.
 
 ## Troubleshooting

--- a/charts/text-embeddings-inference/docs/operations.md
+++ b/charts/text-embeddings-inference/docs/operations.md
@@ -1,0 +1,52 @@
+# Production operations
+
+## Acceptance and capacity
+
+Verify `/info`, real `/embed` output and `/v1/embeddings` compatibility before routing production traffic.
+Use application-specific retrieval quality checks in addition to finite vector shape. Load-test realistic token
+lengths and batch distributions; CPU, RAM and VRAM costs depend on the selected model and backend.
+The default resources support the small validation model and do not constitute a capacity recommendation for all models.
+
+Multiple replicas independently load model weights. CPU HPA requires metrics-server and measures container `tei`.
+Increasing replicas can increase Hub traffic during a cold rollout. Persistent RWO cache disables this topology.
+For local models, the existing volume must be readable by every scheduled replica.
+
+## Monitoring
+
+Enable the private metrics listener and select real Prometheus Pods with explicit namespace/Pod peers.
+Install Prometheus Operator CRDs before enabling ServiceMonitor or PrometheusRule. Prometheus must select the
+ServiceMonitor labels and namespace. A ServiceMonitor object alone does not prove a successful scrape.
+
+Inspect `up` for the metrics endpoint and native `te_request_count`, `te_request_success` and inference-duration
+histograms after real requests. The default alert detects a down target; define latency/error SLOs from measured
+traffic and the exact release's metric labels. Restrict access to monitoring metadata.
+
+## Troubleshooting
+
+| Symptom | Check and correction |
+| --- | --- |
+| Pod remains Pending | Inspect node architecture, CPU/RAM requests, PVC binding and device-plugin resources. |
+| Model download fails | Check pinned revision, artifact availability, Hub token permissions and DNS/public HTTPS policy. |
+| Gated model returns 401/403 during download | Accept model terms and supply a separate authorized Hub token Secret. |
+| Native container cannot write cache | Check fsGroup 1000 support and existing-claim ownership; inspect storage driver behavior. |
+| Offline startup tries to resolve missing artifacts | Verify the complete backend-specific model directory and local source selection. |
+| API returns 401 | Check the referenced Secret key and client bearer credential; restart Pods after rotation. |
+| API returns 413 | Reduce request bytes or deliberately increase both the chart payload budget and capacity. |
+| API returns 422 | Inspect input token length and client batch count; truncation may discard meaningful input. |
+| Reranking returns 424 | The default embedding model is not a reranker; select and validate an appropriate model separately. |
+| OOMKilled or GPU allocation failure | Reduce concurrent/batch/token budgets or reserve sufficient model and activation memory. |
+| Startup health returns 502 | NGINX may start before model loading finishes; inspect native logs and startup-probe budget. |
+| Prometheus target absent | Check ServiceMonitor namespace/label selection and installed Operator CRDs. |
+| Metrics target is down | Check explicit monitoring peers, Service endpoints and the private metrics port. |
+| CPU HPA has unknown metrics | Check metrics-server health, CPU requests and container `tei` resource metrics. |
+| Model outputs changed after upgrade | Compare revision, dtype, pooling, prompts and normalization against index provenance. |
+| Rolling update stalls | Check surge capacity and volume access; do not use RollingUpdate with the RWO cache. |
+
+## Recovery and rollback
+
+Retain declared values, immutable model provenance and credential references. Download cache can be reconstructed;
+local model volumes need a separate artifact copy or snapshot strategy. This chart contains no user-document or
+vector-index backup job. Restore your external vector index together with its corresponding model contract.
+
+After restoring or rolling back, verify credentials and actual vector output again. Keep client retry budgets
+bounded: in-memory requests are not durable, and repeated load during recovery can delay model readiness.

--- a/charts/text-embeddings-inference/docs/security.md
+++ b/charts/text-embeddings-inference/docs/security.md
@@ -1,0 +1,44 @@
+# Credentials and network isolation
+
+## API credential ownership
+
+Default installation generates a 48-character random API key. Live Helm upgrades reuse the existing Secret value.
+Render-only GitOps controllers should use an existing Secret to avoid unstable random rendering. The chart never
+accepts inline API or Hub credentials in values. Secret encryption at rest and access controls are cluster concerns.
+
+For rotation, update the source Secret and restart the Deployment. API clients and server must coordinate because
+the native API accepts one key at a time. Keep secrets out of shell history, debug traces and issue attachments.
+Changing the Secret key name or deleting a generated Secret can change credentials on the next reconciliation.
+
+## External Secrets Operator
+
+Install ESO and an authorized SecretStore first. Each `externalSecrets.items[]` object supports name/metadata
+overrides and the upstream `spec` contract, including data/dataFrom and source references. The chart supplies
+default refresh interval and target name only when omitted. Reference that target through `auth.existingSecret`.
+A separate item can provide the Hub token; the two credentials have unrelated trust and rotation lifecycles.
+
+After installation, inspect ExternalSecret readiness and verify that the target Secret contains the configured
+key. Do not print its value. ESO updates do not modify existing process environment; trigger a Pod rollout after
+rotation. The CI fake-store profile verifies a real reconciled Secret and authenticated inference.
+
+## Native logging
+
+The pinned TEI release logs parsed arguments, including API_KEY, at INFO. The chart enforces LOG_LEVEL=warn,
+preserves warning/error output and disallows chart-owned environment overrides. This is a version-specific
+mitigation and should be revisited against upstream code during upgrades. Do not enable verbose native logging
+with live credentials while investigating startup failures.
+
+## Listeners and peers
+
+Native TEI binds to loopback port 8081. NGINX exposes the API on 8080 and blocks `/metrics`, `/docs` and `/api-doc`.
+The optional 9464 listener permits only `/metrics` and has a separate Service. No bearer key is required for those
+native metrics; `metrics.ingressFrom` must explicitly identify trusted monitoring peers.
+
+NetworkPolicy enforcement requires a CNI that implements it. Disabling the policy removes the monitoring network
+boundary even though the public proxy still blocks metric paths. Namespace selectors and Pod selectors in the
+same peer are conjunctive; separate peer entries are alternatives. Use both to select a specific Prometheus
+workload in a specific namespace. Ingress-controller permissions are independent of monitoring permissions.
+
+TLS terminates at an existing ingress or Gateway. The chart's internal Service is HTTP; use suitable cluster
+transport controls when internal encryption is required. Health paths remain public for readiness. API-key
+authentication supplies shared access control, not tenancy, per-user audit identity or client rate quotas.

--- a/charts/text-embeddings-inference/docs/security.md
+++ b/charts/text-embeddings-inference/docs/security.md
@@ -16,6 +16,8 @@ Install ESO and an authorized SecretStore first. Each `externalSecrets.items[]` 
 overrides and the upstream `spec` contract, including data/dataFrom and source references. The chart supplies
 default refresh interval and target name only when omitted. Reference that target through `auth.existingSecret`.
 A separate item can provide the Hub token; the two credentials have unrelated trust and rotation lifecycles.
+Rendered ExternalSecret names must be unique, including after Kubernetes name truncation. Give multiple items
+distinct names or fullname overrides; duplicate implicit auth names are rejected before installation.
 
 After installation, inspect ExternalSecret readiness and verify that the target Secret contains the configured
 key. Do not print its value. ESO updates do not modify existing process environment; trigger a Pod rollout after

--- a/charts/text-embeddings-inference/examples/cuda.yaml
+++ b/charts/text-embeddings-inference/examples/cuda.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Requires a compatible NVIDIA GPU, driver and device plugin. Hardware execution is not covered by CPU CI.
+image:
+  tag: cuda-1.9.3@sha256:249a0bc87522bfe2f1012b4d194f0225878f47079115ada3aeb0b1ef257b402a
+gpu:
+  enabled: true
+  count: 1
+model:
+  dtype: float16
+resources:
+  requests: {cpu: '2', memory: 2Gi}
+  limits: {cpu: '4', memory: 4Gi}
+nodeSelector:
+  kubernetes.io/arch: amd64
+  nvidia.com/gpu.present: 'true'
+rollout:
+  strategy: Recreate

--- a/charts/text-embeddings-inference/examples/external-secrets.yaml
+++ b/charts/text-embeddings-inference/examples/external-secrets.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Requires ESO and an authorized ClusterSecretStore named production-secrets.
+auth:
+  existingSecret: embeddings-api
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: embeddings-api
+      spec:
+        secretStoreRef:
+          name: production-secrets
+          kind: ClusterSecretStore
+        data:
+          - secretKey: api-key
+            remoteRef:
+              key: applications/embeddings/api
+              property: api-key

--- a/charts/text-embeddings-inference/examples/metrics.yaml
+++ b/charts/text-embeddings-inference/examples/metrics.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Requires Prometheus Operator; match selectors to your actual monitoring Pods.
+metrics:
+  enabled: true
+  ingressFrom:
+    - podSelector:
+        matchLabels:
+          app: tei-monitor
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    scrapeTimeout: 10s
+  prometheusRule:
+    enabled: true

--- a/charts/text-embeddings-inference/examples/offline.yaml
+++ b/charts/text-embeddings-inference/examples/offline.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Requires a pre-populated tei-local-model PVC with complete verified model artifacts.
+model:
+  source: local
+  servedName: bge-small-en-v1.5-offline
+  local:
+    existingClaim: tei-local-model
+networkPolicy:
+  allowHubDownloads: false

--- a/charts/text-embeddings-inference/examples/production.yaml
+++ b/charts/text-embeddings-inference/examples/production.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Compatible model replicas; requires metrics-server and enough capacity for each model copy.
+replicaCount: 2
+rollout:
+  strategy: RollingUpdate
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: text-embeddings-inference

--- a/charts/text-embeddings-inference/examples/simple.yaml
+++ b/charts/text-embeddings-inference/examples/simple.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Authenticated CPU API using the pinned public model and independent ephemeral cache.
+replicaCount: 1

--- a/charts/text-embeddings-inference/examples/staging.yaml
+++ b/charts/text-embeddings-inference/examples/staging.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Two independent replicas for staging compatibility checks; model changes use a separate release.
+replicaCount: 2
+rollout:
+  strategy: RollingUpdate
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1

--- a/charts/text-embeddings-inference/scripts/runtime-smoke.mjs
+++ b/charts/text-embeddings-inference/scripts/runtime-smoke.mjs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync,spawn} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+const [context,namespace,release]=process.argv.slice(2);
+assert.match(context??'',/^k3d-/);assert.ok(namespace&&release);
+const kubectl=(args,options={})=>execFileSync('kubectl',['--context',context,'-n',namespace,...args],{encoding:'utf8',timeout:90000,...options});
+const values=JSON.parse(execFileSync('helm',['get','values',release,'-n',namespace,'--kube-context',context,'-a','-o','json'],{encoding:'utf8'}));
+const selector=`app.kubernetes.io/instance=${release},app.kubernetes.io/name=text-embeddings-inference`;
+const deploy=JSON.parse(kubectl(['get','deploy','-l',selector,'-o','json'])).items[0];assert.ok(deploy);
+const pods=()=>JSON.parse(kubectl(['get','pods','-l',selector,'-o','json'])).items.filter(p=>!p.metadata.deletionTimestamp);
+const apiEnv=deploy.spec.template.spec.containers.find(c=>c.name==='tei').env.find(e=>e.name==='API_KEY');
+const secretName=apiEnv?.valueFrom.secretKeyRef.name;
+const readKey=()=>secretName?Buffer.from(JSON.parse(kubectl(['get','secret',secretName,'-o','json'])).data[values.auth.secretKey],'base64').toString():'';
+const apiKey=readKey();if(values.auth.enabled)assert.ok(apiKey.length>=8);
+if(values.externalSecrets.enabled){
+ const items=JSON.parse(kubectl(['get','externalsecrets','-o','json'])).items;
+ assert.ok(items.length>0);
+ for(const item of items){
+  kubectl(['wait','externalsecret/'+item.metadata.name,'--for=condition=Ready=True','--timeout=60s']);
+  const synced=JSON.parse(kubectl(['get','externalsecret',item.metadata.name,'-o','json']));
+  assert.ok(synced.status.conditions.some(c=>c.type==='Ready'&&c.status==='True'&&c.reason==='SecretSynced'));
+ }
+ console.log('PASS External Secrets Ready and SecretSynced before authenticated inference');
+}
+const auth=key=>key?{Authorization:'Bearer '+key}:{};
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+async function forward(resource,port,action){
+ const child=spawn('kubectl',['--context',context,'-n',namespace,'port-forward',resource,':'+port,'--address=127.0.0.1'],{windowsHide:true,stdio:['ignore','pipe','pipe']});let output='';for(const s of [child.stdout,child.stderr])s.on('data',b=>output+=b);
+ try{const deadline=Date.now()+20000;while(!/127\.0\.0\.1:(\d+) ->/.test(output)&&Date.now()<deadline&&child.exitCode===null)await sleep(100);const local=output.match(/127\.0\.0\.1:(\d+) ->/)?.[1];assert.ok(local,'Port-forward unavailable');return await action('http://127.0.0.1:'+local);}
+ finally{if(child.exitCode===null&&child.signalCode===null){if(process.platform==='win32'){try{execFileSync('taskkill',['/PID',String(child.pid),'/T','/F'],{stdio:'ignore'});}catch(error){try{process.kill(child.pid,0);throw error;}catch(probe){if(probe.code!=='ESRCH')throw probe;}}}else child.kill();}}
+}
+const request=(base,path,options={})=>fetch(base+path,{signal:AbortSignal.timeout(45000),...options});
+const post=(base,path,data,key=apiKey)=>request(base,path,{method:'POST',headers:{'Content-Type':'application/json',...auth(key)},body:JSON.stringify(data)});
+const input=['A cat sits on the mat.','A cat sits on the mat.','The stock market closed lower today.'];
+const dot=(a,b)=>a.reduce((s,n,i)=>s+n*b[i],0);
+let reference;
+async function check(base,negative=false){
+ assert.equal((await request(base,'/health')).status,200);
+ for(const path of ['/metrics','//metrics','/%6Detrics','/docs','/api-doc/openapi.json'])assert.equal((await request(base,path)).status,404,'Private/documentation path exposed: '+path);
+ if(values.auth.enabled){for(const key of ['',apiKey+'-wrong'])assert.equal((await post(base,'/embed',{inputs:input[0]},key)).status,401);}
+ const info=await request(base,'/info',{headers:auth(apiKey)});assert.equal(info.status,200);const metadata=await info.json();
+ assert.equal(metadata.version,'1.9.3');assert.equal(metadata.model_id,values.model.source==='hub'?values.model.id:'/models');
+ if(values.model.source==='hub')assert.equal(metadata.model_sha,values.model.revision);
+ assert.equal(metadata.max_concurrent_requests,values.inference.maxConcurrentRequests);assert.equal(metadata.max_client_batch_size,values.inference.maxClientBatchSize);
+ assert.equal(metadata.max_batch_tokens,values.inference.maxBatchTokens);assert.equal(metadata.max_batch_requests,values.inference.maxBatchRequests);
+ assert.equal(metadata.auto_truncate,values.inference.autoTruncate);assert.equal(metadata.tokenization_workers,values.inference.tokenizationWorkers);assert.equal(metadata.model_dtype,values.model.dtype);
+ const response=await post(base,'/embed',{inputs:input,normalize:true});assert.equal(response.status,200);const vectors=await response.json();
+ assert.equal(vectors.length,3);for(const v of vectors){assert.equal(v.length,384);assert.ok(v.every(Number.isFinite));assert.ok(Math.abs(Math.sqrt(dot(v,v))-1)<0.001);}
+ assert.ok(dot(vectors[0],vectors[1])>0.9999);assert.ok(dot(vectors[0],vectors[2])<0.9,'Semantically unrelated text must differ');
+ if(reference)assert.ok(dot(reference,vectors[0])>0.9999,'Model output changed across replicas/replacement');else reference=vectors[0];
+ const compatible=await post(base,'/v1/embeddings',{input:[input[0]],model:values.model.servedName||metadata.model_id});assert.equal(compatible.status,200);const result=await compatible.json();
+ assert.equal(result.object,'list');assert.equal(result.data[0].index,0);assert.equal(result.model,values.model.servedName||metadata.model_id);assert.ok(result.usage.total_tokens>0);assert.ok(dot(result.data[0].embedding,vectors[0])>0.9999);
+ if(negative){
+  assert.equal((await post(base,'/embed',{inputs:[]})).status,400);
+  assert.equal((await post(base,'/embed',{inputs:Array(values.inference.maxClientBatchSize+1).fill('test')})).status,422);
+  assert.equal((await post(base,'/embed',{inputs:'x'.repeat(values.inference.payloadLimit+100)})).status,413);
+  const long='hello '.repeat(metadata.max_input_length+20);assert.equal((await post(base,'/embed',{inputs:long,truncate:false})).status,422);assert.equal((await post(base,'/embed',{inputs:long,truncate:true})).status,200);
+  assert.equal((await post(base,'/rerank',{query:'cat',texts:['cat','market']})).status,424);
+ }
+}
+for(const p of pods()){
+ assert.equal(p.spec.automountServiceAccountToken,false);
+ assert.ok(!p.spec.volumes.some(v=>v.projected?.sources?.some(s=>s.serviceAccountToken)));
+ assert.equal(p.spec.securityContext.runAsUser,1000);
+ for(const c of p.spec.containers){assert.equal(c.securityContext.readOnlyRootFilesystem,true);assert.equal(c.securityContext.allowPrivilegeEscalation,false);}
+ await forward('pod/'+p.metadata.name,values.proxy.port,base=>check(base,true));
+ const logs=kubectl(['logs',p.metadata.name,'-c','tei']);if(apiKey)assert.ok(!logs.includes(apiKey),'Native logs exposed API credentials');
+}
+console.log('PASS native model identity, finite normalized semantic embeddings, OpenAI equivalence, authentication and admission limits');
+const peer='tei-isolation-peer';
+const peerPod={apiVersion:'v1',kind:'Pod',metadata:{name:peer,labels:{'helmforge.dev/runtime-fixture':'true'}},spec:{terminationGracePeriodSeconds:1,automountServiceAccountToken:false,restartPolicy:'Never',securityContext:{runAsNonRoot:true,runAsUser:1000,runAsGroup:1000,seccompProfile:{type:'RuntimeDefault'}},containers:[{name:'curl',image:values.image.repository+':'+values.image.tag,command:['/bin/sh','-c','sleep 600'],args:[],securityContext:{allowPrivilegeEscalation:false,readOnlyRootFilesystem:true,capabilities:{drop:['ALL']}},resources:{requests:{cpu:'10m',memory:'32Mi'},limits:{cpu:'100m',memory:'128Mi'}}}]}};
+console.log('Checking isolated peer');kubectl(['apply','-f','-'],{input:JSON.stringify(peerPod)});kubectl(['wait','--for=condition=Ready','pod/'+peer,'--timeout=60s']);
+console.log('Isolated peer ready');
+const peerCurl=(url)=>kubectl(['exec',peer,'--','curl','--silent','--show-error','--max-time','4','--output','/dev/null','--write-out','%{http_code}',url],{timeout:10000,stdio:['ignore','pipe','pipe']});
+function denied(action){try{const result=action();assert.equal(result.trim(),'000','Unexpected network connectivity');}catch(error){assert.ok(error.status===7||error.status===28||error.status===6,'Unexpected denial: '+String(error.message).slice(0,120));}}
+try{
+ console.log('Checking public health and native loopback boundary');
+ const pod=pods()[0],ip=pod.status.podIP.includes(':')?'['+pod.status.podIP+']':pod.status.podIP;
+ assert.equal(peerCurl(`http://${ip}:${values.proxy.port}/health`),'200');
+ denied(()=>peerCurl(`http://${ip}:8081/health`));
+ if(values.metrics.enabled){
+  denied(()=>peerCurl(`http://${ip}:${values.metrics.port}/metrics`));
+  await forward('pod/'+pod.metadata.name,values.metrics.port,async base=>{
+   const m=await request(base,'/metrics');assert.equal(m.status,200);const text=await m.text();assert.match(text,/te_request_count/);assert.match(text,/te_request_success/);assert.match(text,/te_request_inference_duration/);assert.equal((await post(base,'/embed',{inputs:'test'})).status,404);
+  });
+  if(values.metrics.serviceMonitor.enabled){
+   kubectl(['rollout','status','statefulset/prometheus-tei-monitor','--timeout=90s']);
+   await forward('service/tei-monitor',9090,async base=>{
+    const query='te_request_success{namespace="'+namespace+'"}';const deadline=Date.now()+45000;let series=[];
+    do{const r=await(await request(base,'/api/v1/query?query='+encodeURIComponent(query))).json();series=r.data?.result??[];if(series.some(s=>Number(s.value[1])>0))break;await sleep(2000);}while(Date.now()<deadline);
+    assert.ok(series.some(s=>Number(s.value[1])>0),'Real Prometheus did not observe successful inference');
+    const up=await(await request(base,'/api/v1/query?query='+encodeURIComponent('up{namespace="'+namespace+'",endpoint="metrics"}'))).json();assert.ok(up.data.result.some(s=>s.value[1]==='1'));
+    if(values.metrics.prometheusRule.enabled){const rules=await(await request(base,'/api/v1/rules')).json();assert.ok(rules.data.groups.some(g=>g.rules.some(r=>r.name==='TextEmbeddingsInferenceUnavailable')));}
+   });
+  }
+  console.log('PASS private native Prometheus metrics, denied unrelated peer and real successful-inference scrape');
+ }
+ if(values.model.source==='local'){
+  const policy=JSON.parse(kubectl(['get','networkpolicy',deploy.metadata.name,'-o','json'])).spec;
+  assert.ok(policy.policyTypes.includes('Egress'));
+  assert.deepEqual(policy.egress??[],[]);
+  const api=JSON.parse(execFileSync('kubectl',['--context',context,'-n','default','get','service','kubernetes','-o','json'],{encoding:'utf8'})).spec.clusterIP;
+  const apiUrl='https://'+(api.includes(':')?'['+api+']':api)+':443';
+  const good=kubectl(['exec',peer,'--','curl','-k','--silent','--max-time','5','--output','/dev/null','--write-out','%{http_code}',apiUrl]);assert.match(good,/^(401|403)$/);
+  denied(()=>kubectl(['exec',pod.metadata.name,'-c','tei','--','curl','-k','--silent','--max-time','4','--output','/dev/null','--write-out','%{http_code}',apiUrl],{timeout:10000,stdio:['ignore','pipe','pipe']}));
+  console.log('PASS local read-only model inference with all egress denied and positive network control');
+ }
+}finally{kubectl(['delete','pod',peer,'--wait=true','--timeout=30s']);}
+if(values.autoscaling.enabled){
+ const deadline=Date.now()+90000;let hpa;
+ do{hpa=JSON.parse(kubectl(['get','hpa',deploy.metadata.name,'-o','json']));if(hpa.status?.currentMetrics?.some(m=>m.containerResource?.current?.averageUtilization!==undefined))break;await sleep(2000);}while(Date.now()<deadline);
+ assert.ok(hpa.status.currentMetrics.some(m=>m.containerResource?.current?.averageUtilization!==undefined),'CPU HPA must observe real container metrics');assert.ok(hpa.status.currentReplicas>=values.autoscaling.minReplicas);
+ console.log('PASS multiple independent model replicas and real CPU HPA metrics');
+}
+if(values.cache.persistence.enabled)kubectl(['exec',pods()[0].metadata.name,'-c','tei','--','sh','-c','printf retained > /data/helmforge-cache-marker']);
+if(values.auth.enabled&&!values.auth.existingSecret){
+ execFileSync('helm',['upgrade',release,fileURLToPath(new URL('../',import.meta.url)),'-n',namespace,'--kube-context',context,'--reuse-values','--wait','--timeout','120s'],{encoding:'utf8',timeout:130000});
+ assert.equal(readKey(),apiKey,'Generated credential changed during Helm upgrade');
+ console.log('PASS generated API credential retained by real Helm upgrade');
+}
+kubectl(['rollout','restart','deployment/'+deploy.metadata.name]);kubectl(['rollout','status','deployment/'+deploy.metadata.name,'--timeout=120s'],{timeout:130000});
+assert.equal(readKey(),apiKey,'API credential changed after Pod replacement');
+for(const p of pods())await forward('pod/'+p.metadata.name,values.proxy.port,base=>check(base));
+if(values.cache.persistence.enabled)assert.equal(kubectl(['exec',pods()[0].metadata.name,'-c','tei','--','cat','/data/helmforge-cache-marker']),'retained');
+console.log('PASS native inference, model identity and original API credential after Pod replacement'+(values.cache.persistence.enabled?', retained cache volume':''));

--- a/charts/text-embeddings-inference/scripts/runtime-smoke.mjs
+++ b/charts/text-embeddings-inference/scripts/runtime-smoke.mjs
@@ -27,8 +27,10 @@ const auth=key=>key?{Authorization:'Bearer '+key}:{};
 const sleep=ms=>new Promise(r=>setTimeout(r,ms));
 async function forward(resource,port,action){
  const child=spawn('kubectl',['--context',context,'-n',namespace,'port-forward',resource,':'+port,'--address=127.0.0.1'],{windowsHide:true,stdio:['ignore','pipe','pipe']});let output='';for(const s of [child.stdout,child.stderr])s.on('data',b=>output+=b);
+ let actionFailed=false;
  try{const deadline=Date.now()+20000;while(!/127\.0\.0\.1:(\d+) ->/.test(output)&&Date.now()<deadline&&child.exitCode===null)await sleep(100);const local=output.match(/127\.0\.0\.1:(\d+) ->/)?.[1];assert.ok(local,'Port-forward unavailable');return await action('http://127.0.0.1:'+local);}
- finally{if(child.exitCode===null&&child.signalCode===null){if(process.platform==='win32'){try{execFileSync('taskkill',['/PID',String(child.pid),'/T','/F'],{stdio:'ignore'});}catch(error){try{process.kill(child.pid,0);throw error;}catch(probe){if(probe.code!=='ESRCH')throw probe;}}}else child.kill();}}
+ catch(error){actionFailed=true;throw error;}
+ finally{try{if(child.exitCode===null&&child.signalCode===null){if(process.platform==='win32'){try{execFileSync('taskkill',['/PID',String(child.pid),'/T','/F'],{stdio:'ignore'});}catch(error){try{process.kill(child.pid,0);throw error;}catch(probe){if(probe.code!=='ESRCH')throw probe;}}}else child.kill();}}catch(error){if(actionFailed)console.error('Port-forward cleanup also failed:',String(error.message).slice(0,200));else throw error;}}
 }
 const request=(base,path,options={})=>fetch(base+path,{signal:AbortSignal.timeout(45000),...options});
 const post=(base,path,data,key=apiKey)=>request(base,path,{method:'POST',headers:{'Content-Type':'application/json',...auth(key)},body:JSON.stringify(data)});
@@ -78,6 +80,14 @@ try{
  console.log('Checking public health and native loopback boundary');
  const pod=pods()[0],ip=pod.status.podIP.includes(':')?'['+pod.status.podIP+']':pod.status.podIP;
  assert.equal(peerCurl(`http://${ip}:${values.proxy.port}/health`),'200');
+ if(values.service.ipFamilyPolicy==='RequireDualStack'||values.service.ipFamilies.includes('IPv6')){
+  const ipv6=pod.status.podIPs.find(p=>p.ip.includes(':'))?.ip;assert.ok(ipv6,'IPv6 Pod address is required');
+  assert.equal(peerCurl(`http://[${ipv6}]:${values.proxy.port}/health`),'200');
+  const service=JSON.parse(kubectl(['get','service',deploy.metadata.name,'-o','json']));
+  const serviceV6=service.spec.clusterIPs.find(ip=>ip.includes(':'));assert.ok(serviceV6,'IPv6 Service address is required');
+  assert.equal(peerCurl(`http://[${serviceV6}]:${values.service.port}/health`),'200');
+  console.log('PASS native health through IPv6 Pod and Service listeners');
+ }
  denied(()=>peerCurl(`http://${ip}:8081/health`));
  if(values.metrics.enabled){
   denied(()=>peerCurl(`http://${ip}:${values.metrics.port}/metrics`));
@@ -91,7 +101,11 @@ try{
     do{const r=await(await request(base,'/api/v1/query?query='+encodeURIComponent(query))).json();series=r.data?.result??[];if(series.some(s=>Number(s.value[1])>0))break;await sleep(2000);}while(Date.now()<deadline);
     assert.ok(series.some(s=>Number(s.value[1])>0),'Real Prometheus did not observe successful inference');
     const up=await(await request(base,'/api/v1/query?query='+encodeURIComponent('up{namespace="'+namespace+'",endpoint="metrics"}'))).json();assert.ok(up.data.result.some(s=>s.value[1]==='1'));
-    if(values.metrics.prometheusRule.enabled){const rules=await(await request(base,'/api/v1/rules')).json();assert.ok(rules.data.groups.some(g=>g.rules.some(r=>r.name==='TextEmbeddingsInferenceUnavailable')));}
+    if(values.metrics.prometheusRule.enabled){
+     const rules=await(await request(base,'/api/v1/rules')).json();const rule=rules.data.groups.flatMap(g=>g.rules).find(r=>r.name==='TextEmbeddingsInferenceUnavailable');assert.ok(rule);assert.match(rule.query,/absent\(/);
+     const absentQuery=rule.query.replace(/service="[^"]+"/g,'service="tei-missing-target"');
+     const absent=await(await request(base,'/api/v1/query?query='+encodeURIComponent(absentQuery))).json();assert.ok(absent.data.result.some(s=>s.value[1]==='1'),'The actual alert expression must detect an absent target');
+    }
    });
   }
   console.log('PASS private native Prometheus metrics, denied unrelated peer and real successful-inference scrape');
@@ -116,11 +130,11 @@ if(values.autoscaling.enabled){
 if(values.cache.persistence.enabled)kubectl(['exec',pods()[0].metadata.name,'-c','tei','--','sh','-c','printf retained > /data/helmforge-cache-marker']);
 if(values.auth.enabled&&!values.auth.existingSecret){
  execFileSync('helm',['upgrade',release,fileURLToPath(new URL('../',import.meta.url)),'-n',namespace,'--kube-context',context,'--reuse-values','--wait','--timeout','120s'],{encoding:'utf8',timeout:130000});
- assert.equal(readKey(),apiKey,'Generated credential changed during Helm upgrade');
+ assert.ok(readKey()===apiKey,'Generated credential changed during Helm upgrade');
  console.log('PASS generated API credential retained by real Helm upgrade');
 }
 kubectl(['rollout','restart','deployment/'+deploy.metadata.name]);kubectl(['rollout','status','deployment/'+deploy.metadata.name,'--timeout=120s'],{timeout:130000});
-assert.equal(readKey(),apiKey,'API credential changed after Pod replacement');
+assert.ok(readKey()===apiKey,'API credential changed after Pod replacement');
 for(const p of pods())await forward('pod/'+p.metadata.name,values.proxy.port,base=>check(base));
 if(values.cache.persistence.enabled)assert.equal(kubectl(['exec',pods()[0].metadata.name,'-c','tei','--','cat','/data/helmforge-cache-marker']),'retained');
 console.log('PASS native inference, model identity and original API credential after Pod replacement'+(values.cache.persistence.enabled?', retained cache volume':''));

--- a/charts/text-embeddings-inference/templates/NOTES.txt
+++ b/charts/text-embeddings-inference/templates/NOTES.txt
@@ -13,6 +13,7 @@ Each replica loads its own model; reserve enough RAM or VRAM.
 =========
 kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "text-embeddings-inference.fullname" . }} 8080:{{ .Values.service.port }}
 HTTP API: http://localhost:8080/embed and /v1/embeddings
+IPv6 listeners: {{ .Values.proxy.ipv6 }} (required for IPv6/dual-stack Services)
 {{ if .Values.auth.enabled }}Bearer authentication uses Secret {{ include "text-embeddings-inference.authSecret" . }}, key {{ .Values.auth.secretKey }}.
 Retrieve credentials through your approved secret-management workflow.
 {{ else }}Authentication is disabled. Restrict access to trusted clients.
@@ -44,6 +45,8 @@ In-memory requests are not durable. Clients need bounded retries and timeouts.
 =============
 Private native metrics: {{ .Values.metrics.enabled }}
 ServiceMonitor: {{ .Values.metrics.serviceMonitor.enabled }}
+PrometheusRule: {{ .Values.metrics.prometheusRule.enabled }}
+When enabled, the default rule covers missing/down scrape targets after 5 minutes.
 Explicit monitoring peers are required. The public API blocks metrics and docs.
 NetworkPolicy enforcement requires a compatible CNI.
 

--- a/charts/text-embeddings-inference/templates/NOTES.txt
+++ b/charts/text-embeddings-inference/templates/NOTES.txt
@@ -1,0 +1,63 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+Text Embeddings Inference deployment
+
+1. Installation summary
+=======================
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Image: {{ include "text-embeddings-inference.image" . }}
+Model source: {{ .Values.model.source }}
+Each replica loads its own model; reserve enough RAM or VRAM.
+
+2. Access
+=========
+kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "text-embeddings-inference.fullname" . }} 8080:{{ .Values.service.port }}
+HTTP API: http://localhost:8080/embed and /v1/embeddings
+{{ if .Values.auth.enabled }}Bearer authentication uses Secret {{ include "text-embeddings-inference.authSecret" . }}, key {{ .Values.auth.secretKey }}.
+Retrieve credentials through your approved secret-management workflow.
+{{ else }}Authentication is disabled. Restrict access to trusted clients.
+{{ end }}Terminate TLS at your ingress or Gateway for production clients.
+
+3. Configuration
+================
+Pin both the image and immutable model revision. Pooling, prompts, normalization
+and model revision affect vector compatibility. Payload and batch limits apply.
+LOG_LEVEL=warn prevents the pinned native version from logging API credentials.
+
+4. Persistence and backup
+=========================
+Persistent download cache: {{ .Values.cache.persistence.enabled }}
+Cache artifacts are reproducible; no application database is deployed.
+Local mode requires a complete model in an existing read-only mounted PVC.
+Preserve model provenance, deployment values and credentials separately.
+
+5. Scaling and availability
+===========================
+Replicas: {{ .Values.replicaCount }}
+CPU autoscaling: {{ .Values.autoscaling.enabled }}
+Strategy: {{ .Values.rollout.strategy }}
+RWO cache requires one replica and Recreate. Independent caches support replicas.
+RollingUpdate is for compatible models; index migrations need separate releases.
+In-memory requests are not durable. Clients need bounded retries and timeouts.
+
+6. Monitoring
+=============
+Private native metrics: {{ .Values.metrics.enabled }}
+ServiceMonitor: {{ .Values.metrics.serviceMonitor.enabled }}
+Explicit monitoring peers are required. The public API blocks metrics and docs.
+NetworkPolicy enforcement requires a compatible CNI.
+
+7. Security and troubleshooting
+==============================
+kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "text-embeddings-inference.fullname" . }} -c tei
+kubectl -n {{ .Release.Namespace }} describe pods -l app.kubernetes.io/instance={{ .Release.Name }}
+Check model permissions, download egress, memory and scheduler/GPU events.
+Native inference listens only on loopback; NGINX exposes the controlled API.
+
+8. Upgrade and documentation
+============================
+helm upgrade {{ .Release.Name }} helmforge/text-embeddings-inference -n {{ .Release.Namespace }} -f values.yaml
+kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "text-embeddings-inference.fullname" . }}
+Back up your vector index before changing model contracts; re-embed deliberately.
+Documentation: https://helmforge.dev/docs/charts/text-embeddings-inference
+Happy Helmforging :)

--- a/charts/text-embeddings-inference/templates/_helpers.tpl
+++ b/charts/text-embeddings-inference/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "text-embeddings-inference.name" -}}{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}{{- end -}}
+{{- define "text-embeddings-inference.fullname" -}}{{- if .Values.fullnameOverride -}}{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}{{- else -}}{{- printf "%s-%s" .Release.Name (include "text-embeddings-inference.name" .) | trunc 63 | trimSuffix "-" -}}{{- end -}}{{- end -}}
+{{- define "text-embeddings-inference.chart" -}}{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}{{- end -}}
+{{- define "text-embeddings-inference.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "text-embeddings-inference.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+{{- define "text-embeddings-inference.labels" -}}
+helm.sh/chart: {{ include "text-embeddings-inference.chart" . }}
+{{ include "text-embeddings-inference.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{ with .Values.commonLabels }}{{ toYaml . }}{{- end }}
+{{- end -}}
+{{- define "text-embeddings-inference.serviceAccountName" -}}{{- if .Values.serviceAccount.create -}}{{- default (include "text-embeddings-inference.fullname" .) .Values.serviceAccount.name -}}{{- else -}}{{- default "default" .Values.serviceAccount.name -}}{{- end -}}{{- end -}}
+{{- define "text-embeddings-inference.image" -}}{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}{{- end -}}
+
+{{- define "text-embeddings-inference.httpRouteName" -}}
+{{- if .route.name -}}{{ .route.name | trunc 63 | trimSuffix "-" }}{{- else if gt (int .index) 0 -}}{{ printf "%s-%v" (include "text-embeddings-inference.fullname" .root | trunc 55 | trimSuffix "-") .index }}{{- else -}}{{ include "text-embeddings-inference.fullname" .root }}{{- end -}}
+{{- end -}}
+
+{{- define "text-embeddings-inference.suffix" -}}{{ printf "%s-%s" (include "text-embeddings-inference.fullname" .root | trunc (int (sub 62 (len .suffix))) | trimSuffix "-") .suffix }}{{- end -}}
+{{- define "text-embeddings-inference.authSecret" -}}{{ default (include "text-embeddings-inference.suffix" (dict "root" . "suffix" "auth")) .Values.auth.existingSecret }}{{- end -}}
+{{- define "text-embeddings-inference.cacheClaim" -}}{{ default (include "text-embeddings-inference.suffix" (dict "root" . "suffix" "cache")) .Values.cache.persistence.existingClaim }}{{- end -}}
+{{- define "text-embeddings-inference.externalSecretName" -}}{{- if .item.fullnameOverride -}}{{ .item.fullnameOverride | trunc 63 | trimSuffix "-" }}{{- else -}}{{ include "text-embeddings-inference.suffix" (dict "root" .root "suffix" (default "auth" .item.name)) }}{{- end -}}{{- end -}}
+{{- define "text-embeddings-inference.validate" -}}
+{{- if and (eq .Values.model.source "hub") (or (not .Values.model.id) (not (regexMatch "^[a-f0-9]{40}$" .Values.model.revision))) -}}{{ fail "hub models require model.id and an immutable 40-character model.revision" }}{{- end -}}
+{{- if and (eq .Values.model.source "local") (not .Values.model.local.existingClaim) -}}{{ fail "local models require model.local.existingClaim containing complete model artifacts" }}{{- end -}}
+{{- if and .Values.model.defaultPrompt .Values.model.defaultPromptName -}}{{ fail "model.defaultPrompt and model.defaultPromptName are mutually exclusive" }}{{- end -}}
+{{- if or (eq (int .Values.proxy.port) 8081) (eq (int .Values.metrics.port) 8081) (eq (int .Values.proxy.port) (int .Values.metrics.port)) -}}{{ fail "public, private metrics and reserved loopback 8081 ports must differ" }}{{- end -}}
+{{- if and .Values.cache.persistence.enabled (or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1) (ne .Values.rollout.strategy "Recreate")) -}}{{ fail "persistent cache requires one replica, Recreate strategy and autoscaling disabled" }}{{- end -}}
+{{- if and .Values.autoscaling.enabled (or .Values.gpu.enabled (not (dig "requests" "cpu" "" .Values.resources))) -}}{{ fail "CPU autoscaling requires CPU requests and gpu.enabled=false" }}{{- end -}}
+{{- if gt (int .Values.autoscaling.minReplicas) (int .Values.autoscaling.maxReplicas) -}}{{ fail "autoscaling.minReplicas cannot exceed maxReplicas" }}{{- end -}}
+{{- $minimum := int .Values.replicaCount -}}{{- if .Values.autoscaling.enabled -}}{{- $minimum = int .Values.autoscaling.minReplicas -}}{{- end -}}
+{{- if and .Values.podDisruptionBudget.enabled (or (lt $minimum 2) (ge (int .Values.podDisruptionBudget.maxUnavailable) $minimum)) -}}{{ fail "podDisruptionBudget requires at least two minimum replicas and a smaller maxUnavailable" }}{{- end -}}
+{{- if and .Values.metrics.enabled (not .Values.metrics.ingressFrom) -}}{{ fail "metrics.ingressFrom must explicitly authorize monitoring peers" }}{{- end -}}
+{{- if and (or .Values.metrics.serviceMonitor.enabled .Values.metrics.prometheusRule.enabled) (not .Values.metrics.enabled) -}}{{ fail "monitoring resources require metrics.enabled" }}{{- end -}}
+{{- if and .Values.metrics.prometheusRule.enabled (not .Values.metrics.serviceMonitor.enabled) -}}{{ fail "the built-in metrics target alert requires metrics.serviceMonitor.enabled" }}{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}{{ fail "ingress.hosts is required when ingress is enabled" }}{{- end -}}
+{{- if and .Values.gpu.enabled (contains "cpu-" .Values.image.tag) -}}{{ fail "gpu.enabled requires a compatible pinned CUDA image tag" }}{{- end -}}
+{{- if and (not .Values.gpu.enabled) (not (hasPrefix "cpu-" .Values.image.tag)) -}}{{ fail "CPU deployment requires the official cpu image variant" }}{{- end -}}
+{{- if and (not .Values.gpu.enabled) (ne (int .Values.inference.maxBatchRequests) 8) -}}{{ fail "the pinned CPU backend forces exactly eight batch requests; inference.maxBatchRequests must be 8" }}{{- end -}}
+{{- if ne (get .Values.nodeSelector "kubernetes.io/arch" | default "amd64") "amd64" -}}{{ fail "the pinned TEI 1.9.3 images support linux/amd64 only" }}{{- end -}}
+{{- if le (int .Values.terminationGracePeriodSeconds) (int .Values.proxy.readTimeoutSeconds) -}}{{ fail "terminationGracePeriodSeconds must exceed proxy.readTimeoutSeconds" }}{{- end -}}
+{{- range $labels := list .Values.commonLabels .Values.podLabels -}}{{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" -}}{{- if hasKey $labels $key -}}{{ fail (printf "selector label %s cannot be overridden" $key) }}{{- end -}}{{- end -}}{{- end -}}
+{{- $reserved := list "API_KEY" "HF_TOKEN" "LOG_LEVEL" "HOSTNAME" "PORT" "MODEL_ID" "REVISION" "SERVED_MODEL_NAME" "POOLING" "DTYPE" "DEFAULT_PROMPT" "DEFAULT_PROMPT_NAME" "HUGGINGFACE_HUB_CACHE" "HF_HOME" "MAX_CONCURRENT_REQUESTS" "MAX_BATCH_TOKENS" "MAX_BATCH_REQUESTS" "MAX_CLIENT_BATCH_SIZE" "PAYLOAD_LIMIT" "AUTO_TRUNCATE" "TOKENIZATION_WORKERS" "RAYON_NUM_THREADS" "OMP_NUM_THREADS" "MKL_NUM_THREADS" -}}
+{{- range .Values.extraEnv -}}{{- if has .name $reserved -}}{{ fail (printf "extraEnv cannot override chart-owned %s" .name) }}{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/text-embeddings-inference/templates/_helpers.tpl
+++ b/charts/text-embeddings-inference/templates/_helpers.tpl
@@ -26,6 +26,7 @@ app.kubernetes.io/part-of: helmforge
 {{- define "text-embeddings-inference.cacheClaim" -}}{{ default (include "text-embeddings-inference.suffix" (dict "root" . "suffix" "cache")) .Values.cache.persistence.existingClaim }}{{- end -}}
 {{- define "text-embeddings-inference.externalSecretName" -}}{{- if .item.fullnameOverride -}}{{ .item.fullnameOverride | trunc 63 | trimSuffix "-" }}{{- else -}}{{ include "text-embeddings-inference.suffix" (dict "root" .root "suffix" (default "auth" .item.name)) }}{{- end -}}{{- end -}}
 {{- define "text-embeddings-inference.validate" -}}
+{{- if and (not .Values.proxy.ipv6) (or (has "IPv6" .Values.service.ipFamilies) (has .Values.service.ipFamilyPolicy (list "PreferDualStack" "RequireDualStack"))) -}}{{ fail "proxy.ipv6 must be enabled when requesting IPv6 or dual-stack Services" }}{{- end -}}
 {{- if and (eq .Values.model.source "hub") (or (not .Values.model.id) (not (regexMatch "^[a-f0-9]{40}$" .Values.model.revision))) -}}{{ fail "hub models require model.id and an immutable 40-character model.revision" }}{{- end -}}
 {{- if and (eq .Values.model.source "local") (not .Values.model.local.existingClaim) -}}{{ fail "local models require model.local.existingClaim containing complete model artifacts" }}{{- end -}}
 {{- if and .Values.model.defaultPrompt .Values.model.defaultPromptName -}}{{ fail "model.defaultPrompt and model.defaultPromptName are mutually exclusive" }}{{- end -}}
@@ -47,4 +48,12 @@ app.kubernetes.io/part-of: helmforge
 {{- range $labels := list .Values.commonLabels .Values.podLabels -}}{{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" -}}{{- if hasKey $labels $key -}}{{ fail (printf "selector label %s cannot be overridden" $key) }}{{- end -}}{{- end -}}{{- end -}}
 {{- $reserved := list "API_KEY" "HF_TOKEN" "LOG_LEVEL" "HOSTNAME" "PORT" "MODEL_ID" "REVISION" "SERVED_MODEL_NAME" "POOLING" "DTYPE" "DEFAULT_PROMPT" "DEFAULT_PROMPT_NAME" "HUGGINGFACE_HUB_CACHE" "HF_HOME" "MAX_CONCURRENT_REQUESTS" "MAX_BATCH_TOKENS" "MAX_BATCH_REQUESTS" "MAX_CLIENT_BATCH_SIZE" "PAYLOAD_LIMIT" "AUTO_TRUNCATE" "TOKENIZATION_WORKERS" "RAYON_NUM_THREADS" "OMP_NUM_THREADS" "MKL_NUM_THREADS" -}}
 {{- range .Values.extraEnv -}}{{- if has .name $reserved -}}{{ fail (printf "extraEnv cannot override chart-owned %s" .name) }}{{- end -}}{{- end -}}
+{{- end -}}
+{{- define "text-embeddings-inference.validateExternalSecrets" -}}
+{{- $names := dict -}}
+{{- range .Values.externalSecrets.items -}}
+{{- $name := include "text-embeddings-inference.externalSecretName" (dict "root" $ "item" .) -}}
+{{- if hasKey $names $name -}}{{ fail "ExternalSecret names must be unique after rendering and truncation" }}{{- end -}}
+{{- $_ := set $names $name true -}}
+{{- end -}}
 {{- end -}}

--- a/charts/text-embeddings-inference/templates/configmap.yaml
+++ b/charts/text-embeddings-inference/templates/configmap.yaml
@@ -22,7 +22,9 @@ data:
       proxy_send_timeout {{ .Values.proxy.readTimeoutSeconds }}s;
       server {
         listen {{ .Values.proxy.port }};
+        {{- if .Values.proxy.ipv6 }}
         listen [::]:{{ .Values.proxy.port }};
+        {{- end }}
         server_name _;
         client_max_body_size {{ .Values.inference.payloadLimit | int }};
         add_header X-Content-Type-Options nosniff always;
@@ -40,7 +42,9 @@ data:
       {{- if .Values.metrics.enabled }}
       server {
         listen {{ .Values.metrics.port }};
+        {{- if .Values.proxy.ipv6 }}
         listen [::]:{{ .Values.metrics.port }};
+        {{- end }}
         server_name _;
         location = /metrics { proxy_pass http://127.0.0.1:8081/metrics; }
         location / { return 404; }

--- a/charts/text-embeddings-inference/templates/configmap.yaml
+++ b/charts/text-embeddings-inference/templates/configmap.yaml
@@ -1,0 +1,49 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    worker_processes auto;
+    pid /tmp/nginx.pid;
+    error_log /dev/stderr warn;
+    events { worker_connections 1024; }
+    http {
+      access_log off;
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
+      proxy_connect_timeout 5s;
+      proxy_read_timeout {{ .Values.proxy.readTimeoutSeconds }}s;
+      proxy_send_timeout {{ .Values.proxy.readTimeoutSeconds }}s;
+      server {
+        listen {{ .Values.proxy.port }};
+        listen [::]:{{ .Values.proxy.port }};
+        server_name _;
+        client_max_body_size {{ .Values.inference.payloadLimit | int }};
+        add_header X-Content-Type-Options nosniff always;
+        location ^~ /metrics { return 404; }
+        location ^~ /docs { return 404; }
+        location ^~ /api-doc { return 404; }
+        location / {
+          proxy_pass http://127.0.0.1:8081;
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+      }
+      {{- if .Values.metrics.enabled }}
+      server {
+        listen {{ .Values.metrics.port }};
+        listen [::]:{{ .Values.metrics.port }};
+        server_name _;
+        location = /metrics { proxy_pass http://127.0.0.1:8081/metrics; }
+        location / { return 404; }
+      }
+      {{- end }}
+    }

--- a/charts/text-embeddings-inference/templates/deployment.yaml
+++ b/charts/text-embeddings-inference/templates/deployment.yaml
@@ -1,0 +1,145 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: {{ .Values.rollout.strategy }}
+    {{- if eq .Values.rollout.strategy "RollingUpdate" }}
+    rollingUpdate: {maxSurge: {{ .Values.rollout.maxSurge }}, maxUnavailable: {{ .Values.rollout.maxUnavailable }}}
+    {{- end }}
+  selector:
+    matchLabels: {{ include "text-embeddings-inference.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "text-embeddings-inference.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}{{ toYaml . | nindent 8 }}{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}{{ toYaml . | nindent 8 }}{{- end }}
+    spec:
+      serviceAccountName: {{ include "text-embeddings-inference.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml . | nindent 8 }}{{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}{{- end }}
+      containers:
+        - name: tei
+          image: {{ include "text-embeddings-inference.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          args: ["--json-output"]
+          env:
+            - {name: HOSTNAME, value: "127.0.0.1"}
+            - {name: PORT, value: "8081"}
+            - {name: LOG_LEVEL, value: "warn"}
+            - {name: HF_HOME, value: "/data"}
+            - {name: HUGGINGFACE_HUB_CACHE, value: "/data/hub"}
+            - name: MODEL_ID
+              value: {{ ternary "/models" .Values.model.id (eq .Values.model.source "local") | quote }}
+            {{- if eq .Values.model.source "hub" }}
+            - {name: REVISION, value: {{ .Values.model.revision | quote }}}
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef: {name: {{ include "text-embeddings-inference.authSecret" . }}, key: {{ .Values.auth.secretKey }}}
+            {{- end }}
+            {{- if .Values.model.hubToken.existingSecret }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef: {name: {{ .Values.model.hubToken.existingSecret }}, key: {{ .Values.model.hubToken.key }}}
+            {{- end }}
+            {{- range $key, $value := dict "SERVED_MODEL_NAME" .Values.model.servedName "POOLING" .Values.model.pooling "DTYPE" .Values.model.dtype "DEFAULT_PROMPT" .Values.model.defaultPrompt "DEFAULT_PROMPT_NAME" .Values.model.defaultPromptName }}
+            {{- if $value }}
+            - {name: {{ $key }}, value: {{ $value | quote }}}
+            {{- end }}{{- end }}
+            - {name: AUTO_TRUNCATE, value: {{ .Values.inference.autoTruncate | quote }}}
+            {{- range $key, $value := dict "MAX_CONCURRENT_REQUESTS" .Values.inference.maxConcurrentRequests "MAX_BATCH_TOKENS" .Values.inference.maxBatchTokens "MAX_BATCH_REQUESTS" .Values.inference.maxBatchRequests "MAX_CLIENT_BATCH_SIZE" .Values.inference.maxClientBatchSize "PAYLOAD_LIMIT" .Values.inference.payloadLimit "TOKENIZATION_WORKERS" .Values.inference.tokenizationWorkers "RAYON_NUM_THREADS" .Values.inference.threads "OMP_NUM_THREADS" .Values.inference.threads "MKL_NUM_THREADS" .Values.inference.threads }}
+            - {name: {{ $key }}, value: {{ $value | int | quote }}}
+            {{- end }}
+            {{- with .Values.extraEnv }}{{ toYaml . | nindent 12 }}{{- end }}
+          {{- $resources := deepCopy .Values.resources }}
+          {{- if .Values.gpu.enabled }}
+          {{- $requests := $resources.requests | default dict }}{{- $limits := $resources.limits | default dict }}
+          {{- $_ := set $requests "nvidia.com/gpu" (.Values.gpu.count | toString) }}{{- $_ := set $limits "nvidia.com/gpu" (.Values.gpu.count | toString) }}
+          {{- $_ := set $resources "requests" $requests }}{{- $_ := set $resources "limits" $limits }}
+          {{- end }}
+          resources: {{ toYaml $resources | nindent 12 }}
+          {{- range $kind, $probe := .Values.probes }}
+          {{- if $probe.enabled }}
+          {{ $kind }}Probe:
+            exec:
+              command: [curl, --fail, --silent, --show-error, --max-time, {{ $probe.timeoutSeconds | quote }}, "http://127.0.0.1:8081/health"]
+            {{- omit $probe "enabled" | toYaml | nindent 12 }}
+          {{- end }}{{- end }}
+          volumeMounts:
+            - {name: cache, mountPath: /data}
+            - {name: native-tmp, mountPath: /tmp}
+            {{- if eq .Values.model.source "local" }}
+            - name: model
+              mountPath: /models
+              readOnly: true
+              {{- with .Values.model.local.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
+            {{- end }}
+        - name: proxy
+          image: {{ printf "%s:%s" .Values.proxy.image.repository .Values.proxy.image.tag | quote }}
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          command: [nginx]
+          args: [-g, "daemon off;"]
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          resources: {{ toYaml .Values.proxy.resources | nindent 12 }}
+          ports:
+            - {name: http, containerPort: {{ .Values.proxy.port }}}
+            {{- if .Values.metrics.enabled }}
+            - {name: metrics, containerPort: {{ .Values.metrics.port }}}
+            {{- end }}
+          startupProbe:
+            httpGet: {path: /health, port: http}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+          readinessProbe:
+            httpGet: {path: /health, port: http}
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket: {port: http}
+            periodSeconds: 30
+          volumeMounts:
+            - {name: config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true}
+            - {name: proxy-tmp, mountPath: /tmp}
+      volumes:
+        - name: cache
+          {{- if .Values.cache.persistence.enabled }}
+          persistentVolumeClaim: {claimName: {{ include "text-embeddings-inference.cacheClaim" . }}}
+          {{- else }}
+          emptyDir: {sizeLimit: {{ .Values.cache.emptyDirSizeLimit | quote }}}
+          {{- end }}
+        - {name: native-tmp, emptyDir: {sizeLimit: 1Gi}}
+        - {name: proxy-tmp, emptyDir: {sizeLimit: 64Mi}}
+        - name: config
+          configMap: {name: {{ include "text-embeddings-inference.fullname" . }}}
+        {{- if eq .Values.model.source "local" }}
+        - name: model
+          persistentVolumeClaim: {claimName: {{ .Values.model.local.existingClaim }}, readOnly: true}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}{{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}{{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}{{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}{{- end }}

--- a/charts/text-embeddings-inference/templates/externalsecret.yaml
+++ b/charts/text-embeddings-inference/templates/externalsecret.yaml
@@ -1,5 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
+{{- include "text-embeddings-inference.validateExternalSecrets" . }}
 {{- range .Values.externalSecrets.items | default list }}
 {{- $externalSecretName := include "text-embeddings-inference.externalSecretName" (dict "root" $ "item" .) }}
 {{- $spec := deepCopy (.spec | default dict) }}

--- a/charts/text-embeddings-inference/templates/externalsecret.yaml
+++ b/charts/text-embeddings-inference/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "text-embeddings-inference.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "text-embeddings-inference.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/gateway-httproute.yaml
+++ b/charts/text-embeddings-inference/templates/gateway-httproute.yaml
@@ -1,0 +1,58 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- $names := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes | default list }}
+{{- if not .parentRefs }}{{ fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- $name := include "text-embeddings-inference.httpRouteName" (dict "root" $ "route" . "index" $index) }}
+{{- if hasKey $names $name }}{{ fail "HTTPRoute names must be unique" }}{{- end }}
+{{- $_ := set $names $name true }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "text-embeddings-inference.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .parentRefs }}
+  parentRefs:
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- end }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .rules }}
+    {{- range .rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else if not .omitDefaultBackend }}
+      backendRefs:
+        - name: {{ include "text-embeddings-inference.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ include "text-embeddings-inference.fullname" $ }}
+          port: {{ $.Values.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/hpa.yaml
+++ b/charts/text-embeddings-inference/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef: {apiVersion: apps/v1, kind: Deployment, name: {{ include "text-embeddings-inference.fullname" . }}}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  behavior:
+    scaleDown: {stabilizationWindowSeconds: 300}
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: tei
+        target: {type: Utilization, averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/ingress.yaml
+++ b/charts/text-embeddings-inference/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels:
+    {{- include "text-embeddings-inference.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "text-embeddings-inference.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/metrics.yaml
+++ b/charts/text-embeddings-inference/templates/metrics.yaml
@@ -47,10 +47,10 @@ spec:
     - name: {{ include "text-embeddings-inference.fullname" . }}.inference
       rules:
         - alert: TextEmbeddingsInferenceUnavailable
-          expr: up{namespace={{ .Release.Namespace | quote }},service={{ include "text-embeddings-inference.suffix" (dict "root" . "suffix" "metrics") | quote }}} == 0
+          expr: up{namespace={{ .Release.Namespace | quote }},service={{ include "text-embeddings-inference.suffix" (dict "root" . "suffix" "metrics") | quote }}} == 0 or absent(up{namespace={{ .Release.Namespace | quote }},service={{ include "text-embeddings-inference.suffix" (dict "root" . "suffix" "metrics") | quote }}})
           for: 5m
           labels: {severity: warning}
-          annotations: {summary: "Text Embeddings Inference scrape target is unavailable"}
+          annotations: {summary: "Text Embeddings Inference scrape target is missing or unavailable"}
         {{- with .Values.metrics.prometheusRule.additionalRules }}{{ toYaml . | nindent 8 }}{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/text-embeddings-inference/templates/metrics.yaml
+++ b/charts/text-embeddings-inference/templates/metrics.yaml
@@ -1,0 +1,56 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "text-embeddings-inference.suffix" (dict "root" . "suffix" "metrics") }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - {name: metrics, port: {{ .Values.metrics.port }}, targetPort: metrics}
+  selector: {{ include "text-embeddings-inference.selectorLabels" . | nindent 4 }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels:
+    {{- include "text-embeddings-inference.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}{{ toYaml . | nindent 4 }}{{- end }}
+spec:
+  selector:
+    matchLabels: {{ include "text-embeddings-inference.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- if .Values.metrics.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels:
+    {{- include "text-embeddings-inference.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}{{ toYaml . | nindent 4 }}{{- end }}
+spec:
+  groups:
+    - name: {{ include "text-embeddings-inference.fullname" . }}.inference
+      rules:
+        - alert: TextEmbeddingsInferenceUnavailable
+          expr: up{namespace={{ .Release.Namespace | quote }},service={{ include "text-embeddings-inference.suffix" (dict "root" . "suffix" "metrics") | quote }}} == 0
+          for: 5m
+          labels: {severity: warning}
+          annotations: {summary: "Text Embeddings Inference scrape target is unavailable"}
+        {{- with .Values.metrics.prometheusRule.additionalRules }}{{ toYaml . | nindent 8 }}{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/networkpolicy.yaml
+++ b/charts/text-embeddings-inference/templates/networkpolicy.yaml
@@ -1,0 +1,50 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{ include "text-embeddings-inference.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egressIsolation }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - podSelector: {}
+        {{- end }}
+      ports: [{protocol: TCP, port: http}]
+    {{- if .Values.metrics.enabled }}
+    - from: {{ toYaml .Values.metrics.ingressFrom | nindent 8 }}
+      ports: [{protocol: TCP, port: metrics}]
+    {{- end }}
+  {{- if .Values.networkPolicy.egressIsolation }}
+  {{- if and (eq .Values.model.source "hub") .Values.networkPolicy.allowHubDownloads }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels: {kubernetes.io/metadata.name: kube-system}
+          podSelector:
+            matchLabels: {k8s-app: kube-dns}
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16]
+        - ipBlock:
+            cidr: '::/0'
+            except: ['fc00::/7', 'fe80::/10', '::1/128']
+      ports: [{protocol: TCP, port: 443}]
+    {{- with .Values.networkPolicy.extraEgress }}{{ toYaml . | nindent 4 }}{{- end }}
+  {{- else }}
+  egress: {{ toYaml .Values.networkPolicy.extraEgress | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/pdb.yaml
+++ b/charts/text-embeddings-inference/templates/pdb.yaml
@@ -1,0 +1,12 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels: {{ include "text-embeddings-inference.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/pvc.yaml
+++ b/charts/text-embeddings-inference/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.cache.persistence.enabled (not .Values.cache.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "text-embeddings-inference.cacheClaim" . }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+  {{- with .Values.cache.persistence.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes: [ReadWriteOnce]
+  {{- if eq .Values.cache.persistence.storageClass "-" }}
+  storageClassName: ""
+  {{- else if .Values.cache.persistence.storageClass }}
+  storageClassName: {{ .Values.cache.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests: {storage: {{ .Values.cache.persistence.size | quote }}}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/secret.yaml
+++ b/charts/text-embeddings-inference/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+{{- $name := include "text-embeddings-inference.authSecret" . }}
+{{- $old := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $key := randAlphaNum 48 | b64enc }}
+{{- if and $old (hasKey ($old.data | default dict) .Values.auth.secretKey) }}{{- $key = index $old.data .Values.auth.secretKey }}{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels: {{ include "text-embeddings-inference.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.auth.secretKey }}: {{ $key | quote }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/service.yaml
+++ b/charts/text-embeddings-inference/templates/service.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "text-embeddings-inference.fullname" . }}
+  labels:
+    {{- include "text-embeddings-inference.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+
+  selector:
+    {{- include "text-embeddings-inference.selectorLabels" . | nindent 4 }}

--- a/charts/text-embeddings-inference/templates/serviceaccount.yaml
+++ b/charts/text-embeddings-inference/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "text-embeddings-inference.serviceAccountName" . }}
+  labels:
+    {{- include "text-embeddings-inference.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/text-embeddings-inference/templates/validate.yaml
+++ b/charts/text-embeddings-inference/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "text-embeddings-inference.validate" . -}}

--- a/charts/text-embeddings-inference/tests/gateway_contract_test.yaml
+++ b/charts/text-embeddings-inference/tests/gateway_contract_test.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Canonical Gateway API routes
+templates:
+  - gateway-httproute.yaml
+tests:
+  - it: omits routes by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: defaults custom rules to the application backend
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - parentRefs:
+            - name: shared
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /files
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-text-embeddings-inference
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /files
+  - it: gives unnamed routes unique names
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - parentRefs:
+            - name: one
+        - parentRefs:
+            - name: two
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-text-embeddings-inference-1
+        documentIndex: 1
+  - it: rejects duplicate names
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: same
+          parentRefs:
+            - name: one
+        - name: same
+          parentRefs:
+            - name: two
+    asserts:
+      - failedTemplate:
+          errorMessage: HTTPRoute names must be unique

--- a/charts/text-embeddings-inference/tests/review_contracts_test.yaml
+++ b/charts/text-embeddings-inference/tests/review_contracts_test.yaml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Listener compatibility and ExternalSecret identity
+templates:
+  - configmap.yaml
+  - externalsecret.yaml
+  - validate.yaml
+tests:
+  - it: avoids IPv6 sockets by default
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: listen \[::\]
+  - it: enables IPv6 on public and private listeners explicitly
+    template: configmap.yaml
+    set:
+      proxy.ipv6: true
+      metrics.enabled: true
+      metrics.ingressFrom:
+        - podSelector: {}
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: listen \[::\]:8080;
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: listen \[::\]:9464;
+  - it: rejects dual-stack Services without an IPv6 listener
+    template: validate.yaml
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+    asserts:
+      - failedTemplate:
+          errorMessage: proxy.ipv6 must be enabled when requesting IPv6 or dual-stack Services
+  - it: rejects colliding implicit ExternalSecret names
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - spec:
+            secretStoreRef:
+              name: store
+        - spec:
+            secretStoreRef:
+              name: store
+    asserts:
+      - failedTemplate:
+          errorMessage: ExternalSecret names must be unique after rendering and truncation
+  - it: rejects duplicate explicit ExternalSecret names
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: identity
+          spec:
+            secretStoreRef:
+              name: store
+        - fullnameOverride: identity
+          spec:
+            secretStoreRef:
+              name: store
+    asserts:
+      - failedTemplate:
+          errorMessage: ExternalSecret names must be unique after rendering and truncation
+  - it: rejects ExternalSecret names that collide after truncation
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-one
+          spec:
+            secretStoreRef:
+              name: store
+        - fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-two
+          spec:
+            secretStoreRef:
+              name: store
+    asserts:
+      - failedTemplate:
+          errorMessage: ExternalSecret names must be unique after rendering and truncation

--- a/charts/text-embeddings-inference/tests/schema_contracts_test.yaml
+++ b/charts/text-embeddings-inference/tests/schema_contracts_test.yaml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Kubernetes Ingress and probe schema contracts
+templates:
+  - validate.yaml
+tests:
+  - it: rejects zero startup periodSeconds
+    set:
+      probes.startup.periodSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*periodSeconds.*
+  - it: rejects zero startup timeoutSeconds
+    set:
+      probes.startup.timeoutSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*timeoutSeconds.*
+  - it: rejects zero startup failureThreshold
+    set:
+      probes.startup.failureThreshold: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*failureThreshold.*
+  - it: rejects zero readiness periodSeconds
+    set:
+      probes.readiness.periodSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*periodSeconds.*
+  - it: rejects zero readiness timeoutSeconds
+    set:
+      probes.readiness.timeoutSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*timeoutSeconds.*
+  - it: rejects zero readiness failureThreshold
+    set:
+      probes.readiness.failureThreshold: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*failureThreshold.*
+  - it: rejects zero liveness periodSeconds
+    set:
+      probes.liveness.periodSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*periodSeconds.*
+  - it: rejects zero liveness timeoutSeconds
+    set:
+      probes.liveness.timeoutSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*timeoutSeconds.*
+  - it: rejects zero liveness failureThreshold
+    set:
+      probes.liveness.failureThreshold: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: .*failureThreshold.*
+  - it: rejects ingress with missing paths
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: embeddings.example.com
+    asserts:
+      - failedTemplate:
+          errorPattern: .*paths.*
+  - it: rejects ingress with empty paths
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: embeddings.example.com
+          paths: []
+    asserts:
+      - failedTemplate:
+          errorPattern: .*paths.*
+  - it: rejects ingress with missing path
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: embeddings.example.com
+          paths:
+            - pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorPattern: .*path.*
+  - it: rejects ingress with missing path type
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: embeddings.example.com
+          paths:
+            - path: /
+    asserts:
+      - failedTemplate:
+          errorPattern: .*pathType.*
+  - it: rejects ingress with missing hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorPattern: .*host.*

--- a/charts/text-embeddings-inference/tests/secret_routing_test.yaml
+++ b/charts/text-embeddings-inference/tests/secret_routing_test.yaml
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Secret and public route contracts
+templates:
+  - secret.yaml
+  - externalsecret.yaml
+  - service.yaml
+  - ingress.yaml
+tests:
+  - it: omits ExternalSecrets when disabled
+    template: externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: rejects a missing external source
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: api
+          spec: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true
+  - it: preserves independent targets and refresh intervals for multiple credentials
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: api
+          spec:
+            refreshInterval: 5m
+            target:
+              name: api-target
+            secretStoreRef:
+              name: store
+        - name: hub
+          spec:
+            secretStoreRef:
+              name: store
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.target.name
+          value: api-target
+        documentIndex: 0
+      - equal:
+          path: spec.refreshInterval
+          value: 5m
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-text-embeddings-inference-hub
+        documentIndex: 1
+  - it: creates a random native key without an inline values credential
+    template: secret.yaml
+    asserts:
+      - matchRegex:
+          path: data["api-key"]
+          pattern: ^[A-Za-z0-9+/=]{64}$
+  - it: omits generated credentials when referencing an existing Secret
+    template: secret.yaml
+    set:
+      auth.existingSecret: existing-api
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: supports explicit anonymous internal serving
+    template: secret.yaml
+    set:
+      auth.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders canonical ExternalSecret target defaults
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: tei-eso
+          spec:
+            secretStoreRef:
+              name: store
+              kind: ClusterSecretStore
+            data:
+              - secretKey: api-key
+                remoteRef:
+                  key: tei/api
+    asserts:
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.target.name
+          value: tei-eso
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: supports dual-stack inference without exposing metrics
+    template: service.yaml
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+  - it: renders an explicit ingress class
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: embeddings.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx

--- a/charts/text-embeddings-inference/tests/secret_routing_test.yaml
+++ b/charts/text-embeddings-inference/tests/secret_routing_test.yaml
@@ -100,6 +100,7 @@ tests:
     template: service.yaml
     set:
       service.ipFamilyPolicy: RequireDualStack
+      proxy.ipv6: true
       service.ipFamilies:
         - IPv4
         - IPv6

--- a/charts/text-embeddings-inference/tests/storage_monitoring_test.yaml
+++ b/charts/text-embeddings-inference/tests/storage_monitoring_test.yaml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Cache, isolation and monitoring
+templates:
+  - pvc.yaml
+  - networkpolicy.yaml
+  - metrics.yaml
+  - hpa.yaml
+  - pdb.yaml
+tests:
+  - it: keeps ephemeral cache as default
+    template: pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates an owned RWO cache only when requested
+    template: pvc.yaml
+    set:
+      cache.persistence.enabled: true
+    asserts:
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+  - it: does not recreate an existing cache claim
+    template: pvc.yaml
+    set:
+      cache.persistence.enabled: true
+      cache.persistence.existingClaim: owned-cache
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: denies all offline egress
+    template: networkpolicy.yaml
+    set:
+      model.source: local
+      model.local.existingClaim: model
+    asserts:
+      - equal:
+          path: spec.egress
+          value: []
+  - it: only permits declared scraper peers on the private listener
+    template: networkpolicy.yaml
+    set:
+      metrics.enabled: true
+      metrics.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: prometheus
+    asserts:
+      - equal:
+          path: spec.ingress[1].from
+          value:
+            - podSelector:
+                matchLabels:
+                  app: prometheus
+      - equal:
+          path: spec.ingress[1].ports
+          value:
+            - protocol: TCP
+              port: metrics
+  - it: renders real native monitoring resources
+    template: metrics.yaml
+    set:
+      metrics.enabled: true
+      metrics.ingressFrom:
+        - podSelector: {}
+      metrics.serviceMonitor.enabled: true
+      metrics.prometheusRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+        documentIndex: 1
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: TextEmbeddingsInferenceUnavailable
+        documentIndex: 2
+  - it: targets the native container CPU rather than the proxy
+    template: hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.metrics[0].containerResource.container
+          value: tei
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+  - it: protects an actual replicated service
+    template: pdb.yaml
+    set:
+      replicaCount: 2
+      podDisruptionBudget.enabled: true
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1

--- a/charts/text-embeddings-inference/tests/validation_test.yaml
+++ b/charts/text-embeddings-inference/tests/validation_test.yaml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Reject unsafe or incompatible inference contracts
+templates:
+  - validate.yaml
+tests:
+  - it: rejects CPU backend batch settings that upstream would silently replace
+    set:
+      inference.maxBatchRequests: 4
+    asserts:
+      - failedTemplate:
+          errorMessage: the pinned CPU backend forces exactly eight batch requests; inference.maxBatchRequests must be 8
+  - it: rejects floating model revisions
+    set:
+      model.revision: ''
+    asserts:
+      - failedTemplate:
+          errorMessage: hub models require model.id and an immutable 40-character model.revision
+  - it: requires local artifacts
+    set:
+      model.source: local
+    asserts:
+      - failedTemplate:
+          errorMessage: local models require model.local.existingClaim containing complete model artifacts
+  - it: prevents log credential exposure
+    set:
+      extraEnv:
+        - name: LOG_LEVEL
+          value: info
+    asserts:
+      - failedTemplate:
+          errorMessage: extraEnv cannot override chart-owned LOG_LEVEL
+  - it: prevents native listener bypass
+    set:
+      extraEnv:
+        - name: HOSTNAME
+          value: 0.0.0.0
+    asserts:
+      - failedTemplate:
+          errorMessage: extraEnv cannot override chart-owned HOSTNAME
+  - it: prevents shared writable cache scaling
+    set:
+      cache.persistence.enabled: true
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: persistent cache requires one replica, Recreate strategy and autoscaling disabled
+  - it: prevents cache surge mounts
+    set:
+      cache.persistence.enabled: true
+      rollout.strategy: RollingUpdate
+    asserts:
+      - failedTemplate:
+          errorMessage: persistent cache requires one replica, Recreate strategy and autoscaling disabled
+  - it: requires explicit monitoring peers
+    set:
+      metrics.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: metrics.ingressFrom must explicitly authorize monitoring peers
+  - it: prevents misleading singleton PDB
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: podDisruptionBudget requires at least two minimum replicas and a smaller maxUnavailable
+  - it: requires a CUDA image for GPUs
+    set:
+      gpu.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu.enabled requires a compatible pinned CUDA image tag
+  - it: prevents CPU HPA on GPU workloads
+    set:
+      gpu.enabled: true
+      autoscaling.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: CPU autoscaling requires CPU requests and gpu.enabled=false
+  - it: reserves loopback port
+    set:
+      proxy.port: 8081
+    asserts:
+      - failedTemplate:
+          errorMessage: public, private metrics and reserved loopback 8081 ports must differ
+  - it: rejects contradictory prompt configuration
+    set:
+      model.defaultPrompt: 'query: '
+      model.defaultPromptName: query
+    asserts:
+      - failedTemplate:
+          errorMessage: model.defaultPrompt and model.defaultPromptName are mutually exclusive

--- a/charts/text-embeddings-inference/tests/workload_test.yaml
+++ b/charts/text-embeddings-inference/tests/workload_test.yaml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Native inference and protected listeners
+templates:
+  - deployment.yaml
+  - configmap.yaml
+tests:
+  - it: keeps the native entrypoint, tokenless identity and exact integer limits
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - notExists:
+          path: spec.template.spec.containers[0].command
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PAYLOAD_LIMIT
+            value: '1048576'
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_LEVEL
+            value: warn
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTNAME
+            value: 127.0.0.1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+  - it: renders integer payload limits in the proxy and denies public metrics
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: client_max_body_size 1048576;
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: location \^~ /metrics \{ return 404; \}
+  - it: requests and limits an NVIDIA device without replacing the CUDA entrypoint
+    template: deployment.yaml
+    set:
+      gpu.enabled: true
+      gpu.count: 2
+      image.tag: cuda-1.9.3@sha256:249a0bc87522bfe2f1012b4d194f0225878f47079115ada3aeb0b1ef257b402a
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"]
+          value: '2'
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: '2'
+      - notExists:
+          path: spec.template.spec.containers[0].command
+  - it: mounts complete local model artifacts read-only
+    template: deployment.yaml
+    set:
+      model.source: local
+      model.local.existingClaim: offline-model
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: model
+            mountPath: /models
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MODEL_ID
+            value: /models
+  - it: references independent API and Hub credentials
+    template: deployment.yaml
+    set:
+      auth.existingSecret: api
+      model.hubToken.existingSecret: hub
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: api
+                key: api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hub
+                key: token

--- a/charts/text-embeddings-inference/values.schema.json
+++ b/charts/text-embeddings-inference/values.schema.json
@@ -296,6 +296,9 @@
             }
           },
           "additionalProperties": true
+        },
+        "ipv6": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -362,7 +365,44 @@
         "hosts": {
           "type": "array",
           "items": {
-            "type": "object"
+            "type": "object",
+            "required": [
+              "host",
+              "paths"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "pathType"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "pattern": "^/"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": [
+                        "Prefix",
+                        "Exact",
+                        "ImplementationSpecific"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tls": {
@@ -612,15 +652,15 @@
             },
             "periodSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "timeoutSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "failureThreshold": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             }
           },
           "additionalProperties": false
@@ -633,15 +673,15 @@
             },
             "periodSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "timeoutSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "failureThreshold": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             }
           },
           "additionalProperties": false
@@ -654,15 +694,15 @@
             },
             "periodSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "timeoutSeconds": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             },
             "failureThreshold": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
             }
           },
           "additionalProperties": false

--- a/charts/text-embeddings-inference/values.schema.json
+++ b/charts/text-embeddings-inference/values.schema.json
@@ -1,0 +1,781 @@
+{
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]*(@sha256:[a-f0-9]{64})?$",
+          "not": {
+            "pattern": "(^|[-:])latest(@|$)"
+          }
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "model": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": [
+            "hub",
+            "local"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "string",
+          "pattern": "^$|^[a-f0-9]{40}$"
+        },
+        "servedName": {
+          "type": "string"
+        },
+        "pooling": {
+          "type": "string",
+          "enum": [
+            "",
+            "cls",
+            "mean",
+            "last-token",
+            "splade"
+          ]
+        },
+        "dtype": {
+          "type": "string",
+          "enum": [
+            "float32",
+            "float16"
+          ]
+        },
+        "defaultPrompt": {
+          "type": "string"
+        },
+        "defaultPromptName": {
+          "type": "string"
+        },
+        "local": {
+          "type": "object",
+          "properties": {
+            "existingClaim": {
+              "type": "string"
+            },
+            "subPath": {
+              "type": "string",
+              "pattern": "^([A-Za-z0-9._-][A-Za-z0-9._/-]*)?$",
+              "not": {
+                "pattern": "(^|/)\\.\\.(/|$)"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "hubToken": {
+          "type": "object",
+          "properties": {
+            "existingSecret": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "inference": {
+      "type": "object",
+      "properties": {
+        "maxConcurrentRequests": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxBatchTokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxBatchRequests": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxClientBatchSize": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payloadLimit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "autoTruncate": {
+          "type": "boolean"
+        },
+        "tokenizationWorkers": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "threads": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "cache": {
+      "type": "object",
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "emptyDirSizeLimit": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "gpu": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "proxy": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]*(@sha256:[a-f0-9]{64})?$",
+              "not": {
+                "pattern": "(^|[-:])latest(@|$)"
+              }
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "readTimeoutSeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": [
+            "",
+            "SingleStack",
+            "PreferDualStack",
+            "RequireDualStack"
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "IPv4",
+              "IPv6"
+            ]
+          },
+          "uniqueItems": true,
+          "maxItems": 2
+        }
+      },
+      "additionalProperties": false
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressClassName": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "prometheusRule": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "additionalRules": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "egressIsolation": {
+          "type": "boolean"
+        },
+        "allowHubDownloads": {
+          "type": "boolean"
+        },
+        "extraEgress": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fsGroup": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fsGroupChangePolicy": {
+          "type": "string"
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "readiness": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "liveness": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "rollout": {
+      "type": "object",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": [
+            "Recreate",
+            "RollingUpdate"
+          ]
+        },
+        "maxSurge": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {
+        "kubernetes.io/arch": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "podLabels": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "podAnnotations": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Text Embeddings Inference values"
+}

--- a/charts/text-embeddings-inference/values.yaml
+++ b/charts/text-embeddings-inference/values.yaml
@@ -107,6 +107,8 @@ proxy:
     pullPolicy: IfNotPresent
   # -- Public Pod listener; native TEI always binds loopback port 8081.
   port: 8080
+  # -- Enable IPv6 sockets; required for IPv6/dual-stack Services and must be false when kernel IPv6 is disabled.
+  ipv6: false
   # -- Native response timeout; use a longer termination grace period.
   readTimeoutSeconds: 120
   # -- Proxy CPU and memory budgets, separate from model inference.

--- a/charts/text-embeddings-inference/values.yaml
+++ b/charts/text-embeddings-inference/values.yaml
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# -- Override the short chart name.
+nameOverride: ''
+# -- Override the complete resource name.
+fullnameOverride: ''
+# -- Additional resource labels; selector keys are reserved.
+commonLabels: {}
+# -- Independent model replicas; each loads its own RAM or VRAM copy.
+replicaCount: 1
+# -- Official TEI image; preserve its native entrypoint, including CUDA selection.
+image:
+  # -- Official image repository or your trusted mirror.
+  repository: ghcr.io/huggingface/text-embeddings-inference
+  # -- Pinned version and immutable image digest.
+  tag: cpu-1.9.3@sha256:ad950d30878eceb72aaf32024d26fa2b1d04a75304fa0b4776b49aa1941fea07
+  # -- Kubernetes image pull policy.
+  pullPolicy: IfNotPresent
+# -- Registry credential Secret references.
+imagePullSecrets: []
+# -- One immutable model per release. Changing model identity requires a vector-index migration.
+model:
+  # -- Hub download or a complete read-only local model PVC.
+  source: hub
+  # -- Hugging Face repository ID used in hub mode.
+  id: BAAI/bge-small-en-v1.5
+  # -- Required immutable 40-character Hub commit in hub mode.
+  revision: 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+  # -- Optional OpenAI response model name; empty uses the native model ID.
+  servedName: ''
+  # -- Optional native pooling override: cls, mean, last-token or splade.
+  pooling: ''
+  # -- Native numerical type; match the model and selected hardware.
+  dtype: float32
+  # -- Optional literal embedding prompt, mutually exclusive with defaultPromptName.
+  defaultPrompt: ''
+  # -- Optional named prompt already present in the model configuration.
+  defaultPromptName: ''
+  # -- Complete local model artifacts mounted read-only at /models.
+  local:
+    # -- Prepopulated PVC required in local mode; multi-node replicas require compatible read-only storage.
+    existingClaim: ''
+    # -- Optional relative directory within the model PVC.
+    subPath: ''
+  # -- Independent read-only Hub credential for private or gated models.
+  hubToken:
+    # -- Existing Secret name.
+    existingSecret: ''
+    # -- Secret data key.
+    key: token
+# -- Native batching and admission limits, not throughput guarantees.
+inference:
+  # -- Maximum admitted concurrent requests; saturation applies native backpressure.
+  maxConcurrentRequests: 64
+  # -- Total token budget per dynamic batch; must fit model input length when truncation is disabled.
+  maxBatchTokens: 2048
+  # -- Maximum individual requests per backend batch; the pinned CPU backend forces exactly eight.
+  maxBatchRequests: 8
+  # -- Maximum input count per client request; overflow returns native HTTP 422.
+  maxClientBatchSize: 16
+  # -- Maximum request body bytes, enforced by the public proxy and native router.
+  payloadLimit: 1048576
+  # -- Automatically truncate overlength inputs; false preserves explicit rejection.
+  autoTruncate: false
+  # -- Tokenizer workers independent of the inference thread budget.
+  tokenizationWorkers: 2
+  # -- CPU Rayon, OpenMP and MKL thread budget per model replica.
+  threads: 2
+# -- Native API bearer authentication; /health remains unauthenticated.
+auth:
+  # -- Require native bearer authentication on inference and model information.
+  enabled: true
+  # -- Existing API credential Secret; empty creates and retains a random key across Helm upgrades.
+  existingSecret: ''
+  # -- Key within the generated or existing Secret.
+  secretKey: api-key
+# -- Reproducible model cache, not application data or a backup.
+cache:
+  # -- Optional single-replica ReadWriteOnce cache; requires Recreate and no HPA.
+  persistence:
+    # -- Use persistent cache storage instead of a per-Pod emptyDir.
+    enabled: false
+    # -- Reuse an existing writable cache PVC instead of creating one.
+    existingClaim: ''
+    # -- StorageClass for a new cache PVC; empty uses the cluster default, dash disables dynamic provisioning.
+    storageClass: ''
+    # -- Requested capacity of the cache PVC.
+    size: 5Gi
+    # -- Annotations on the cache PVC.
+    annotations: {}
+  # -- Ephemeral per-Pod cache limit; include full model artifacts and download overhead.
+  emptyDirSizeLimit: 5Gi
+# -- Optional NVIDIA allocation; set a compatible pinned CUDA image explicitly.
+gpu:
+  # -- Allocate NVIDIA GPUs; GPU runtime is not validated by the CPU-only lab.
+  enabled: false
+  # -- GPU units requested and limited per replica.
+  count: 1
+# -- Official unprivileged NGINX separates native API and private metrics paths.
+proxy:
+  # -- Official unprivileged proxy image and pull policy.
+  image:
+    # -- Official image repository or your trusted mirror.
+    repository: docker.io/nginxinc/nginx-unprivileged
+    # -- Pinned version and immutable image digest.
+    tag: 1.30.4-alpine@sha256:442753882674b49ae2c1de83ed67896131c0777f56df5005e356e62bc3f7e7ce
+    # -- Kubernetes image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Public Pod listener; native TEI always binds loopback port 8081.
+  port: 8080
+  # -- Native response timeout; use a longer termination grace period.
+  readTimeoutSeconds: 120
+  # -- Proxy CPU and memory budgets, separate from model inference.
+  resources:
+    # -- Resources reserved by the scheduler.
+    requests:
+      # -- Kubernetes CPU quantity.
+      cpu: 50m
+      # -- Kubernetes memory quantity.
+      memory: 32Mi
+    # -- Maximum container resources.
+    limits:
+      # -- Kubernetes CPU quantity.
+      cpu: 500m
+      # -- Kubernetes memory quantity.
+      memory: 128Mi
+# -- Public inference Service; never includes the metrics port.
+service:
+  # -- Kubernetes Service exposure type.
+  type: ClusterIP
+  # -- Public Service port routed to the NGINX listener.
+  port: 80
+  # -- Annotations on the public Service.
+  annotations: {}
+  # -- Kubernetes IP family policy; empty uses the cluster default.
+  ipFamilyPolicy: ''
+  # -- Requested Service families, such as IPv4 and IPv6.
+  ipFamilies: []
+# -- Optional Ingress terminating at the public inference Service.
+ingress:
+  # -- Render an Ingress.
+  enabled: false
+  # -- Ingress controller class; empty omits the field.
+  ingressClassName: ''
+  # -- Annotations on the Ingress.
+  annotations: {}
+  # -- Explicit host/path rules required when Ingress is enabled.
+  hosts: []
+  # -- TLS host and Secret references managed by the edge controller.
+  tls: []
+# -- Canonical HTTPRoute definitions targeting a shared Gateway.
+gatewayAPI:
+  # -- Render Gateway API HTTPRoutes.
+  enabled: false
+  # -- Route items with parentRefs, hostnames, matches and optional filters.
+  httpRoutes: []
+# -- Canonical External Secrets Operator resources for referenced credentials.
+externalSecrets:
+  # -- Render ExternalSecret items.
+  enabled: false
+  # -- Default provider refresh interval.
+  refreshInterval: 1h
+  # -- Complete ExternalSecret item specs with explicit Secret store references.
+  items: []
+# -- Native TEI Prometheus exposition through a separate private NGINX listener.
+metrics:
+  # -- Enable the private metrics listener and Service.
+  enabled: false
+  # -- Private Pod and Service scrape port; never exposed by application routes.
+  port: 9464
+  # -- Explicit NetworkPolicy peers allowed to scrape; required when metrics is enabled.
+  ingressFrom: []
+  # -- Optional Prometheus Operator scraping resource.
+  serviceMonitor:
+    # -- Render a ServiceMonitor; requires an installed Prometheus Operator.
+    enabled: false
+    # -- Scrape interval.
+    interval: 30s
+    # -- Per-scrape timeout, no longer than interval.
+    scrapeTimeout: 10s
+    # -- Discovery labels expected by your Prometheus.
+    labels: {}
+  # -- Optional scrape availability alert and additional native metric rules.
+  prometheusRule:
+    # -- Render PrometheusRule; requires ServiceMonitor for the built-in target alert.
+    enabled: false
+    # -- Rule discovery labels.
+    labels: {}
+    # -- Additional valid Prometheus alerting or recording rules.
+    additionalRules: []
+# -- Pod network boundaries; CNI enforcement is required.
+networkPolicy:
+  # -- Render application ingress and optional egress isolation.
+  enabled: true
+  # -- Allowed application peers; empty permits same-namespace Pods.
+  ingressFrom: []
+  # -- Enable outbound isolation.
+  egressIsolation: true
+  # -- Allow DNS and public HTTPS for Hub/CDN artifacts in hub mode; ignored in local mode.
+  allowHubDownloads: true
+  # -- Additional explicit egress rules, for example a managed telemetry collector.
+  extraEgress: []
+# -- Dedicated tokenless workload identity.
+serviceAccount:
+  # -- Create the workload ServiceAccount.
+  create: true
+  # -- Existing or overridden ServiceAccount name.
+  name: ''
+  # -- ServiceAccount annotations.
+  annotations: {}
+  # -- Mount a Kubernetes API token; false is the secure default.
+  automountServiceAccountToken: false
+# -- Pod identity and cache volume ownership; default UID/GID/fsGroup 1000.
+podSecurityContext:
+  # -- Require a non-root process.
+  runAsNonRoot: true
+  # -- Numeric process UID.
+  runAsUser: 1000
+  # -- Numeric process group.
+  runAsGroup: 1000
+  # -- Group owning writable mounted volumes.
+  fsGroup: 1000
+  # -- Volume ownership reconciliation policy.
+  fsGroupChangePolicy: OnRootMismatch
+  # -- Pod seccomp configuration.
+  seccompProfile:
+    # -- Seccomp profile type applied to the Pod.
+    type: RuntimeDefault
+# -- Native and proxy container hardening.
+securityContext:
+  # -- Allow process privilege escalation.
+  allowPrivilegeEscalation: false
+  # -- Mount the image filesystem read-only.
+  readOnlyRootFilesystem: true
+  # -- Linux capability policy.
+  capabilities:
+    # -- Capabilities removed from the container.
+    drop:
+      - ALL
+# -- Native TEI CPU/memory budget; each replica loads a complete model.
+resources:
+  # -- Resources reserved by the scheduler.
+  requests:
+    # -- Kubernetes CPU quantity.
+    cpu: 500m
+    # -- Kubernetes memory quantity.
+    memory: 512Mi
+  # -- Maximum container resources.
+  limits:
+    # -- Kubernetes CPU quantity.
+    cpu: '2'
+    # -- Kubernetes memory quantity.
+    memory: 2Gi
+# -- Native loopback /health probes; startup budget includes download and warmup.
+probes:
+  # -- Native startup health budget; period, timeout and threshold also govern proxy startup.
+  startup:
+    # -- Enable this native health probe.
+    enabled: true
+    # -- Seconds between health probes.
+    periodSeconds: 5
+    # -- Maximum health probe duration.
+    timeoutSeconds: 3
+    # -- Consecutive failures before the probe action.
+    failureThreshold: 120
+  # -- Native model readiness; proxy readiness independently checks the public health path.
+  readiness:
+    # -- Enable this native health probe.
+    enabled: true
+    # -- Seconds between health probes.
+    periodSeconds: 10
+    # -- Maximum health probe duration.
+    timeoutSeconds: 3
+    # -- Consecutive failures before the probe action.
+    failureThreshold: 3
+  # -- Native model health restart policy; proxy liveness independently checks its TCP listener.
+  liveness:
+    # -- Enable this native health probe.
+    enabled: true
+    # -- Seconds between health probes.
+    periodSeconds: 30
+    # -- Maximum health probe duration.
+    timeoutSeconds: 3
+    # -- Consecutive failures before the probe action.
+    failureThreshold: 3
+# -- Use Recreate to avoid mixed model versions; RollingUpdate requires compatible model identity and spare capacity.
+rollout:
+  # -- Recreate or RollingUpdate; persistent RWO cache requires Recreate.
+  strategy: Recreate
+  # -- Extra Pods during RollingUpdate; a GPU surge needs spare GPUs.
+  maxSurge: 1
+  # -- Maximum unavailable Pods during RollingUpdate.
+  maxUnavailable: 0
+# -- Graceful native shutdown budget; requests are not durably queued.
+terminationGracePeriodSeconds: 150
+# -- CPU ContainerResource HPA; not a GPU utilization signal.
+autoscaling:
+  # -- Scale independent CPU replicas; requires ephemeral cache and CPU requests.
+  enabled: false
+  # -- Minimum replicas; at least two when a PDB is enabled.
+  minReplicas: 2
+  # -- Maximum replicas; reserve model RAM for every Pod.
+  maxReplicas: 4
+  # -- TEI container CPU target, excluding proxy consumption.
+  targetCPUUtilizationPercentage: 70
+# -- Protection against voluntary evictions; does not make a singleton highly available.
+podDisruptionBudget:
+  # -- Render a PDB only for at least two minimum replicas.
+  enabled: false
+  # -- Replicas allowed to be unavailable during voluntary eviction.
+  maxUnavailable: 1
+# -- Placement labels; pinned TEI 1.9.3 images support linux/amd64 only.
+nodeSelector:
+  # -- Required node architecture for the pinned CPU and CUDA images.
+  kubernetes.io/arch: amd64
+# -- Tolerations for dedicated inference or GPU nodes.
+tolerations: []
+# -- Pod/node affinity; spread independent replicas across failure domains.
+affinity: {}
+# -- Kubernetes topology spread constraints.
+topologySpreadConstraints: []
+# -- Optional scheduling priority class.
+priorityClassName: ''
+# -- Additional Pod labels; selector labels cannot be overridden.
+podLabels: {}
+# -- Additional Pod annotations; use a rotation annotation to restart after external Secret changes.
+podAnnotations: {}
+# -- Additional non-reserved native environment variables; credentials, binding and log safety are chart-owned.
+extraEnv: []


### PR DESCRIPTION
Add a maintained chart for the official Hugging Face Text Embeddings Inference HTTP server. A default installation serves real BGE embeddings behind native bearer authentication, with both image and model revision pinned.

The chart keeps native inference on loopback behind unprivileged NGINX, blocks public metrics/Swagger paths, and offers a separate native metrics Service with explicit network peers, ServiceMonitor and PrometheusRule. API credentials are generated and retained during live Helm upgrades or supplied through existing/ESO Secrets. Native logging is fixed at WARN because this upstream version logs API credentials at INFO.

Model delivery supports immutable Hub revisions, single-replica persistent cache, or a complete read-only local-model PVC with all workload egress denied. Independent CPU replicas support container CPU HPA, disruption budgets and compatible-model rolling updates. Ingress, canonical HTTPRoute, explicit opt-in IPv6/dual-stack Services and a pinned CUDA resource example are included. The chart rejects CPU backend batch limits that upstream silently overrides.

Validation:

- `make validate-chart CHART=text-embeddings-inference CONTEXT=k3d-helmforge-tests-wsl TIMEOUT=600`: all static layers and 13 sequential runtime scenarios.
- 59 Helm unit tests and seven rendered examples.
- Native model/revision and actual admission settings, finite normalized 384-dimensional semantic vectors, OpenAI equivalence, rejected credentials/inputs/batches/payloads, preserved credentials after Helm upgrade and Pod replacement.
- Real native Prometheus scrape after successful inference and evaluation of the missing-target alert expression, denied unrelated metrics peer, local offline inference plus a denied egress connection and a successful unrestricted control, persistent-cache marker retention, replicated model output and real container CPU HPA metrics.
- Pod/container logs and events reviewed; model warmup health failures and initial HPA metric unavailability are transient and resolved on healthy workloads. No unexpected container restarts.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 98.48485%, no suppressed controls. C-0012 matches the numeric MAX_BATCH_TOKENS/TOKENIZATION_WORKERS names; API/Hub credentials use Secret references.
- Standards, template standards, Markdown, release/attribution, site sync and organization parity checks.

GPU manifests are statically validated; GPU inference/performance and alternative model families need their own hardware/model acceptance tests. Model-contract changes require deliberate vector-index migration. There is no application database or vector-index backup job.

Site PR: helmforgedev/site#559
Organization catalog PR: helmforgedev/.github#24

Resolves #1182

