### PR TITLE
feat(hermes-agent)!: add production hermes agent chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What HelmForge Provides
 
-HelmForge is a catalog of 112 Helm charts built around a consistent operating contract:
+HelmForge is a catalog of 113 Helm charts built around a consistent operating contract:
 official upstream images, pinned versions, explicit values, reproducible validation, and signed releases.
 
 Use HelmForge when you want charts that stay close to upstream applications while still behaving like a

--- a/charts/hermes-agent/.helmignore
+++ b/charts/hermes-agent/.helmignore
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+.git
+*.tgz
+Chart.lock
+scripts/

--- a/charts/hermes-agent/Chart.yaml
+++ b/charts/hermes-agent/Chart.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: hermes-agent
+description: Persistent Hermes Agent gateway with authenticated API, controlled configuration, native telemetry and recoverable state.
+type: application
+version: 0.1.0
+appVersion: 2026.9.11
+kubeVersion: '>=1.30.0-0'
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - hermes-agent
+  - ai
+  - automation
+  - kubernetes
+home: https://helmforge.dev/docs/charts/hermes-agent
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/hermes-agent
+  - https://github.com/NousResearch/hermes-agent
+icon: https://helmforge.dev/icons/charts/hermes-agent.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Add a persistent Hermes Agent gateway with production lifecycle controls"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/hermes-agent
+    - name: Upstream
+      url: https://github.com/NousResearch/hermes-agent

--- a/charts/hermes-agent/DESIGN.md
+++ b/charts/hermes-agent/DESIGN.md
@@ -1,0 +1,72 @@
+# Hermes Agent design
+
+## One trusted agent per release
+
+Hermes combines an agent loop, persistent memory, learned skills, SQLite session history, scheduled work, messaging adapters and an OpenAI-compatible API. These
+capabilities share one state directory and execution identity. The chart deploys one StatefulSet replica and one retained PVC; adding replicas would create
+competing gateway writers. Kubernetes reschedules the singleton, with downtime. This is not an HA or multi-tenant isolation design.
+
+Use separate releases, Secrets, storage and network policies for mutually untrusted agents. API credentials permit the selected tools. The optional dashboard
+has full administrative access to the same state and process namespace. The default API toolset contains only memory; enabling terminal, browser, MCP or other
+tools expands that trust boundary.
+
+## Official image and immutable execution
+
+The chart pins the official Nous Research multi-platform image by release and manifest digest. The tested release is v2026.9.11; its internal Python version
+string is 0.21.2. Linux amd64 was exercised in k3d; an arm64 manifest is present but was not runtime-tested here.
+
+The image's standard s6 startup performs root-only initialization. Kubernetes instead starts the official gateway/dashboard foreground commands as UID/GID 10000
+with a read-only root filesystem and all capabilities dropped. A configure init container creates state directories, reconciles declared files and synchronizes
+the image's bundled skills. A small exec-only entrypoint discovers the bundled Chromium binary without downloading anything. Runtime lazy installation is
+disabled.
+
+The Pod shares its process namespace so the Kubernetes sandbox process reaps orphaned children and the dashboard can observe the gateway PID. No host PID
+namespace, host Docker socket, default API token, ClusterRole or privileged container is used. The collector has no agent-state mount; the backup uploader has
+only completed archive staging.
+
+## Configuration and identity lifecycle
+
+`config.policy=managed` reconciles config.yaml at every Pod initialization. `seed` writes it only when absent and is required for dashboard editing. SOUL.md is
+chart-managed only when `config.soul` is nonempty; an empty value leaves an existing persona untouched. Seed mode also preserves existing provider, monitoring
+and platform configuration: changing values alone does not replace the seeded file. Choose a deliberate maintenance migration back to managed mode when needed.
+
+Generated API credentials use live Helm lookup and are retained with the PVC. Render-only GitOps controllers should supply an existing Secret or ESO-generated
+Secret; random render output is not a stable identity. Secret changes do not automatically restart environment consumers. Roll the StatefulSet after credential
+rotation. Secret names, keys and chart-created retention are explicit contracts.
+
+## Connectivity and health
+
+The API listens on container port 8642. Ingress and HTTPRoute target its Service; dashboard administration uses a separate private Service on 9119. Network
+policies select container ports independently of user-facing Service ports. Inbound API, dashboard and metrics peers are separate allowlists. Public HTTPS
+egress is available by default; private provider/MCP/S3 endpoints require explicit extra rules. The chart does not provide DNS-name-aware egress filtering.
+
+Liveness uses inexpensive public process health. Readiness parses authenticated `/health/detailed`: upstream can return HTTP 200 while reporting degraded
+readiness. A healthy gateway is not proof that a paid model credential has quota or that an external messaging platform is reachable.
+
+## Observability and recovery
+
+Hermes exports native gateway-health metrics through OTLP. An optional official collector accepts OTLP only on loopback and exposes Prometheus metrics through a
+restricted Service. ServiceMonitor and PrometheusRule integrate with an existing Prometheus Operator. These are native gateway/scheduler metrics, not inferred
+token costs or request accounting.
+
+Backups use the pinned native exclusion policy, backup lock and SQLite online backup helper inside a stricter archive pipeline. Missing files, unreadable data
+and failed database snapshots prevent success. Checksums cover every member and the complete ZIP. The uploader reads the remote archive back and compares its
+bytes before publishing the completion manifest. The consistency boundary is each SQLite database; ordinary files and separate databases are not captured in one
+global transaction.
+
+Recovery validates an archive in staging before copying to an empty volume. A persistent incomplete marker prevents gateway startup after interrupted
+publication. A completion marker makes later Pod restarts idempotent. Importing upstream backup code has initialization side effects, so recovery uses a
+temporary HERMES_HOME and a separate target path. It never invokes native service-revival or overwrite import commands.
+
+## Comparison and implementation provenance
+
+The community chart at <https://github.com/ultraworkers/hermes-agent-helm-chart> already offers useful non-root security, API authentication, ESO and network
+isolation. This implementation was written independently using HelmForge conventions. It adds a verified current image, explicit configuration ownership,
+retained identity/state, semantic readiness, native telemetry and tested S3 disaster recovery. No unsupported operator or multi-tenant CRDs are installed.
+
+## Validation scope
+
+The chart-owned runtime harness drives the real Hermes agent and memory tool using a deterministic local OpenAI-compatible provider. It checks authentication,
+network isolation, state survival, metrics, dashboard login, ESO and S3 recovery in the relevant profiles. This validates integration mechanics without paid API
+calls or messages to real users. Cloud provider credentials, live Telegram/Discord/Slack delivery, remote SSH services and OIDC identity providers still require
+environment-specific acceptance.

--- a/charts/hermes-agent/README.md
+++ b/charts/hermes-agent/README.md
@@ -86,6 +86,7 @@ All default values are listed below; upstream pass-through configuration remains
 | `agent.toolsets` | `["memory"]` | API toolsets. Memory-only by default; enabling terminal/browser grants additional capabilities. |
 | `agent.maxIterations` | `30` | Maximum tool execution turns for one agent request. |
 | `agent.apiKeyEnv` | `""` | Credential environment variable for a named custom provider; never an inline API key. |
+| `agent.allowInsecureHTTP` | `false` | Explicit HTTP exception for credentialed custom endpoints in isolated tests or trusted networks. |
 | `config` | Object | Non-secret upstream configuration with explicit ownership on Pod initialization. |
 | `config.policy` | `"managed"` | managed reconciles declared files; seed preserves existing files and permits dashboard edits. |
 | `config.values` | `{}` | Additional upstream configuration. Do not place credentials here; chart-owned sections are validated. |

--- a/charts/hermes-agent/README.md
+++ b/charts/hermes-agent/README.md
@@ -1,0 +1,245 @@
+# Hermes Agent
+
+Deploy [Hermes Agent](https://hermes-agent.nousresearch.com/) as a persistent, authenticated agent gateway using the official Nous Research image. One release
+owns its sessions, memory, learned skills, schedules and workspace.
+
+## Features
+
+- Verified official release and immutable multi-platform image digest.
+- Singleton StatefulSet, retained data and API identity, non-root execution and read-only installation.
+- Authenticated OpenAI-compatible API, explicit toolsets and messaging user allowlists.
+- Managed or seed-once configuration, bundled skills and optional privileged dashboard with separate authentication.
+- Existing Secrets and canonical External Secrets Operator integration.
+- Default-deny inbound networking, Ingress, Gateway API and explicit dual-stack API and dashboard support.
+- Native OTLP gateway metrics, optional official collector, ServiceMonitor and PrometheusRule.
+- Scheduled S3 backups with SQLite snapshots, file inventories, remote byte verification and empty-volume-only recovery.
+
+## Install
+
+Create a provider Secret from an environment file that is not committed to Git. For the default OpenRouter provider, include OPENROUTER_API_KEY. Select another
+model/provider in values as needed.
+
+```bash
+kubectl create namespace agents
+kubectl -n agents create secret generic hermes-provider --from-env-file=provider.env
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm upgrade --install hermes helmforge/hermes-agent --namespace agents \
+  --set credentials.existingSecret=hermes-provider
+```
+
+OCI distribution is also available at `oci://ghcr.io/helmforgedev/helm/hermes-agent`. Kubernetes 1.30 or newer and a suitable StorageClass are required. The
+default gateway requests 1Gi memory; increase it for browser, terminal, MCP and concurrent work. An arm64 image manifest exists; the local runtime evidence is
+Linux amd64.
+
+The generated API Secret is `<fullname>-auth`, key `api-key`. Supply `auth.existingSecret` for stable render-only GitOps identity. A Ready Pod confirms gateway
+health, not provider billing/quota or external platform access.
+
+## Connect
+
+```bash
+kubectl -n agents port-forward service/hermes-hermes-agent 8642:8642
+```
+
+Use an OpenAI-compatible client with base URL `http://127.0.0.1:8642/v1` and the API bearer token. API credentials authorize the selected agent tools. For
+in-cluster clients, configure `networkPolicy.ingressFrom`; for external clients, terminate TLS at a trusted ingress/Gateway controller. Default toolsets permit
+memory only.
+
+## Production boundaries
+
+This chart runs one trusted agent, with one gateway writer. There is no horizontal scaling or transparent HA; upgrades and node replacement cause downtime.
+Separate untrusted agents into separate releases and credentials. The optional dashboard is a full administrative surface in the same trust boundary. No default
+host socket, privileged container or Kubernetes API token is granted.
+
+The chart-owned acceptance fixture drives real Hermes inference orchestration and tool calls without paid external requests. Cloud credentials, live messaging,
+remote execution and OIDC providers still require environment-specific acceptance. See the operational guides below before enabling additional tools.
+
+## Operational guides
+
+- [Design and trust boundaries](DESIGN.md)
+- [Providers, dashboard, messaging and upgrades](docs/operations.md)
+- [Backup and disaster recovery](docs/backup-restore.md)
+- [Native observability](docs/observability.md)
+
+## Values reference
+
+All default values are listed below; upstream pass-through configuration remains under `config.values`.
+
+| Value | Default | Purpose |
+| --- | --- | --- |
+| `nameOverride` | `""` | Override the chart name used in resource labels. |
+| `fullnameOverride` | `""` | Override all resource name prefixes for a stable existing installation. |
+| `image` | Object | Official Hermes runtime, pinned to a verified multi-platform release digest. |
+| `image.repository` | `"docker.io/nousresearch/hermes-agent"` | Official container image repository. |
+| `image.tag` | `"v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1"` | Pinned release tag and immutable digest. |
+| `image.pullPolicy` | `"IfNotPresent"` | Kubernetes image pull policy. |
+| `imagePullSecrets` | `[]` | image pull secrets setting for the gateway. |
+| `auth` | Object | Bearer credential protecting API access and configured agent tools. |
+| `auth.existingSecret` | `""` | Use an existing Secret; empty generates a random token retained with persistent state. |
+| `auth.key` | `"api-key"` | Secret key containing the API bearer token. |
+| `credentials` | Object | Provider and messaging credentials are injected only from a Kubernetes Secret. |
+| `credentials.existingSecret` | `""` | Secret containing upstream environment variables such as OPENROUTER_API_KEY. |
+| `agent` | Object | Default model and explicitly allowed API toolsets. |
+| `agent.model` | `"anthropic/claude-opus-4.6"` | Upstream model identifier; a corresponding provider credential is required for inference. |
+| `agent.provider` | `"openrouter"` | Provider identifier, including custom:<name> for an OpenAI-compatible endpoint. |
+| `agent.baseUrl` | `""` | Optional model endpoint; custom providers should use apiKeyEnv for credential selection. |
+| `agent.toolsets` | `["memory"]` | API toolsets. Memory-only by default; enabling terminal/browser grants additional capabilities. |
+| `agent.maxIterations` | `30` | Maximum tool execution turns for one agent request. |
+| `agent.apiKeyEnv` | `""` | Credential environment variable for a named custom provider; never an inline API key. |
+| `config` | Object | Non-secret upstream configuration with explicit ownership on Pod initialization. |
+| `config.policy` | `"managed"` | managed reconciles declared files; seed preserves existing files and permits dashboard edits. |
+| `config.values` | `{}` | Additional upstream configuration. Do not place credentials here; chart-owned sections are validated. |
+| `config.soul` | `""` | Optional SOUL.md persona. Empty leaves upstream/user persona unmanaged. |
+| `persistence` | Object | One retained state volume per release; no concurrent gateway writers. |
+| `persistence.enabled` | `true` | Persist sessions, SQLite state, memory, skills and workspace. |
+| `persistence.existingClaim` | `""` | Existing persistent claim to mount instead of creating one. |
+| `persistence.storageClass` | `""` | StorageClass name; empty uses the cluster default. |
+| `persistence.accessModes` | `["ReadWriteOnce"]` | Claim access modes; shared backup mounts require RWO or RWX. |
+| `persistence.size` | `"10Gi"` | Requested persistent volume capacity. |
+| `persistence.retain` | `true` | Keep chart-created PVC and generated API Secret after uninstall. |
+| `service` | Object | service setting for the gateway. |
+| `service.type` | `"ClusterIP"` | type setting for service. |
+| `service.port` | `8642` | Service port; network policies use the fixed container port. |
+| `service.annotations` | `{}` | Additional Kubernetes annotations. |
+| `service.ipFamilyPolicy` | `""` | ip family policy setting for service. |
+| `service.ipFamilies` | `[]` | ip families setting for service. |
+| `service.loadBalancerSourceRanges` | `[]` | load balancer source ranges setting for service. |
+| `serviceAccount` | Object | service account setting for the gateway. |
+| `serviceAccount.create` | `true` | create setting for serviceAccount. |
+| `serviceAccount.name` | `""` | Existing or overridden Kubernetes resource name. |
+| `serviceAccount.annotations` | `{}` | Additional Kubernetes annotations. |
+| `resources` | Object | Container CPU and memory requests and limits. |
+| `resources.requests` | Object | Guaranteed scheduler resource requests. |
+| `resources.requests.cpu` | `"250m"` | CPU quantity. |
+| `resources.requests.memory` | `"1Gi"` | Memory quantity. |
+| `resources.limits` | Object | Enforced container resource limits. |
+| `resources.limits.cpu` | `"2"` | CPU quantity. |
+| `resources.limits.memory` | `"2Gi"` | Memory quantity. |
+| `nodeSelector` | Object | node selector setting for the gateway. |
+| `nodeSelector.kubernetes.io/os` | `"linux"` | See the values contract. |
+| `tolerations` | `[]` | tolerations setting for the gateway. |
+| `affinity` | `{}` | affinity setting for the gateway. |
+| `podAnnotations` | `{}` | pod annotations setting for the gateway. |
+| `extraEnv` | `[]` | extra env setting for the gateway. |
+| `networkPolicy` | Object | Default-deny ingress with separate API, dashboard and metrics peer allowlists. |
+| `networkPolicy.enabled` | `true` | Enable this optional integration. |
+| `networkPolicy.ingressFrom` | `[]` | Kubernetes NetworkPolicy peers allowed to call container port 8642. |
+| `networkPolicy.extraEgress` | `[]` | Explicit extra egress rules for custom providers, MCP servers or remote execution. |
+| `networkPolicy.allowInternet` | `true` | Allow public IPv4/IPv6 HTTPS egress for providers; private networks require extraEgress. |
+| `terminationGracePeriodSeconds` | `120` | Time for gateway shutdown and in-flight work before Kubernetes terminates the Pod. |
+| `channels` | Object | Opt-in messaging adapters; credentials come from credentials.existingSecret and user allowlists are required. |
+| `channels.telegram` | Object | telegram setting for channels. |
+| `channels.telegram.enabled` | `false` | Enable this optional integration. |
+| `channels.telegram.allowedUsers` | `[]` | Explicit upstream user IDs permitted to interact with this messaging adapter. |
+| `channels.telegram.toolsets` | `["memory"]` | Toolsets exposed to this messaging adapter. |
+| `channels.discord` | Object | discord setting for channels. |
+| `channels.discord.enabled` | `false` | Enable this optional integration. |
+| `channels.discord.allowedUsers` | `[]` | Explicit upstream user IDs permitted to interact with this messaging adapter. |
+| `channels.discord.toolsets` | `["memory"]` | Toolsets exposed to this messaging adapter. |
+| `channels.slack` | Object | slack setting for channels. |
+| `channels.slack.enabled` | `false` | Enable this optional integration. |
+| `channels.slack.allowedUsers` | `[]` | Explicit upstream user IDs permitted to interact with this messaging adapter. |
+| `channels.slack.toolsets` | `["memory"]` | Toolsets exposed to this messaging adapter. |
+| `dashboard` | Object | Optional privileged administration UI in the gateway Pod; requires config.policy=seed. |
+| `dashboard.enabled` | `false` | Enable this optional integration. |
+| `dashboard.existingSecret` | `""` | Secret with HERMES_DASHBOARD_BASIC_AUTH_USERNAME, HERMES_DASHBOARD_BASIC_AUTH_PASSWORD and HERMES_DASHBOARD_BASIC_AUTH_SECRET. |
+| `dashboard.publicUrl` | `""` | External HTTPS dashboard origin, used by Host validation and OAuth redirects. |
+| `dashboard.resources` | Object | Container CPU and memory requests and limits. |
+| `dashboard.resources.requests` | Object | Guaranteed scheduler resource requests. |
+| `dashboard.resources.requests.cpu` | `"100m"` | CPU quantity. |
+| `dashboard.resources.requests.memory` | `"256Mi"` | Memory quantity. |
+| `dashboard.resources.limits` | Object | Enforced container resource limits. |
+| `dashboard.resources.limits.cpu` | `"1"` | CPU quantity. |
+| `dashboard.resources.limits.memory` | `"1Gi"` | Memory quantity. |
+| `dashboard.service` | Object | service setting for dashboard. |
+| `dashboard.service.port` | `9119` | Service port; network policies use the fixed container port. |
+| `dashboard.service.annotations` | `{}` | Additional Kubernetes annotations. |
+| `dashboard.ingressFrom` | `[]` | NetworkPolicy peers allowed to reach the administrative dashboard on container port 9119. |
+| `ingress` | Object | Optional API ingress. TLS termination is the ingress controller responsibility. |
+| `ingress.enabled` | `false` | Enable this optional integration. |
+| `ingress.ingressClassName` | `""` | ingress class name setting for ingress. |
+| `ingress.annotations` | `{}` | Additional Kubernetes annotations. |
+| `ingress.hosts` | `[{"host":"hermes.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | hosts setting for ingress. |
+| `ingress.tls` | `[]` | tls setting for ingress. |
+| `gatewayAPI` | Object | Canonical Gateway API HTTPRoutes; backend defaults to the authenticated API Service. |
+| `gatewayAPI.enabled` | `false` | Enable this optional integration. |
+| `gatewayAPI.httpRoutes` | `[]` | http routes setting for gatewayAPI. |
+| `externalSecrets` | Object | Optional integration with an existing External Secrets Operator installation. |
+| `externalSecrets.enabled` | `false` | Enable this optional integration. |
+| `externalSecrets.refreshInterval` | `"1h"` | refresh interval setting for externalSecrets. |
+| `externalSecrets.items` | `[]` | items setting for externalSecrets. |
+| `metrics` | Object | Native Hermes gateway health metrics exported through OTLP; no synthetic inference/cost metrics. |
+| `metrics.enabled` | `false` | Enable native upstream OTLP gateway-health metrics. |
+| `metrics.intervalSeconds` | `15` | interval seconds setting for metrics. |
+| `metrics.externalEndpoint` | `""` | Full external OTLP HTTP metrics URL ending in /v1/metrics when the collector is disabled. |
+| `metrics.collector` | Object | Optional local official collector translating OTLP to Prometheus on port 8889. |
+| `metrics.collector.enabled` | `true` | Enable this optional integration. |
+| `metrics.collector.image` | Object | image setting for metrics.collector. |
+| `metrics.collector.image.repository` | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"` | Official container image repository. |
+| `metrics.collector.image.tag` | `"0.160.0@sha256:799dc6cf12c96192af37b5bdba804da8c10b3bc563b43cb90c3f3c58d9572ad6"` | Pinned release tag and immutable digest. |
+| `metrics.collector.image.pullPolicy` | `"IfNotPresent"` | Kubernetes image pull policy. |
+| `metrics.collector.resources` | Object | Container CPU and memory requests and limits. |
+| `metrics.collector.resources.requests` | Object | Guaranteed scheduler resource requests. |
+| `metrics.collector.resources.requests.cpu` | `"50m"` | CPU quantity. |
+| `metrics.collector.resources.requests.memory` | `"64Mi"` | Memory quantity. |
+| `metrics.collector.resources.limits` | Object | Enforced container resource limits. |
+| `metrics.collector.resources.limits.cpu` | `"500m"` | CPU quantity. |
+| `metrics.collector.resources.limits.memory` | `"256Mi"` | Memory quantity. |
+| `metrics.serviceMonitor` | Object | service monitor setting for metrics. |
+| `metrics.serviceMonitor.enabled` | `false` | Enable this optional integration. |
+| `metrics.serviceMonitor.labels` | `{}` | Additional Kubernetes labels. |
+| `metrics.serviceMonitor.interval` | `"30s"` | Prometheus scrape interval. |
+| `metrics.serviceMonitor.scrapeTimeout` | `"10s"` | Prometheus scrape timeout. |
+| `metrics.prometheusRule` | Object | prometheus rule setting for metrics. |
+| `metrics.prometheusRule.enabled` | `false` | Enable this optional integration. |
+| `metrics.prometheusRule.labels` | `{}` | Additional Kubernetes labels. |
+| `metrics.prometheusRule.additionalRules` | `[]` | additional rules setting for metrics.prometheusRule. |
+| `metrics.ingressFrom` | `[]` | NetworkPolicy peers allowed to scrape the private metrics Service. |
+| `backup` | Object | Scheduled SQLite-consistent native snapshots uploaded to S3 with a completion manifest. |
+| `backup.enabled` | `false` | Enable the backup CronJob; requires persistent storage and S3 configuration. |
+| `backup.schedule` | `"0 3 * * *"` | schedule setting for backup. |
+| `backup.timeZone` | `"Etc/UTC"` | time zone setting for backup. |
+| `backup.suspend` | `false` | suspend setting for backup. |
+| `backup.successfulJobsHistoryLimit` | `1` | successful jobs history limit setting for backup. |
+| `backup.failedJobsHistoryLimit` | `2` | failed jobs history limit setting for backup. |
+| `backup.activeDeadlineSeconds` | `1800` | active deadline seconds setting for backup. |
+| `backup.stagingSize` | `"10Gi"` | Ephemeral archive staging size; budget for the ZIP and temporary SQLite snapshots. |
+| `backup.resources` | Object | Container CPU and memory requests and limits. |
+| `backup.resources.requests` | Object | Guaranteed scheduler resource requests. |
+| `backup.resources.requests.cpu` | `"100m"` | CPU quantity. |
+| `backup.resources.requests.memory` | `"256Mi"` | Memory quantity. |
+| `backup.resources.limits` | Object | Enforced container resource limits. |
+| `backup.resources.limits.cpu` | `"1"` | CPU quantity. |
+| `backup.resources.limits.memory` | `"1Gi"` | Memory quantity. |
+| `backup.s3` | Object | s3 setting for backup. |
+| `backup.s3.bucket` | `""` | bucket setting for backup.s3. |
+| `backup.s3.prefix` | `"hermes-agent"` | prefix setting for backup.s3. |
+| `backup.s3.region` | `"us-east-1"` | region setting for backup.s3. |
+| `backup.s3.endpoint` | `""` | endpoint setting for backup.s3. |
+| `backup.s3.allowInsecureEndpoint` | `false` | Allow HTTP only for explicitly trusted local test/object-storage networks. |
+| `backup.s3.existingSecret` | `""` | Secret with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, optionally AWS_SESSION_TOKEN. |
+| `backup.s3.sse` | `"AES256"` | sse setting for backup.s3. |
+| `backup.s3.kmsKeyId` | `""` | kms key id setting for backup.s3. |
+| `backup.s3.caSecret` | `""` | Optional Secret containing ca.crt for a private HTTPS endpoint. |
+| `backup.image` | Object | image setting for backup. |
+| `backup.image.repository` | `"public.ecr.aws/aws-cli/aws-cli"` | Official container image repository. |
+| `backup.image.tag` | `"2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441"` | Pinned release tag and immutable digest. |
+| `backup.image.pullPolicy` | `"IfNotPresent"` | Kubernetes image pull policy. |
+| `backup.networkPolicy` | Object | network policy setting for backup. |
+| `backup.networkPolicy.extraEgress` | `[]` | Additional backup Pod egress, for example private object storage. |
+| `restore` | Object | Explicit disaster recovery into an empty volume before configuration initialization. |
+| `restore.enabled` | `false` | Restore exactly once into empty state; existing nonempty state is never overwritten. |
+| `restore.manifestKey` | `""` | Full S3 object key of the completed backup manifest; uses backup.s3 settings. |
+| `restore.maxArchiveBytes` | `10737418240` | Maximum downloaded archive size accepted in bytes. |
+| `restore.maxExpandedBytes` | `21474836480` | Maximum aggregate uncompressed archive bytes accepted during restore. |
+
+## Security Scan: hermes-agent
+
+| Framework | Score |
+| --- | --- |
+| MITRE + NSA + SOC2 | 99.393936% |
+
+Security posture acceptable. Scanned the production example with Kubescape v4.0.14.
+The remaining C-0012 finding identifies the literal Bearer authorization header in
+the readiness helper ConfigMap; the actual token is read from the Secret-backed
+process environment and is not embedded in the ConfigMap.

--- a/charts/hermes-agent/ci/agent-values.yaml
+++ b/charts/hermes-agent/ci/agent-values.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-agent-test
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+config:
+  values:
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/charts/hermes-agent/ci/agent-values.yaml
+++ b/charts/hermes-agent/ci/agent-values.yaml
@@ -5,6 +5,7 @@ agent:
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
   apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   values:
     model:

--- a/charts/hermes-agent/ci/backup-s3-values.yaml
+++ b/charts/hermes-agent/ci/backup-s3-values.yaml
@@ -4,13 +4,10 @@ agent:
   model: helmforge-fixture
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   values:
-    providers:
-      fixture:
-        base_url: http://hermes-provider:8080/v1
-        api_mode: chat_completions
-        key_env: OPENAI_API_KEY
     model:
       api_mode: chat_completions
     auxiliary:

--- a/charts/hermes-agent/ci/backup-s3-values.yaml
+++ b/charts/hermes-agent/ci/backup-s3-values.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-agent-test
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+config:
+  values:
+    providers:
+      fixture:
+        base_url: http://hermes-provider:8080/v1
+        api_mode: chat_completions
+        key_env: OPENAI_API_KEY
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    bucket: hermes-backups
+    existingSecret: hermes-s3-credentials
+    endpoint: https://hermes-s3:8333
+    caSecret: hermes-s3-ca
+    sse: ''
+  networkPolicy:
+    extraEgress:
+      - to:
+          - podSelector:
+              matchLabels:
+                app: hermes-s3
+                component: server
+        ports:
+          - protocol: TCP
+            port: 8333

--- a/charts/hermes-agent/ci/default-values.yaml
+++ b/charts/hermes-agent/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-default

--- a/charts/hermes-agent/ci/dual-stack-values.yaml
+++ b/charts/hermes-agent/ci/dual-stack-values.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-dual-stack
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+config:
+  policy: seed
+  values:
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+service:
+  port: 80
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+dashboard:
+  enabled: true
+  existingSecret: hermes-dashboard-fixture

--- a/charts/hermes-agent/ci/dual-stack-values.yaml
+++ b/charts/hermes-agent/ci/dual-stack-values.yaml
@@ -5,6 +5,7 @@ agent:
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
   apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   policy: seed
   values:

--- a/charts/hermes-agent/ci/external-secrets-values.yaml
+++ b/charts/hermes-agent/ci/external-secrets-values.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-eso
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+config:
+  values:
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+auth:
+  existingSecret: hermes-eso-auth
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: hermes-eso-auth
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        target:
+          template:
+            engineVersion: v2
+            data:
+              api-key: hermes-fixture-{{ .password }}-long-token
+        data:
+          - secretKey: password
+            remoteRef:
+              key: test/password

--- a/charts/hermes-agent/ci/external-secrets-values.yaml
+++ b/charts/hermes-agent/ci/external-secrets-values.yaml
@@ -5,6 +5,7 @@ agent:
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
   apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   values:
     model:

--- a/charts/hermes-agent/ci/fixtures/agent-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/agent-values.yaml
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/charts/hermes-agent/ci/fixtures/backup-s3-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/backup-s3-values.yaml
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-s3-ca
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  ca.crt: "-----BEGIN CERTIFICATE-----\r\nMIIDSTCCAjGgAwIBAgIUF7H2GCK3bP8v3spbLcFDEp7weVYwDQYJKoZIhvcNAQEL\r\nBQAwFDESMBAGA1UEAwwJaGVybWVzLXMzMB4XDTI2MDkxMTIwNTIzOFoXDTM2MDkw\r\nODIwNTIzOFowFDESMBAGA1UEAwwJaGVybWVzLXMzMIIBIjANBgkqhkiG9w0BAQEF\r\nAAOCAQ8AMIIBCgKCAQEAsF00lCtHOhGmq4BenzIE545M1AawaCugoa61bTyfeKkw\r\nrM7HXmoqcd/AxX0YCtl/XxeNiAKpzMITPuHzN+qLH7YqO5gV+Le1Yq12VkIc36BP\r\nYtOP+SxwyUKShoTV4ATBhYLLAyjqssvsa6jP4HX8dt/4KoDCUtexgA9Iilj5MvqR\r\noZ7CHTXuw/NdR7qdYJ/MGraIEu9NBrNuNzZi1z/4uBpebQtjgO9Kc7kuzwVlG4FH\r\ndW2GvsD/rGcjTkD1v0MH5v9GraxUgEGncZMc6I6xM6iNfrdXhdYXA5TBit+A9x9r\r\nZhEDlKSCnTIL4m4I2g6aZ+YM7zdPaljwiGc6Q/TB6QIDAQABo4GSMIGPMB0GA1Ud\r\nDgQWBBS/iMSid3DxXR0NJkAjHisyYlBG6DAfBgNVHSMEGDAWgBS/iMSid3DxXR0N\r\nJkAjHisyYlBG6DA8BgNVHREENTAzggloZXJtZXMtczOCJmhlcm1lcy1zMy5oZi12\r\nYWxpZGF0ZS1oZXJtZXMtYWdlbnQuc3ZjMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI\r\nhvcNAQELBQADggEBAGYU4aghnVx9/2SHjTXJ6sAN4ISiZYEmCQGDkkkLc0lUK3Au\r\ngW+ctz642g2W4wf4MN+jOXgp2MGWSrVVd74FBOGzBjnzBYXSbsm+ccgaY7Om9+ns\r\nIZN5880uMP+n8jql+pNYUpTyPDz7aNoZUFgjCCmaBNtW5IlltAAaCzSkSdFFPUi6\r\npWpmyLmptbBcmXu3IeBZAtgGHToBvFzSXcqHX2RRz1t0fJy94XZKv4OvQ0W5qf3l\r\nIqS1Y+vps30Z3k195JG0DnquzkPUyaoOqJ+aHuAx24lXD7IpbmbtAf2N1DDxAHrQ\r\n520nHRRC5GdgrGZXnscrRj0VjuXPpAN3NwAKVbo=\r\n-----END CERTIFICATE-----\r\n"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-s3-tls
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: kubernetes.io/tls
+stringData:
+  tls.crt: "-----BEGIN CERTIFICATE-----\r\nMIIDSTCCAjGgAwIBAgIUF7H2GCK3bP8v3spbLcFDEp7weVYwDQYJKoZIhvcNAQEL\r\nBQAwFDESMBAGA1UEAwwJaGVybWVzLXMzMB4XDTI2MDkxMTIwNTIzOFoXDTM2MDkw\r\nODIwNTIzOFowFDESMBAGA1UEAwwJaGVybWVzLXMzMIIBIjANBgkqhkiG9w0BAQEF\r\nAAOCAQ8AMIIBCgKCAQEAsF00lCtHOhGmq4BenzIE545M1AawaCugoa61bTyfeKkw\r\nrM7HXmoqcd/AxX0YCtl/XxeNiAKpzMITPuHzN+qLH7YqO5gV+Le1Yq12VkIc36BP\r\nYtOP+SxwyUKShoTV4ATBhYLLAyjqssvsa6jP4HX8dt/4KoDCUtexgA9Iilj5MvqR\r\noZ7CHTXuw/NdR7qdYJ/MGraIEu9NBrNuNzZi1z/4uBpebQtjgO9Kc7kuzwVlG4FH\r\ndW2GvsD/rGcjTkD1v0MH5v9GraxUgEGncZMc6I6xM6iNfrdXhdYXA5TBit+A9x9r\r\nZhEDlKSCnTIL4m4I2g6aZ+YM7zdPaljwiGc6Q/TB6QIDAQABo4GSMIGPMB0GA1Ud\r\nDgQWBBS/iMSid3DxXR0NJkAjHisyYlBG6DAfBgNVHSMEGDAWgBS/iMSid3DxXR0N\r\nJkAjHisyYlBG6DA8BgNVHREENTAzggloZXJtZXMtczOCJmhlcm1lcy1zMy5oZi12\r\nYWxpZGF0ZS1oZXJtZXMtYWdlbnQuc3ZjMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI\r\nhvcNAQELBQADggEBAGYU4aghnVx9/2SHjTXJ6sAN4ISiZYEmCQGDkkkLc0lUK3Au\r\ngW+ctz642g2W4wf4MN+jOXgp2MGWSrVVd74FBOGzBjnzBYXSbsm+ccgaY7Om9+ns\r\nIZN5880uMP+n8jql+pNYUpTyPDz7aNoZUFgjCCmaBNtW5IlltAAaCzSkSdFFPUi6\r\npWpmyLmptbBcmXu3IeBZAtgGHToBvFzSXcqHX2RRz1t0fJy94XZKv4OvQ0W5qf3l\r\nIqS1Y+vps30Z3k195JG0DnquzkPUyaoOqJ+aHuAx24lXD7IpbmbtAf2N1DDxAHrQ\r\n520nHRRC5GdgrGZXnscrRj0VjuXPpAN3NwAKVbo=\r\n-----END CERTIFICATE-----\r\n"
+  tls.key: "-----BEGIN PRIVATE KEY-----\r\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCwXTSUK0c6Eaar\r\ngF6fMgTnjkzUBrBoK6ChrrVtPJ94qTCszsdeaipx38DFfRgK2X9fF42IAqnMwhM+\r\n4fM36osftio7mBX4t7VirXZWQhzfoE9i04/5LHDJQpKGhNXgBMGFgssDKOqyy+xr\r\nqM/gdfx23/gqgMJS17GAD0iKWPky+pGhnsIdNe7D811Hup1gn8watogS700Gs243\r\nNmLXP/i4Gl5tC2OA70pzuS7PBWUbgUd1bYa+wP+sZyNOQPW/Qwfm/0atrFSAQadx\r\nkxzojrEzqI1+t1eF1hcDlMGK34D3H2tmEQOUpIKdMgvibgjaDppn5gzvN09qWPCI\r\nZzpD9MHpAgMBAAECggEAD9/Nzx3fnv6Oes6Wxbu79QcqC2YQPAocPt1Ru3O602Kg\r\nLNe+WnVSHXaTPHtkXfqidDHTpYe+1p0r3Au8p35rGBc+kSdg5+aKMyfzmDNCc87z\r\nQk0SXw5U1wqw016SvSOUcyLZCM9mo6IHBVA4KMcZ6q3BYbr98rSzJ3iIshos0P2W\r\nGov8SzqrZ0F+QEdaPPSR38BrAi8jb5J6kiWAKZnIFvXIiKnjjLRrMnXqjYS+lg1n\r\nlq+AaZRuVoaYizrulJRKt+kqFidKHgu0xQ+3JzuiaDyCzFsgEofjmKdOy3CnirK5\r\n3k80YlKpkXiT+Jd4cCtDZs2RJPvpNTcqXtk5NtvGwQKBgQDm8+cA8CQOU26D/eTh\r\nd6CWbusJ6jORTwVc8/ko2ZHYbEiK1vZ2qy0+lLZNd80ckUpmCZ1MXvaj9Qixyb2R\r\nG8euemvXSP3Kr303gC3QgT4xGzzokbQpTn25/cMwD3xqrco18DP+jxziCYxebvpu\r\nLBrpsObWm88/rAHOB1TDn9kiQQKBgQDDfbiWCNFWhgm9KPpgqF6DjSHe8XyRSsl2\r\nMh71jv7orSrG0DCSQlM9LpqYENpraIK+w4tOvZot2KtCrq5VOfLYC6rof4jJWLxf\r\njG4+09+I0Y9znBKmTul5xw2Hyx9X6SlwXy3jlmxXCc2S4kxdmJX8PEpG5XBPRdnc\r\nx3LsgbnlqQKBgQCOUvIhlttxZKLvflBFTdZNvk7jzks3Ge5hKQx7yxBgweI2hWBf\r\nIv//1988gD6Lg1HI7dXc0YzG32MbRQqoWOlGMbUxd47HEDxnLnuNSYhM9M8lN11C\r\nM1exfZuCi5iNmUnK0ZsJHaKb/WxeaZ+0s0NmjhjDWkNupo56K/RllaVWwQKBgGlh\r\nXB+EoVQC7T0K2e1A1bIUYi3L/1pS9kbAve+hJchHkMebcpNlLXnNpYhTjWpY7CHp\r\nRy8rBfGw2qEXiOJoWoAbygWKujHPo7vd94/mppkaXjnz6Bm+cB01MBYDaOH6zlvE\r\n8ve8HqrMngSP+Jp7pl5SIbgV9nTFMqvQ2CKly5ABAoGAP2I1qSvJM9UdRjWRdEuk\r\n8arfSHxjCyyTOnuCfXvLNk7LYbWx3bJTTwRw6iXdfvTJatg1OlJKY45fTkQ9RU2E\r\nrXhevYOIEssVxSfwCEW4Z3ymQHQH/9YIswzbUpt8O4X0rJbfe466D7qFEg85LL4D\r\npuxyrXk3mHzPhBGMHXapyQY=\r\n-----END PRIVATE KEY-----\r\n"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-s3-credentials
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: hermes-ci-backup
+  AWS_SECRET_ACCESS_KEY: hermes-ci-backup-secret-never-production
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-s3-admin
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: hermes-ci-admin
+  AWS_SECRET_ACCESS_KEY: hermes-ci-admin-secret-never-production
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-s3-config
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  s3.json: >
+    {"identities":[{"name":"ci-admin","credentials":[{"accessKey":"hermes-ci-admin","secretKey":"hermes-ci-admin-secret-never-production"}],"actions":["Admin","Read","Write","List","Tagging"]},{"name":"ci-backup","credentials":[{"accessKey":"hermes-ci-backup","secretKey":"hermes-ci-backup-secret-never-production"}],"actions":["Read:hermes-backups","Write:hermes-backups","List:hermes-backups"]}]}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-s3
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-s3
+      component: server
+  template:
+    metadata:
+      labels:
+        app: hermes-s3
+        component: server
+        helmforge.dev/runtime-fixture: 'true'
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: seaweedfs
+          image: chrislusf/seaweedfs:4.46@sha256:08d516132314207d10c8e37cbffc1f32b147d870169688734cc61c6231625b62
+          command:
+            - weed
+          args:
+            - server
+            - '-dir=/data'
+            - '-ip=127.0.0.1'
+            - '-ip.bind=0.0.0.0'
+            - '-master.volumeSizeLimitMB=64'
+            - '-volume.max=4'
+            - '-filer'
+            - '-s3'
+            - '-s3.config=/config/s3.json'
+            - '-s3.cert.file=/tls/tls.crt'
+            - '-s3.key.file=/tls/tls.key'
+          workingDir: /data
+          ports:
+            - name: s3
+              containerPort: 8333
+          startupProbe:
+            tcpSocket:
+              port: s3
+            periodSeconds: 2
+            failureThreshold: 90
+          readinessProbe:
+            tcpSocket:
+              port: s3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              cpu: '1'
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: hermes-s3-config
+        - name: tls
+          secret:
+            secretName: hermes-s3-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-s3
+  labels:
+    app: hermes-s3
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-s3
+    component: server
+  ports:
+    - name: s3
+      port: 8333
+      targetPort: s3
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hermes-s3-create-bucket
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 240
+  template:
+    metadata:
+      labels:
+        app: hermes-s3
+        component: setup
+        helmforge.dev/runtime-fixture: 'true'
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-bucket
+          image: >-
+            public.ecr.aws/aws-cli/aws-cli:2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441
+          command:
+            - /bin/bash
+            - '-ec'
+          args:
+            - |
+              set -u
+              export AWS_MAX_ATTEMPTS=1
+              probe_key="helmforge-fixture-readiness/${HOSTNAME}.bin"
+              # One MiB exercises volume storage rather than only small inline filer metadata.
+              dd if=/dev/zero of=/tmp/probe.upload bs=1048576 count=1 status=none
+              expected="$(sha256sum /tmp/probe.upload)"; expected="${expected%% *}"
+              s3() {
+                aws --endpoint-url https://hermes-s3:8333 --cli-connect-timeout 2 --cli-read-timeout 3 s3api "$@"
+              }
+              for ((attempt=0; attempt<60 && SECONDS<180; attempt++)); do
+                if s3 head-bucket --bucket hermes-backups >/tmp/readiness-error 2>&1 ||
+                  s3 create-bucket --bucket hermes-backups >/tmp/readiness-error 2>&1; then
+                  if s3 put-object --bucket hermes-backups --key "$probe_key" --body /tmp/probe.upload >/tmp/readiness-error 2>&1 &&
+                    s3 get-object --bucket hermes-backups --key "$probe_key" /tmp/probe.download >/tmp/readiness-error 2>&1; then
+                    actual="$(sha256sum /tmp/probe.download)"; actual="${actual%% *}"
+                    if [[ "$actual" == "$expected" && "$(stat -c %s /tmp/probe.download)" == 1048576 ]] &&
+                      s3 delete-object --bucket hermes-backups --key "$probe_key" >/tmp/readiness-error 2>&1; then
+                      echo 'HTTPS S3 fixture passed real object upload, download, byte/hash verification and exact probe cleanup'
+                      exit 0
+                    fi
+                  fi
+                fi
+                sleep 2
+              done
+              echo 'HTTPS S3 fixture data path did not become ready within its bounded retry budget' >&2
+              cat /tmp/readiness-error >&2
+              exit 1
+          envFrom:
+            - secretRef:
+                name: hermes-s3-admin
+          env:
+            - name: AWS_DEFAULT_REGION
+              value: us-east-1
+            - name: AWS_CA_BUNDLE
+              value: /tls/ca.crt
+            - name: AWS_EC2_METADATA_DISABLED
+              value: 'true'
+            - name: AWS_PAGER
+              value: ''
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ca
+              mountPath: /tls
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: ca
+          secret:
+            secretName: hermes-s3-ca
+        - name: tmp
+          emptyDir: {}
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/charts/hermes-agent/ci/fixtures/dual-stack-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/dual-stack-values.yaml
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-dashboard-fixture
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  HERMES_DASHBOARD_BASIC_AUTH_USERNAME: helmforge-ci
+  HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: HermesFixtureOnly-NotForProduction
+  HERMES_DASHBOARD_BASIC_AUTH_SECRET: fixture-signing-secret-64-characters-not-for-production-use-in-ci

--- a/charts/hermes-agent/ci/fixtures/external-secrets-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/external-secrets-values.yaml
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/charts/hermes-agent/ci/fixtures/gateway-api-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/gateway-api-values.yaml
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/charts/hermes-agent/ci/fixtures/observability-values.yaml
+++ b/charts/hermes-agent/ci/fixtures/observability-values.yaml
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  provider.py: |
+    # SPDX-License-Identifier: Apache-2.0
+    """CI-only deterministic OpenAI provider; never writes Hermes application state.
+
+    Send HF_MEMORY_STORE to request the actual Hermes memory tool, HF_HISTORY_CHECK
+    to assert a previous HF_MEMORY_STORE user turn, HF_MEMORY_CHECK to assert memory
+    injected into a system/developer message, or HF_PING for a simple response.
+    GET /stats exposes only counters and bounded metadata, never request content.
+    """
+
+    import hashlib
+    import hmac
+    import json
+    import os
+    import threading
+    import time
+    from collections import Counter, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    MODEL = "helmforge-fixture"
+    MEMORY = "HF_HERMES_PERSISTENT_MEMORY"
+    MAX_BODY = 2 * 1024 * 1024
+    LOCK = threading.Lock()
+    COUNTS = Counter()
+    AUDIT = deque(maxlen=100)
+
+
+    def content_text(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(
+                item.get("text", "") for item in value
+                if isinstance(item, dict) and isinstance(item.get("text"), str)
+            )
+        return ""
+
+
+    def select_response(body):
+        """Return assistant message and safe audit; reject unsuccessful tool calls."""
+        messages = body.get("messages")
+        if body.get("model") != MODEL or not isinstance(messages, list):
+            raise ValueError("invalid_model_or_messages")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("invalid_message")
+        user_indexes = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indexes:
+            raise ValueError("missing_user")
+        last = user_indexes[-1]
+        text = content_text(messages[last].get("content"))
+        previous = [content_text(msg.get("content")) for msg in messages[:last] if msg.get("role") == "user"]
+        tools = body.get("tools") or []
+        has_memory = any(isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory" for tool in tools)
+        audit = {
+            "stream": body.get("stream") is True,
+            "message_count": len(messages),
+            "memory_tool_advertised": has_memory,
+            "prior_store_user": any("HF_MEMORY_STORE" in item for item in previous),
+            "system_memory": any(
+                msg.get("role") in ("system", "developer") and MEMORY in content_text(msg.get("content"))
+                for msg in messages
+            ),
+        }
+        mode = "plain"
+        reply = "HF_HERMES_OK"
+        if "HF_MEMORY_STORE" in text:
+            call_id = "call_hf_memory_" + hashlib.sha256(text.encode()).hexdigest()[:12]
+            results = [msg for msg in messages[last + 1:] if msg.get("role") == "tool" and msg.get("tool_call_id") == call_id]
+            if results:
+                try:
+                    result = json.loads(content_text(results[-1].get("content")))
+                except (TypeError, ValueError):
+                    raise ValueError("memory_result_invalid") from None
+                if not isinstance(result, dict) or result.get("success") is not True:
+                    raise ValueError("memory_result_unsuccessful")
+                mode, reply = "memory_result", "HF_MEMORY_STORED"
+            else:
+                if not has_memory:
+                    raise ValueError("memory_tool_not_advertised")
+                # Repeating a call without its matching result indicates an invalid
+                # protocol/dispatch path, not permission to enter a retry tool loop.
+                if any(call.get("id") == call_id for msg in messages[last + 1:] for call in (msg.get("tool_calls") or [])):
+                    raise ValueError("memory_result_missing")
+                audit["mode"] = "memory_call"
+                return {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": call_id, "type": "function", "function": {
+                        "name": "memory", "arguments": json.dumps({
+                            "action": "add", "target": "memory", "content": MEMORY,
+                        }, separators=(",", ":")),
+                    }}],
+                }, audit
+        elif "HF_HISTORY_CHECK" in text:
+            mode = "history"
+            if not audit["prior_store_user"]:
+                raise ValueError("history_not_restored")
+            reply = "HF_HISTORY_RESTORED"
+        elif "HF_MEMORY_CHECK" in text:
+            mode = "memory_read"
+            if not audit["system_memory"]:
+                raise ValueError("memory_not_loaded")
+            reply = "HF_MEMORY_RESTORED"
+        elif "HF_PING" in text:
+            mode, reply = "ping", "HF_PONG"
+        audit["mode"] = mode
+        return {"role": "assistant", "content": reply}, audit
+
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "HelmForgeCIFixture"
+
+        def setup(self):
+            super().setup()
+            self.connection.settimeout(20)
+
+        def log_message(self, *_args):
+            pass
+
+        def send_json(self, status, value):
+            data = json.dumps(value, separators=(",", ":")).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self):
+            key = os.environ.get("FIXTURE_API_KEY", "helmforge-ci-provider")
+            return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + key)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+            elif self.path == "/stats":
+                with LOCK:
+                    state = {"counts": dict(COUNTS), "audit": list(AUDIT)}
+                self.send_json(200, state)
+            elif self.path == "/v1/models":
+                if not self.authorized():
+                    self.send_json(401, {"error": {"message": "unauthorized"}})
+                    return
+                self.send_json(200, {"object": "list", "data": [{
+                    "id": MODEL, "object": "model", "created": 0, "owned_by": "helmforge-ci",
+                }]})
+            else:
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+
+        def do_POST(self):
+            self.close_connection = True
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "unknown_route"}})
+                return
+            if not self.authorized():
+                with LOCK:
+                    COUNTS["unauthorized"] += 1
+                self.send_json(401, {"error": {"message": "unauthorized"}})
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+                if not 0 < size <= MAX_BODY:
+                    raise ValueError("invalid_body_size")
+                raw = self.rfile.read(size)
+                if len(raw) != size:
+                    raise ValueError("incomplete_body")
+                body = json.loads(raw)
+                if not isinstance(body, dict):
+                    raise ValueError("invalid_body")
+                message, audit = select_response(body)
+            except (ValueError, TypeError, AttributeError, TimeoutError):
+                # Do not return exception text: parser messages may include payload.
+                with LOCK:
+                    COUNTS["rejected"] += 1
+                self.send_json(422, {"error": {"message": "fixture_contract_failed", "type": "invalid_request_error"}})
+                return
+            with LOCK:
+                COUNTS["requests"] += 1
+                COUNTS[audit["mode"]] += 1
+                COUNTS["stream" if audit["stream"] else "json"] += 1
+                AUDIT.append(audit)
+                sequence = COUNTS["requests"]
+            common = {"id": f"chatcmpl-hf-{sequence}", "created": int(time.time()), "model": MODEL}
+            finish = "tool_calls" if message.get("tool_calls") else "stop"
+            try:
+                if body.get("stream") is True:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    delta = dict(message)
+                    if delta.get("tool_calls"):
+                        delta["tool_calls"] = [dict(call, index=i) for i, call in enumerate(delta["tool_calls"])]
+                    for content, reason in ((delta, None), ({}, finish)):
+                        chunk = dict(common, object="chat.completion.chunk", choices=[{
+                            "index": 0, "delta": content, "finish_reason": reason,
+                        }])
+                        self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+                        self.wfile.flush()
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                else:
+                    self.send_json(200, dict(common, object="chat.completion", choices=[{
+                        "index": 0, "message": message, "finish_reason": finish,
+                    }], usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}))
+            except (BrokenPipeError, ConnectionResetError, TimeoutError):
+                with LOCK:
+                    COUNTS["client_disconnect"] += 1
+
+
+    if __name__ == "__main__":
+        bind = os.environ.get("FIXTURE_HOST", "0.0.0.0")
+        port = int(os.environ.get("FIXTURE_PORT", "8080"))
+        server = ThreadingHTTPServer((bind, port), Handler)
+        print(f"HelmForge CI provider listening on port {port}", flush=True)
+        server.serve_forever()
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-provider-credentials
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  OPENAI_API_KEY: helmforge-ci-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-provider
+  labels: &ref_0
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-provider
+  template:
+    metadata:
+      labels: *ref_0
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: docker.io/nousresearch/hermes-agent:v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+          command:
+            - /opt/hermes/.venv/bin/python
+            - /fixture/provider.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+      volumes:
+        - name: fixture
+          configMap:
+            name: hermes-provider
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-provider
+  labels:
+    app: hermes-provider
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: hermes-provider
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-dashboard-fixture
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+stringData:
+  HERMES_DASHBOARD_BASIC_AUTH_USERNAME: helmforge-ci
+  HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: HermesFixtureOnly-NotForProduction
+  HERMES_DASHBOARD_BASIC_AUTH_SECRET: fixture-signing-secret-64-characters-not-for-production-use-in-ci

--- a/charts/hermes-agent/ci/gateway-api-values.yaml
+++ b/charts/hermes-agent/ci/gateway-api-values.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-routes
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+config:
+  values:
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: hermes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: hermes-edge-tls
+      hosts:
+        - hermes.example.com
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: api
+      parentRefs:
+        - name: edge
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - hermes.example.com

--- a/charts/hermes-agent/ci/gateway-api-values.yaml
+++ b/charts/hermes-agent/ci/gateway-api-values.yaml
@@ -5,6 +5,7 @@ agent:
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
   apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   values:
     model:

--- a/charts/hermes-agent/ci/observability-values.yaml
+++ b/charts/hermes-agent/ci/observability-values.yaml
@@ -5,6 +5,7 @@ agent:
   provider: custom:fixture
   baseUrl: http://hermes-provider:8080/v1
   apiKeyEnv: OPENAI_API_KEY
+  allowInsecureHTTP: true
 config:
   values:
     model:

--- a/charts/hermes-agent/ci/observability-values.yaml
+++ b/charts/hermes-agent/ci/observability-values.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hermes-observability
+agent:
+  model: helmforge-fixture
+  provider: custom:fixture
+  baseUrl: http://hermes-provider:8080/v1
+  apiKeyEnv: OPENAI_API_KEY
+config:
+  values:
+    model:
+      api_mode: chat_completions
+    auxiliary:
+      free_only: true
+  policy: seed
+credentials:
+  existingSecret: hermes-provider-credentials
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: hermes-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+dashboard:
+  enabled: true
+  existingSecret: hermes-dashboard-fixture
+metrics:
+  enabled: true
+  intervalSeconds: 5
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true

--- a/charts/hermes-agent/docs/backup-restore.md
+++ b/charts/hermes-agent/docs/backup-restore.md
@@ -70,3 +70,7 @@ node disk.
 
 Verify an authenticated agent turn, old session history and memory in a fresh session before directing production traffic to the recovered release. The local
 acceptance suite performs this recovery against HTTPS S3-compatible storage and checks that a second Pod startup does not replay the restore.
+
+The snapshot walker opens every path component relative to a pinned directory descriptor with symlink following disabled. SQLite snapshots use a pinned file
+descriptor as their source while preserving native online backup and WAL semantics. Directory replacement is covered by a failure-injection test, and descriptor
+cleanup is checked on rejection.

--- a/charts/hermes-agent/docs/backup-restore.md
+++ b/charts/hermes-agent/docs/backup-restore.md
@@ -1,0 +1,72 @@
+# Backup and restore
+
+## Scheduled backups
+
+Enable `backup.enabled`, select the schedule/time zone and configure `backup.s3`. Use a dedicated bucket/prefix and an existing Secret with `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN`. AWS S3 uses the default endpoint; compatible storage accepts an HTTPS endpoint and optional
+`caSecret` containing `ca.crt`. TLS verification is never disabled. The HTTP opt-in exists for explicitly trusted test networks.
+
+The CronJob uses `concurrencyPolicy: Forbid`, no retry of a partially completed run and a bounded active deadline. A required same-node affinity permits a
+second Pod to mount a ReadWriteOnce volume. ReadWriteOncePod is rejected. The producer holds the native backup lock, creates SQLite online snapshots, checks
+full database integrity and builds an inventoried ZIP. The uploader cannot mount the agent PVC.
+
+Upload permissions need PutObject and GetObject for the dedicated prefix. The chart neither lists nor deletes backups. For SSE-KMS, grant the necessary KMS
+encryption/decryption permissions and configure the key ID. Bucket lifecycle controls retention and abandoned partial prefixes. The completed remote layout is:
+
+```text
+<prefix>/hermes-<UTC timestamp>-<random suffix>/backup.zip
+<prefix>/hermes-<UTC timestamp>-<random suffix>/manifest.json
+```
+
+The uploader streams the uploaded ZIP back through SHA-256 verification before writing `manifest.json`. An archive without its completion manifest is not a
+successful backup. Checksums detect corruption; they are not signatures against an authorized malicious bucket writer. Protect access and consider bucket
+versioning/immutability according to your retention requirements.
+
+## Consistency and scope
+
+SQLite snapshots use the native online backup API and include committed WAL state. Full integrity checks run without the native size-based shortcut. Files are
+captured as observed, with exact member hashes. Separate databases, config, cron definitions and workspace files are not captured in a single transaction.
+Quiesce agent work when your recovery point requires a stable cross-file application state.
+
+The backup follows the pinned native exclusion policy for regenerable caches, downloaded runtimes/models, dependencies, SQLite sidecars, nested backup artifacts
+and symlinks. The chart additionally excludes runtime PID/lock/status/process files, gateway control sockets and its own recovery markers. Unexpected special
+files, disappearing included files, unreadable files or failed SQLite snapshots fail the Job. Active file-set changes can require retrying during a quieter
+period.
+
+Included persistent data can contain config, `.env`, upstream authentication files, local vault encryption keys, profiles, memory, learned skills, sessions,
+cron and workspace contents. Treat the archive as sensitive as the live agent. Environment-only Kubernetes Secrets, mounted external credentials and remote
+memory/provider services need independent backup. The chart does not traverse arbitrary external paths or restore the native `_external/` namespace.
+
+## Recovery into a new volume
+
+Create a separate release/PVC and restore from the exact completed manifest key. Keep provider and other external Secrets available in the target namespace.
+Reuse the S3 connection settings even when scheduled backup is disabled:
+
+```yaml
+fullnameOverride: hermes-recovered
+credentials:
+  existingSecret: hermes-provider
+backup:
+  enabled: false
+  s3:
+    bucket: organization-agent-backups
+    existingSecret: hermes-recovery-s3
+restore:
+  enabled: true
+  manifestKey: hermes-agent/hermes-20260911T120000Z-0123456789abcdef/manifest.json
+```
+
+The prepare init container rejects nonempty state before downloading. Recovery checks the manifest/ZIP hashes, member inventory, paths, permissions, sizes and
+SQLite integrity in staging. Only a fully validated archive is copied to the empty target. The incomplete marker stays present until published files are
+reverified; a failed copy cannot start the agent.
+
+After success, the exact manifest key is recorded on the volume. Subsequent restarts skip downloading and preserve current state. Disable `restore.enabled`
+after recovery and verification. Changing the manifest key on an already populated volume is rejected; there is no force/overwrite mode. `config.policy=managed`
+then reconciles the new release's declared config, so explicitly choose the provider/model configuration you intend to run.
+
+Staging must hold the archive plus extracted files for restore, and the archive plus an individual database snapshot for backup. Size `backup.stagingSize`,
+`restore.maxArchiveBytes` and `restore.maxExpandedBytes` together. Staging is disk-backed emptyDir and consumes node ephemeral storage; monitor both the PVC and
+node disk.
+
+Verify an authenticated agent turn, old session history and memory in a fresh session before directing production traffic to the recovered release. The local
+acceptance suite performs this recovery against HTTPS S3-compatible storage and checks that a second Pod startup does not replay the restore.

--- a/charts/hermes-agent/docs/observability.md
+++ b/charts/hermes-agent/docs/observability.md
@@ -1,0 +1,23 @@
+# Observability
+
+Set `metrics.enabled=true` to enable native Hermes gateway-health OTLP export. The optional pinned OpenTelemetry collector runs in the same Pod, binds its OTLP
+HTTP receiver to loopback and publishes Prometheus exposition on port 8889. It does not mount the agent data or provider credentials.
+
+With `metrics.collector.enabled=false`, configure `metrics.externalEndpoint` as the complete OTLP HTTP metrics URL ending in `/v1/metrics`, and allow its
+network destination. The upstream exporter does not append that path automatically. The built-in ServiceMonitor/PrometheusRule require the local collector and
+an existing Prometheus Operator installation.
+
+Permit your Prometheus Pods using `metrics.ingressFrom`. Add the operator's selection labels through `metrics.serviceMonitor.labels` and
+`metrics.prometheusRule.labels`; installing a ServiceMonitor alone does not cause an unrelated Prometheus instance to select it. The native metric names
+normalize to names such as `hermes_gateway_up`, `hermes_gateway_active_agents`, `hermes_platform_up` and scheduler/job gauges.
+
+The bundled rules detect an unavailable gateway and absent native gateway metrics. A healthy collector scrape alone cannot prove that the gateway is exporting.
+Set additional environment-specific rules through `metrics.prometheusRule.additionalRules`. Job metrics from kube-state-metrics can alert on failed/stale backup
+completion; these are separate from Hermes telemetry.
+
+This integration does not fabricate token-cost, model quality, request-latency or billing metrics. Diagnostic and warning-event OTLP export remain disabled.
+Kubernetes logs and authenticated detailed health supplement native metrics, but may contain user activity; restrict log access and retention appropriately.
+
+Size memory for the gateway's concurrent work and enabled tools. Browser/terminal/MCP workloads can exceed the default budget. Monitor agent PVC capacity, node
+ephemeral storage, container restarts, provider rate limits and backup recovery time. The local k3d suite verifies actual OTLP-to-Prometheus values and
+configuration of operator resources; your production Prometheus selection and notification routing require deployment-specific checks.

--- a/charts/hermes-agent/docs/operations.md
+++ b/charts/hermes-agent/docs/operations.md
@@ -73,3 +73,17 @@ an explicit Secret migration.
 - Missing skills/browser binaries: inspect configure logs and the pinned official image; do not enable ad hoc dependency downloads to hide a broken image
   upgrade.
 - Restore refuses startup: preserve the incomplete volume for diagnosis and recover again into a new empty PVC. Do not bypass the incomplete marker.
+
+## Transport security and collector identity
+
+Credentialed custom endpoints require HTTPS by default. `agent.allowInsecureHTTP=true` is an explicit exception for isolated fixtures or a trusted private
+transport; never use it for public provider traffic. Advanced upstream provider configuration under `config.values` must follow the same transport policy.
+
+Public API and dashboard clients must use HTTPS at the trusted edge. The production example attaches only to a Gateway HTTPS listener. When using Ingress,
+configure its TLS Secret or an external TLS terminator, and configure that controller or load balancer to reject HTTP or redirect it before clients send
+credentials. A generic Ingress has no portable redirect field, so the chart does not inject controller-specific annotations or require a local TLS Secret when
+termination occurs upstream. Ingress stays disabled and inbound traffic denied by default.
+
+The gateway and administrative dashboard use UID 10000 in a shared PID namespace. The metrics collector uses UID/GID 10001 with all capabilities dropped; it
+cannot read the gateway's process environment. It has no state-volume or credential Secret mount. The production example budgets 120Gi of node staging for its
+50Gi persistent state and raises restore bounds accordingly; verify node ephemeral-storage capacity before scheduling backup or recovery.

--- a/charts/hermes-agent/docs/operations.md
+++ b/charts/hermes-agent/docs/operations.md
@@ -1,0 +1,75 @@
+# Operating Hermes Agent
+
+## Provider credentials
+
+Create a Secret from an environment file kept outside version control, then set `credentials.existingSecret`:
+
+```bash
+kubectl -n agents create secret generic hermes-provider --from-env-file=provider.env
+helm upgrade --install hermes helmforge/hermes-agent -n agents \
+  --set credentials.existingSecret=hermes-provider
+```
+
+For OpenRouter, the file contains `OPENROUTER_API_KEY`. For a custom OpenAI-compatible endpoint, use `agent.provider=custom:internal`, `agent.baseUrl` and
+`agent.apiKeyEnv` naming the environment variable in that Secret. The pinned upstream release intentionally does not forward generic OPENAI_API_KEY credentials
+to arbitrary hosts. Provider URL, model and credentials must agree.
+
+The API implements OpenAI-compatible chat completions and requires `Authorization: Bearer <API token>`. This API token is distinct from the provider key and
+dashboard credentials. Use `X-Hermes-Session-Id` for gateway-backed conversation continuity. A new session reloads persistent memory; existing sessions can
+retain their original system prompt.
+
+## Tool and messaging access
+
+Default `agent.toolsets: [memory]` avoids exposing terminal/browser execution through a newly installed API. Configure additional native toolsets only for
+trusted API users. Terminal tools using the local backend can read and modify the agent's data and environment. Remote SSH or other upstream execution backends
+can be configured under `config.values.terminal`; provision their authentication, host verification, network access and independent runtime tests before use.
+The chart does not claim a sandbox merely because it uses a container.
+
+Telegram requires `TELEGRAM_BOT_TOKEN`; Discord requires `DISCORD_BOT_TOKEN`; Slack Socket Mode requires `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`. Store them in
+`credentials.existingSecret`, enable the corresponding `channels` entry and declare its `allowedUsers`. Use platform user/member IDs, not display names. Each
+adapter has its own `toolsets`. Do not set allow-all variables in the credential Secret. The chart explicitly sets supported adapter allow-all flags to false
+and owns the configured user lists.
+
+The supported default transports are outbound polling/WebSocket/Socket Mode. No extra inbound Service is needed. Upstream plugins, other channels and external
+tools may need additional dependencies or network access; they are not all included in the chart's runtime acceptance matrix.
+
+## Dashboard administration
+
+Enable the dashboard with `config.policy=seed` and `dashboard.existingSecret`. For basic login, that Secret contains `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`,
+`HERMES_DASHBOARD_BASIC_AUTH_PASSWORD` and a stable, random `HERMES_DASHBOARD_BASIC_AUTH_SECRET` of at least 32 bytes. Upstream also accepts a password hash
+instead of plaintext. For public access, use HTTPS and the upstream OIDC provider variables in this Secret, with `dashboard.publicUrl` and bounded
+`config.values.dashboard.trusted_proxies`.
+
+The chart exposes the dashboard through a separate ClusterIP Service. Use a trusted tunnel or an explicit HTTPRoute backend reference to `<fullname>-dashboard`
+and `dashboard.service.port`; permit the controller through `dashboard.ingressFrom`. API ingress defaults never silently expose the administration UI. OIDC
+identity-provider integration is environment-specific; basic login and session-cookie authentication are exercised locally.
+
+Dashboard users are administrators of the same agent, not isolated tenants. Kubernetes owns lifecycle and image updates: use Helm rollouts instead of UI
+self-update or gateway start/restart controls. The read-only installation intentionally prevents runtime package modifications. Changes to an existing seed-mode
+config survive Helm upgrades; to reconcile declared config again, disable the dashboard, switch to managed policy for the rollout, then deliberately return to
+seed mode.
+
+## Upgrades, retention and credentials
+
+Take and restore-test a backup before changing the image tag/digest together. Inspect upstream release notes for SQLite/config migrations; a Helm image rollback
+cannot undo an incompatible data migration. One writer means a rollout or node drain interrupts service. Avoid a mandatory singleton PDB that prevents
+deliberate maintenance.
+
+PVC and generated API Secret are retained after uninstall by default. Reinstall with the same release/namespace/fullname to reuse them. An existing claim and
+externally managed Secrets retain their own lifecycle. Keep the release identity stable and never attach its data to two gateways.
+
+For GitOps, select `auth.existingSecret` or configure `externalSecrets.items[]` to project that Secret through an already installed ESO. Rotating a Secret
+requires a Pod rollout because provider/API/dashboard credentials are environment variables. Do not change the key name of a retained generated Secret without
+an explicit Secret migration.
+
+## Troubleshooting
+
+- API 401/403: check the API token, not the provider credential; never post credential values in logs/issues.
+- Agent responds with provider authentication errors: verify the selected provider, model, endpoint and named custom provider `key_env` mapping.
+- Service timeout with a Ready Pod: inspect the relevant NetworkPolicy peer list and fixed container target port.
+- HTTP 200 from health but Pod not Ready: inspect authenticated detailed readiness and its individual checks.
+- New values do not affect runtime: check whether `config.policy=seed` is preserving an existing config.yaml.
+- Pending backup Pod: ensure the state PVC supports concurrent same-node mounts; ReadWriteOncePod is incompatible with this design.
+- Missing skills/browser binaries: inspect configure logs and the pinned official image; do not enable ad hoc dependency downloads to hide a broken image
+  upgrade.
+- Restore refuses startup: preserve the incomplete volume for diagnosis and recover again into a new empty PVC. Do not bypass the incomplete marker.

--- a/charts/hermes-agent/examples/chatops.yaml
+++ b/charts/hermes-agent/examples/chatops.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+credentials:
+  existingSecret: hermes-provider-and-telegram
+channels:
+  telegram:
+    enabled: true
+    allowedUsers:
+      - '123456789'
+    toolsets:
+      - memory

--- a/charts/hermes-agent/examples/custom-provider.yaml
+++ b/charts/hermes-agent/examples/custom-provider.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+credentials:
+  existingSecret: hermes-private-provider
+agent:
+  provider: custom:internal
+  model: organization-model
+  baseUrl: https://inference.example.com/v1
+  apiKeyEnv: HERMES_INFERENCE_KEY

--- a/charts/hermes-agent/examples/dashboard.yaml
+++ b/charts/hermes-agent/examples/dashboard.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+fullnameOverride: hermes
+config:
+  policy: seed
+credentials:
+  existingSecret: hermes-provider
+dashboard:
+  enabled: true
+  existingSecret: hermes-dashboard-auth
+  publicUrl: https://hermes-admin.example.com
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: gateway-system
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: admin
+      parentRefs:
+        - name: shared
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - hermes-admin.example.com
+      rules:
+        - backendRefs:
+            - name: hermes-dashboard
+              port: 9119

--- a/charts/hermes-agent/examples/external-secrets.yaml
+++ b/charts/hermes-agent/examples/external-secrets.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+auth:
+  existingSecret: hermes-api
+credentials:
+  existingSecret: hermes-provider
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: hermes-api
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        data:
+          - secretKey: api-key
+            remoteRef:
+              key: agents/hermes
+              property: apiKey
+    - fullnameOverride: hermes-provider
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        data:
+          - secretKey: OPENROUTER_API_KEY
+            remoteRef:
+              key: agents/hermes
+              property: openrouterKey

--- a/charts/hermes-agent/examples/production.yaml
+++ b/charts/hermes-agent/examples/production.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+auth:
+  existingSecret: hermes-api
+credentials:
+  existingSecret: hermes-provider
+persistence:
+  size: 50Gi
+resources:
+  requests:
+    cpu: '1'
+    memory: 2Gi
+  limits:
+    cpu: '4'
+    memory: 4Gi
+networkPolicy:
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: gateway-system
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: shared
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - hermes.example.com
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+  prometheusRule:
+    enabled: true
+    labels:
+      release: prometheus
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+backup:
+  enabled: true
+  stagingSize: 20Gi
+  s3:
+    bucket: organization-agent-backups
+    existingSecret: hermes-backup-s3

--- a/charts/hermes-agent/examples/production.yaml
+++ b/charts/hermes-agent/examples/production.yaml
@@ -43,7 +43,10 @@ metrics:
           kubernetes.io/metadata.name: monitoring
 backup:
   enabled: true
-  stagingSize: 20Gi
+  stagingSize: 120Gi
   s3:
     bucket: organization-agent-backups
     existingSecret: hermes-backup-s3
+restore:
+  maxArchiveBytes: 59055800320
+  maxExpandedBytes: 59055800320

--- a/charts/hermes-agent/examples/simple.yaml
+++ b/charts/hermes-agent/examples/simple.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+credentials:
+  existingSecret: hermes-provider

--- a/charts/hermes-agent/examples/staging.yaml
+++ b/charts/hermes-agent/examples/staging.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the referenced Secrets/controllers before using this example.
+auth:
+  existingSecret: hermes-api
+credentials:
+  existingSecret: hermes-provider
+persistence:
+  size: 20Gi
+networkPolicy:
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: applications

--- a/charts/hermes-agent/files/archive.py
+++ b/charts/hermes-agent/files/archive.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict root-scoped snapshots and offline restore; never run native service revival."""
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import stat
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+from hermes_cli import backup as native
+
+CHUNK = 1024 * 1024
+RUNTIME = {'gateway_state.json', 'gateway.pid', 'cron.pid', 'gateway.lock', 'gateway.sock', 'processes.json'}
+ROOT = Path(os.environ.get('TARGET_HOME', os.environ.get('HERMES_HOME', '/opt/data')))
+WORK = Path('/work')
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def digest_file(path):
+    digest = hashlib.sha256()
+    size = 0
+    with path.open('rb') as stream:
+        while chunk := stream.read(CHUNK):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def safe_name(name):
+    path = PurePosixPath(name)
+    require(isinstance(name, str) and name and not path.is_absolute(), 'Invalid archive path')
+    require('\\' not in name and ':' not in name and '\x00' not in name, 'Invalid archive path')
+    require(all(part not in ('', '.', '..') for part in name.split('/')), 'Ambiguous archive path')
+    require(path.parts[0] != '_external', 'External state is outside this backup contract')
+    return path
+
+
+def excluded(relative):
+    return (native._should_exclude(relative) or relative.name in RUNTIME
+            or (relative.name.startswith('gateway.loop-tick.') and relative.name.endswith('.sock'))
+            or relative.name.startswith('.helmforge-'))
+
+
+def enumerate_files():
+    def fail_walk(error):
+        raise error
+    files = []
+    for directory, children, names in os.walk(ROOT, followlinks=False, onerror=fail_walk):
+        parent = Path(directory)
+        children[:] = sorted(name for name in children
+                             if not (parent / name).is_symlink() and not excluded((parent / name).relative_to(ROOT)))
+        for name in sorted(names):
+            path = parent / name
+            relative = path.relative_to(ROOT)
+            info = path.lstat()
+            if stat.S_ISLNK(info.st_mode) or excluded(relative):
+                continue
+            require(stat.S_ISREG(info.st_mode), 'Unsupported non-regular state file')
+            safe_name(relative.as_posix())
+            require(path.resolve().is_relative_to(ROOT.resolve()), 'State path escapes the managed root')
+            files.append(relative)
+    return files
+
+
+def verify_archive(manifest, archive, destination=None):
+    require(manifest.get('formatVersion') == 1, 'Unsupported backup format')
+    expected = manifest.get('files')
+    require(isinstance(expected, dict) and 0 < len(expected) <= 100000, 'Invalid file inventory')
+    require('config.yaml' in expected and 'state.db' in expected, 'Required Hermes state is missing')
+    require(manifest.get('archive', {}).get('name') == 'backup.zip', 'Invalid archive name')
+    digest, size = digest_file(archive)
+    require(size == manifest['archive']['bytes'] and digest == manifest['archive']['sha256'], 'Archive checksum/size mismatch')
+    max_expanded = int(os.environ.get('MAX_EXPANDED_BYTES', '21474836480'))
+    with zipfile.ZipFile(archive) as bundle:
+        infos = bundle.infolist()
+        require(len(infos) == len(expected) and {entry.filename for entry in infos} == set(expected), 'Archive inventory mismatch')
+        require(sum(entry.file_size for entry in infos) <= max_expanded, 'Expanded archive exceeds configured limit')
+        for entry in infos:
+            path = safe_name(entry.filename)
+            mode = entry.external_attr >> 16
+            require(stat.S_ISREG(mode) and not entry.flag_bits & 1, 'Archive contains a special or encrypted entry')
+            require(entry.compress_type in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED), 'Unsupported compression')
+            metadata = expected[entry.filename]
+            require(entry.file_size == metadata['bytes'], 'Member size mismatch')
+            require(metadata['mode'] in (0o600, 0o700), 'Unsupported member permissions')
+            for parent in path.parents:
+                require(parent.as_posix() not in expected, 'File/directory conflict')
+            output = None
+            if destination:
+                target = destination.joinpath(*path.parts)
+                target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                output = target.open('xb')
+            digest = hashlib.sha256()
+            count = 0
+            try:
+                with bundle.open(entry) as source:
+                    while chunk := source.read(CHUNK):
+                        count += len(chunk)
+                        require(count <= metadata['bytes'], 'Member exceeds declared size')
+                        digest.update(chunk)
+                        if output:
+                            output.write(chunk)
+            finally:
+                if output:
+                    output.close()
+            require(count == metadata['bytes'] and digest.hexdigest() == metadata['sha256'], 'Member checksum mismatch')
+            if destination:
+                target.chmod(metadata['mode'])
+                if metadata.get('sqlite', False) or target.suffix in ('.db', '.sqlite', '.sqlite3'):
+                    require(native.verify_sqlite_integrity(target, max_bytes=0)['valid'], 'Restored SQLite integrity check failed')
+
+
+def backup():
+    require(ROOT.is_dir() and not ROOT.is_symlink(), 'Invalid state directory')
+    require((ROOT / 'config.yaml').is_file() and (ROOT / 'state.db').is_file(), 'Agent state is not initialized')
+    require(not list(WORK.iterdir()), 'Backup staging must be empty')
+    run = datetime.now(timezone.utc).strftime('hermes-%Y%m%dT%H%M%SZ-') + secrets.token_hex(8)
+    archive = WORK / 'backup.zip'
+    inventory = {}
+    with native._backup_operation_lock(ROOT):
+        files = enumerate_files()
+        with zipfile.ZipFile(archive, 'x', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as bundle:
+            for relative in files:
+                source = ROOT / relative
+                require(source.resolve().is_relative_to(ROOT.resolve()) and not source.is_symlink(), 'State path changed during backup')
+                descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
+                info = os.fstat(descriptor)
+                require(stat.S_ISREG(info.st_mode), 'State file changed during backup')
+                signature = os.read(descriptor, 16)
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                is_sqlite = source.suffix in ('.db', '.sqlite', '.sqlite3') or signature == b'SQLite format 3\x00'
+                snapshot = WORK / 'snapshot.db'
+                if is_sqlite:
+                    os.close(descriptor)
+                    require(native._safe_copy_db(source, snapshot), 'Native SQLite snapshot failed')
+                    require(native.verify_sqlite_integrity(snapshot, max_bytes=0)['valid'], 'SQLite snapshot integrity check failed')
+                    source = snapshot
+                    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
+                mode = 0o700 if info.st_mode & 0o111 and not is_sqlite else 0o600
+                entry = zipfile.ZipInfo(relative.as_posix())
+                entry.compress_type = zipfile.ZIP_DEFLATED
+                entry.external_attr = (stat.S_IFREG | mode) << 16
+                digest = hashlib.sha256()
+                size = 0
+                with os.fdopen(descriptor, 'rb') as stream, bundle.open(entry, 'w', force_zip64=True) as output:
+                    while chunk := stream.read(CHUNK):
+                        output.write(chunk)
+                        digest.update(chunk)
+                        size += len(chunk)
+                inventory[entry.filename] = {'bytes': size, 'sha256': digest.hexdigest(), 'mode': mode, 'sqlite': is_sqlite}
+                if snapshot.exists():
+                    snapshot.unlink()
+        require(set(files) == set(enumerate_files()), 'State file set changed during backup; retry during a quieter period')
+    checksum, size = digest_file(archive)
+    manifest = {'formatVersion': 1, 'runId': run, 'completedAt': datetime.now(timezone.utc).isoformat(),
+                'image': os.environ['HERMES_IMAGE'], 'consistency': 'online-per-database',
+                'exclusions': 'native-pinned-policy-plus-runtime-markers; no external memory services or environment-only credentials',
+                'archive': {'name': 'backup.zip', 'bytes': size, 'sha256': checksum}, 'files': inventory}
+    verify_archive(manifest, archive)
+    (WORK / 'manifest.json').write_text(json.dumps(manifest, separators=(',', ':')))
+    (WORK / 'upload.tsv').write_text(f'{run}\t{size}\t{checksum}\n')
+    print('Strict native snapshot verified; ready for upload')
+
+
+def empty_target():
+    require(ROOT.is_dir() and not ROOT.is_symlink(), 'Invalid restore target')
+    entries = [entry for entry in ROOT.iterdir() if entry.name != 'lost+found']
+    require(not entries, 'Restore target is not empty; no overwrite is permitted')
+    lost = ROOT / 'lost+found'
+    if lost.exists():
+        require(lost.is_dir() and not lost.is_symlink() and not list(lost.iterdir()), 'Invalid lost+found directory')
+
+
+def restore():
+    completed = ROOT / '.helmforge-restored'
+    if completed.is_file() and completed.read_text() == os.environ['RESTORE_MANIFEST_KEY']:
+        print('This recovery was already completed; preserving current state')
+        return
+    empty_target()
+    manifest_path = WORK / 'manifest.json'
+    require(manifest_path.stat().st_size <= 20 * 1024 * 1024, 'Manifest exceeds maximum size')
+    require((WORK / 'backup.zip').stat().st_size <= int(os.environ['MAX_ARCHIVE_BYTES']), 'Archive exceeds maximum size')
+    manifest = json.loads(manifest_path.read_text())
+    staging = WORK / 'restore'
+    staging.mkdir(mode=0o700)
+    verify_archive(manifest, WORK / 'backup.zip', staging)
+    empty_target()
+    marker = ROOT / '.helmforge-restore-incomplete'
+    marker.write_text('Offline restore did not complete; do not start a gateway on this volume.\n')
+    for source in staging.iterdir():
+        destination = ROOT / source.name
+        if source.is_dir():
+            shutil.copytree(source, destination)
+        else:
+            shutil.copy2(source, destination)
+    for name, metadata in manifest['files'].items():
+        checksum, size = digest_file(ROOT / name)
+        require(checksum == metadata['sha256'] and size == metadata['bytes'], 'Published restore verification failed')
+    completed.write_text(os.environ['RESTORE_MANIFEST_KEY'])
+    marker.unlink()
+    print('Offline restore verified and completed')
+
+
+def prepare_restore():
+    completed = ROOT / '.helmforge-restored'
+    require(not (ROOT / '.helmforge-restore-incomplete').exists(), 'Previous restore is incomplete')
+    if completed.is_file() and not completed.is_symlink() and completed.read_text() == os.environ['RESTORE_MANIFEST_KEY']:
+        (WORK / 'skip-restore').touch()
+    else:
+        empty_target()
+
+
+if __name__ == '__main__':
+    os.umask(0o077)
+    try:
+        {'backup': backup, 'restore': restore, 'prepare-restore': prepare_restore}[sys.argv[1]]()
+    except Exception as error:
+        detail = str(error) if type(error) is RuntimeError else type(error).__name__
+        print(f'Archive operation failed: {detail}', file=sys.stderr)
+        sys.exit(1)

--- a/charts/hermes-agent/files/archive.py
+++ b/charts/hermes-agent/files/archive.py
@@ -8,6 +8,7 @@ import shutil
 import stat
 import sys
 import zipfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
@@ -118,6 +119,27 @@ def verify_archive(manifest, archive, destination=None):
                     require(native.verify_sqlite_integrity(target, max_bytes=0)['valid'], 'Restored SQLite integrity check failed')
 
 
+@contextmanager
+def open_state_file(relative):
+    """Walk from an open root, rejecting symlinks in every path component."""
+    parts = safe_name(relative.as_posix()).parts
+    directory = os.open(ROOT, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = None
+    try:
+        for part in parts[:-1]:
+            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=directory)
+            os.close(directory)
+            directory = child
+        descriptor = os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory)
+        require(stat.S_ISREG(os.fstat(descriptor).st_mode), 'State file changed during backup')
+        require(Path(f'/proc/self/fd/{descriptor}').resolve().is_relative_to(ROOT.resolve()), 'Opened state file escapes root')
+        yield descriptor
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(directory)
+
+
 def backup():
     require(ROOT.is_dir() and not ROOT.is_symlink(), 'Invalid state directory')
     require((ROOT / 'config.yaml').is_file() and (ROOT / 'state.db').is_file(), 'Agent state is not initialized')
@@ -129,35 +151,34 @@ def backup():
         files = enumerate_files()
         with zipfile.ZipFile(archive, 'x', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as bundle:
             for relative in files:
-                source = ROOT / relative
-                require(source.resolve().is_relative_to(ROOT.resolve()) and not source.is_symlink(), 'State path changed during backup')
-                descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
-                info = os.fstat(descriptor)
-                require(stat.S_ISREG(info.st_mode), 'State file changed during backup')
-                signature = os.read(descriptor, 16)
-                os.lseek(descriptor, 0, os.SEEK_SET)
-                is_sqlite = source.suffix in ('.db', '.sqlite', '.sqlite3') or signature == b'SQLite format 3\x00'
-                snapshot = WORK / 'snapshot.db'
-                if is_sqlite:
-                    os.close(descriptor)
-                    require(native._safe_copy_db(source, snapshot), 'Native SQLite snapshot failed')
-                    require(native.verify_sqlite_integrity(snapshot, max_bytes=0)['valid'], 'SQLite snapshot integrity check failed')
-                    source = snapshot
-                    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
-                mode = 0o700 if info.st_mode & 0o111 and not is_sqlite else 0o600
-                entry = zipfile.ZipInfo(relative.as_posix())
-                entry.compress_type = zipfile.ZIP_DEFLATED
-                entry.external_attr = (stat.S_IFREG | mode) << 16
-                digest = hashlib.sha256()
-                size = 0
-                with os.fdopen(descriptor, 'rb') as stream, bundle.open(entry, 'w', force_zip64=True) as output:
-                    while chunk := stream.read(CHUNK):
-                        output.write(chunk)
-                        digest.update(chunk)
-                        size += len(chunk)
-                inventory[entry.filename] = {'bytes': size, 'sha256': digest.hexdigest(), 'mode': mode, 'sqlite': is_sqlite}
-                if snapshot.exists():
-                    snapshot.unlink()
+                with open_state_file(relative) as descriptor:
+                    info = os.fstat(descriptor)
+                    signature = os.read(descriptor, 16)
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    is_sqlite = relative.suffix in ('.db', '.sqlite', '.sqlite3') or signature == b'SQLite format 3\x00'
+                    snapshot = WORK / 'snapshot.db'
+                    if is_sqlite:
+                        pinned = Path(f'/proc/self/fd/{descriptor}')
+                        require(native._safe_copy_db(pinned, snapshot), 'Native SQLite snapshot failed')
+                        require(pinned.resolve().is_relative_to(ROOT.resolve()), 'State database moved outside root')
+                        require(native.verify_sqlite_integrity(snapshot, max_bytes=0)['valid'], 'SQLite snapshot integrity check failed')
+                        archive_descriptor = os.open(snapshot, os.O_RDONLY | os.O_NOFOLLOW)
+                    else:
+                        archive_descriptor = os.dup(descriptor)
+                    mode = 0o700 if info.st_mode & 0o111 and not is_sqlite else 0o600
+                    entry = zipfile.ZipInfo(relative.as_posix())
+                    entry.compress_type = zipfile.ZIP_DEFLATED
+                    entry.external_attr = (stat.S_IFREG | mode) << 16
+                    digest = hashlib.sha256()
+                    size = 0
+                    with os.fdopen(archive_descriptor, 'rb') as stream, bundle.open(entry, 'w', force_zip64=True) as output:
+                        while chunk := stream.read(CHUNK):
+                            output.write(chunk)
+                            digest.update(chunk)
+                            size += len(chunk)
+                    inventory[entry.filename] = {'bytes': size, 'sha256': digest.hexdigest(), 'mode': mode, 'sqlite': is_sqlite}
+                    if snapshot.exists():
+                        snapshot.unlink()
         require(set(files) == set(enumerate_files()), 'State file set changed during backup; retry during a quieter period')
     checksum, size = digest_file(archive)
     manifest = {'formatVersion': 1, 'runId': run, 'completedAt': datetime.now(timezone.utc).isoformat(),

--- a/charts/hermes-agent/files/bootstrap.py
+++ b/charts/hermes-agent/files/bootstrap.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Initialize only the release's data volume; reconcile declared configuration."""
+import os
+import subprocess
+from pathlib import Path
+
+os.umask(0o077)
+home = Path('/opt/data')
+if (home / '.helmforge-restore-incomplete').exists():
+    raise SystemExit('Restore is incomplete; refusing to start the agent')
+for directory in ('workspace', 'home', 'memories', 'skills', 'sessions', 'cron', 'logs', 'profiles'):
+    target = home / directory
+    if target.is_symlink():
+        raise SystemExit('Refusing a symlinked state directory')
+    target.mkdir(exist_ok=True)
+for name in ('config.yaml', 'SOUL.md'):
+    source = Path('/helmforge') / name
+    target = home / name
+    if target.is_symlink():
+        raise SystemExit('Refusing a symlinked configuration target')
+    if name == 'SOUL.md' and not source.read_text().strip():
+        continue
+    if os.environ['CONFIG_POLICY'] == 'managed' or not target.exists():
+        temporary = home / ('.helmforge-' + name)
+        if temporary.is_symlink():
+            raise SystemExit('Refusing a symlinked temporary configuration path')
+        temporary.write_bytes(source.read_bytes())
+        temporary.chmod(0o600)
+        temporary.replace(target)
+subprocess.run(['/opt/hermes/.venv/bin/python', '/opt/hermes/tools/skills_sync.py'], check=True)
+print('Hermes state and declared configuration initialized')

--- a/charts/hermes-agent/files/entrypoint.py
+++ b/charts/hermes-agent/files/entrypoint.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run the upstream foreground process with bundled browser discovery."""
+import os
+import sys
+from pathlib import Path
+
+os.umask(0o077)
+if not os.environ.get('AGENT_BROWSER_EXECUTABLE_PATH'):
+    directory = Path(os.environ.get('PLAYWRIGHT_BROWSERS_PATH', '/opt/hermes/.playwright'))
+    names = {'chrome', 'chromium', 'chrome-headless-shell', 'headless_shell', 'chromium-browser'}
+    if directory.is_dir():
+        for candidate in sorted(directory.rglob('*')):
+            if candidate.name in names and candidate.is_file() and os.access(candidate, os.X_OK):
+                os.environ['AGENT_BROWSER_EXECUTABLE_PATH'] = str(candidate)
+                break
+if not sys.argv[1:]:
+    raise SystemExit('An explicit foreground command is required')
+os.execv(sys.argv[1], sys.argv[1:])

--- a/charts/hermes-agent/files/health.py
+++ b/charts/hermes-agent/files/health.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Readiness is authenticated JSON state, never just an HTTP 200 response."""
+import json
+import os
+import sys
+import urllib.request
+
+try:
+    request = urllib.request.Request('http://127.0.0.1:8642/health/detailed',
+                                     headers={'Authorization': 'Bearer ' + os.environ['API_SERVER_KEY']})
+    with urllib.request.urlopen(request, timeout=3) as response:
+        healthy = json.load(response).get('readiness', {}).get('status') == 'ok'
+    sys.exit(0 if healthy else 1)
+except Exception:
+    sys.exit(1)

--- a/charts/hermes-agent/files/s3.sh
+++ b/charts/hermes-agent/files/s3.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+umask 077
+if [[ "$1" == download && -f /work/skip-restore ]]; then exit 0; fi
+fail() { printf 'S3 operation failed: %s\n' "$1" >&2; exit 1; }
+export AWS_PAGER='' AWS_EC2_METADATA_DISABLED=true
+[[ ${S3_BUCKET:-} =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail 'invalid bucket'
+[[ ${S3_PREFIX:-} =~ ^[A-Za-z0-9][A-Za-z0-9/_-]*$ && "$S3_PREFIX" != */ ]] || fail 'invalid prefix'
+endpoint=()
+if [[ -n ${S3_ENDPOINT:-} ]]; then
+  case "$S3_ENDPOINT" in
+    https://*) ;;
+    http://*) [[ ${ALLOW_INSECURE_ENDPOINT:-false} == true ]] || fail 'HTTPS required' ;;
+    *) fail 'invalid endpoint' ;;
+  esac
+  [[ "$S3_ENDPOINT" != *'@'* ]] || fail 'endpoint must not contain credentials'
+  endpoint=(--endpoint-url "$S3_ENDPOINT")
+fi
+cloud() { aws "${endpoint[@]}" --region "$S3_REGION" "$@"; }
+encryption=()
+case ${S3_SSE:-} in
+  '') ;;
+  AES256) encryption=(--sse AES256) ;;
+  aws:kms) encryption=(--sse aws:kms --sse-kms-key-id "$S3_KMS_KEY_ID") ;;
+  *) fail 'invalid encryption mode' ;;
+esac
+case "$1" in
+  upload)
+    IFS=$'\t' read -r run size checksum < /work/upload.tsv
+    [[ "$run" =~ ^hermes-[0-9]{8}T[0-9]{6}Z-[0-9a-f]{16}$ && "$size" =~ ^[0-9]+$ && "$checksum" =~ ^[0-9a-f]{64}$ ]] || fail 'invalid snapshot metadata'
+    [[ -f /work/backup.zip && ! -L /work/backup.zip && -s /work/manifest.json ]] || fail 'missing completed archive'
+    [[ $(stat -c %s /work/backup.zip) == "$size" ]] || fail 'local size changed'
+    actual=$(sha256sum /work/backup.zip); actual=${actual%% *}
+    [[ "$actual" == "$checksum" ]] || fail 'local checksum changed'
+    target="s3://${S3_BUCKET}/${S3_PREFIX}/${run}"
+    cloud s3 cp /work/backup.zip "${target}/backup.zip" --only-show-errors "${encryption[@]}"
+    actual=$(cloud s3 cp "${target}/backup.zip" - --only-show-errors | sha256sum); actual=${actual%% *}
+    [[ "$actual" == "$checksum" ]] || fail 'remote byte verification failed'
+    cloud s3 cp /work/manifest.json "${target}/manifest.json" --only-show-errors "${encryption[@]}" --content-type application/json
+    printf 'Backup committed and remote archive verified: %s/manifest.json\n' "$target"
+    ;;
+  download)
+    [[ ${RESTORE_MANIFEST_KEY:-} =~ ^[A-Za-z0-9][A-Za-z0-9/_-]*/manifest\.json$ ]] || fail 'invalid manifest key'
+    [[ ${MAX_ARCHIVE_BYTES:-} =~ ^[0-9]+$ ]] || fail 'invalid archive size limit'
+    target="s3://${S3_BUCKET}/${RESTORE_MANIFEST_KEY%/manifest.json}"
+    cloud s3 cp "${target}/manifest.json" - --only-show-errors | head -c 20971521 > /work/manifest.json
+    [[ $(stat -c %s /work/manifest.json) -le 20971520 ]] || fail 'manifest too large'
+    cloud s3 cp "${target}/backup.zip" - --only-show-errors | head -c "$((MAX_ARCHIVE_BYTES + 1))" > /work/backup.zip
+    [[ $(stat -c %s /work/backup.zip) -le "$MAX_ARCHIVE_BYTES" ]] || fail 'archive too large'
+    ;;
+  *) fail 'unknown operation' ;;
+esac

--- a/charts/hermes-agent/scripts/agent-accept.py
+++ b/charts/hermes-agent/scripts/agent-accept.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+url = 'http://127.0.0.1:8642'
+key = os.environ['API_SERVER_KEY']
+for supplied in ('', 'deliberately-wrong-token'):
+    try:
+        urllib.request.urlopen(urllib.request.Request(url + '/v1/models', headers={'Authorization': 'Bearer ' + supplied}), timeout=10)
+        raise AssertionError('Unauthenticated request accepted')
+    except urllib.error.HTTPError as error:
+        assert error.code in (401, 403), error.code
+print('PASS missing and incorrect API credentials rejected')
+prompt = os.environ.get('TEST_PROMPT', 'HF_MEMORY_STORE')
+session_id = ('hf-memory-fresh-' + uuid.uuid4().hex if prompt == 'HF_MEMORY_CHECK'
+              else 'hf-mvp-persistent-session')
+headers = {'Authorization': 'Bearer ' + key, 'Content-Type': 'application/json', 'X-Hermes-Session-Id': session_id}
+payload = {'model': 'hermes-agent', 'stream': False, 'messages': [{'role': 'user', 'content': prompt}]}
+with urllib.request.urlopen(urllib.request.Request(url + '/v1/chat/completions', data=json.dumps(payload).encode(), headers=headers), timeout=100) as response:
+    answer = json.load(response)['choices'][0]['message']['content']
+expected = {'HF_MEMORY_STORE': 'HF_MEMORY_STORED', 'HF_HISTORY_CHECK': 'HF_HISTORY_RESTORED', 'HF_MEMORY_CHECK': 'HF_MEMORY_RESTORED'}[prompt]
+assert expected in answer, answer
+assert 'HF_HERMES_PERSISTENT_MEMORY' in Path('/opt/data/memories/MEMORY.md').read_text()
+print('PASS real Hermes agent turn, memory tool and persisted memory: ' + expected)

--- a/charts/hermes-agent/scripts/archive-accept.py
+++ b/charts/hermes-agent/scripts/archive-accept.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise recovery failure boundaries in disposable directories, never live state."""
+import json
+import os
+import pathlib
+import shutil
+import sqlite3
+import tempfile
+
+
+def validate(module):
+    temporary = pathlib.Path(tempfile.mkdtemp(prefix='hf-archive-', dir='/tmp'))
+    try:
+        module.ROOT = temporary / 'state'
+        module.WORK = temporary / 'work'
+        module.ROOT.mkdir()
+        module.WORK.mkdir()
+        (module.ROOT / 'config.yaml').write_text('model: test\n')
+        with sqlite3.connect(module.ROOT / 'state.db') as database:
+            database.execute('create table proof (value text)')
+            database.execute("insert into proof values ('restorable')")
+        with sqlite3.connect(module.ROOT / 'provider.store') as database:
+            database.execute('create table provider_state (value text)')
+        os.environ['HERMES_IMAGE'] = 'official-image-contract-test'
+        os.environ['RESTORE_MANIFEST_KEY'] = 'test/manifest.json'
+        os.environ['MAX_ARCHIVE_BYTES'] = '10485760'
+        def fails(action):
+            try:
+                action()
+                raise AssertionError('Invalid archive operation unexpectedly succeeded')
+            except (RuntimeError, PermissionError):
+                pass
+        def clear_work():
+            shutil.rmtree(module.WORK)
+            module.WORK.mkdir()
+        snapshot = module.native._safe_copy_db
+        try:
+            module.native._safe_copy_db = lambda *_args, **_kwargs: False
+            fails(module.backup)
+            assert not (module.WORK / 'manifest.json').exists()
+        finally:
+            module.native._safe_copy_db = snapshot
+        clear_work()
+        blocked = module.ROOT / 'unreadable.txt'
+        blocked.write_text('must-not-be-silently-skipped')
+        blocked.chmod(0)
+        fails(module.backup)
+        assert not (module.WORK / 'manifest.json').exists()
+        blocked.chmod(0o600)
+        blocked.unlink()
+        clear_work()
+        module.backup()
+        manifest = json.loads((module.WORK / 'manifest.json').read_text())
+        assert manifest['files']['provider.store']['sqlite'] is True
+        module.verify_archive(manifest, module.WORK / 'backup.zip')
+        with (module.WORK / 'backup.zip').open('ab') as archive:
+            archive.write(b'corruption')
+        fails(lambda: module.verify_archive(manifest, module.WORK / 'backup.zip'))
+        fails(module.prepare_restore)
+        assert not (module.ROOT / '.helmforge-restore-incomplete').exists()
+        for name in ('../escape', '/absolute', 'parent/../escape', 'C:/escape', 'double//entry', '_external/provider'):
+            fails(lambda: module.safe_name(name))
+        print('PASS failed SQLite snapshot/unreadable file cannot publish success; corrupted archives, unsafe paths and nonempty targets rejected')
+    finally:
+        shutil.rmtree(temporary)

--- a/charts/hermes-agent/scripts/archive-accept.py
+++ b/charts/hermes-agent/scripts/archive-accept.py
@@ -28,7 +28,7 @@ def validate(module):
             try:
                 action()
                 raise AssertionError('Invalid archive operation unexpectedly succeeded')
-            except (RuntimeError, PermissionError):
+            except (RuntimeError, OSError):
                 pass
         def clear_work():
             shutil.rmtree(module.WORK)
@@ -49,6 +49,30 @@ def validate(module):
         blocked.chmod(0o600)
         blocked.unlink()
         clear_work()
+        nested = module.ROOT / 'nested'
+        nested.mkdir()
+        (nested / 'payload.txt').write_text('inside')
+        outside = temporary / 'outside'
+        outside.mkdir()
+        (outside / 'payload.txt').write_text('must-not-be-archived')
+        original_open = module.os.open
+        def replaced_directory(path, flags, *args, **kwargs):
+            if path == 'nested' and kwargs.get('dir_fd') is not None:
+                nested.rename(module.ROOT / 'saved')
+                nested.symlink_to(outside, target_is_directory=True)
+            return original_open(path, flags, *args, **kwargs)
+        descriptors = len(list(pathlib.Path('/proc/self/fd').iterdir()))
+        try:
+            module.os.open = replaced_directory
+            fails(module.backup)
+            assert not (module.WORK / 'manifest.json').exists()
+            assert len(list(pathlib.Path('/proc/self/fd').iterdir())) == descriptors
+        finally:
+            module.os.open = original_open
+            nested.unlink()
+            (module.ROOT / 'saved').rename(nested)
+        clear_work()
+        print('PASS intermediate-directory replacement is rejected without leaking descriptors')
         module.backup()
         manifest = json.loads((module.WORK / 'manifest.json').read_text())
         assert manifest['files']['provider.store']['sqlite'] is True

--- a/charts/hermes-agent/scripts/dashboard-accept.py
+++ b/charts/hermes-agent/scripts/dashboard-accept.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+import http.cookiejar
+import json
+import os
+import urllib.error
+import urllib.request
+
+url = 'http://127.0.0.1:9119'
+opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar()))
+with opener.open(url + '/api/status') as response:
+    status = json.load(response)
+    assert status['auth_required'] is True, 'Dashboard authentication is not required'
+    assert status['gateway_running'] is True, 'Dashboard cannot see the gateway process'
+for path in ('/api/config', '/api/auth/me'):
+    try:
+        opener.open(url + path)
+        raise AssertionError('Unauthenticated dashboard access was accepted')
+    except urllib.error.HTTPError as error:
+        assert error.code in (401, 403), error.code
+for correct in (False, True):
+    payload = {'provider': 'basic', 'username': os.environ['HERMES_DASHBOARD_BASIC_AUTH_USERNAME'], 'password': os.environ['HERMES_DASHBOARD_BASIC_AUTH_PASSWORD'] if correct else 'incorrect'}
+    request = urllib.request.Request(url + '/auth/password-login', data=json.dumps(payload).encode(), headers={'Content-Type': 'application/json'})
+    try:
+        with opener.open(request) as response:
+            assert correct and json.load(response)['ok'] is True
+    except urllib.error.HTTPError as error:
+        assert not correct and error.code == 401, error.code
+with opener.open(url + '/api/auth/me') as response:
+    assert response.status == 200
+print('PASS dashboard denies unauthenticated access, rejects bad password and accepts signed login session')
+with opener.open(url + '/api/status') as response:
+    result = json.load(response)
+    print('Dashboard status fields:', ', '.join(sorted(result)))

--- a/charts/hermes-agent/scripts/runtime-recovery.mjs
+++ b/charts/hermes-agent/scripts/runtime-recovery.mjs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export async function validateRecovery({k,json,helm,values,name,pod,python,chart,namespace,release}) {
+  if(!values.backup.enabled) return;
+  const moduleSource=fs.readFileSync(path.join(chart,'files','archive.py'),'utf8');
+  const acceptance=fs.readFileSync(path.join(chart,'scripts','archive-accept.py'),'utf8');
+  console.log(python(`import types\nmodule=types.ModuleType('archive_contract')\nexec(compile(${JSON.stringify(moduleSource)},'archive.py','exec'),module.__dict__)\n${acceptance}\nvalidate(module)\n`,'hermes',pod,['HERMES_HOME=/tmp/hermes-archive-contract']).trim());
+  const job='hermes-acceptance-backup';
+  k(['create','job',job,`--from=cronjob/${name}-backup`]);
+  k(['wait','--for=condition=complete',`job/${job}`,'--timeout=60s']);
+  assert.match(k(['logs',`job/${job}`,'-c','snapshot']),/Strict native snapshot verified/);
+  const output=k(['logs',`job/${job}`,'-c','upload']);
+  const match=output.match(/s3:\/\/[^/]+\/(.+\/manifest\.json)/);
+  assert(match,'Backup upload must publish its completed manifest');
+  console.log('PASS native SQLite snapshot, HTTPS S3 upload and remote byte verification');
+  const restoreName=`${name.slice(0,40)}-recovered`;
+  const restored=structuredClone(values);
+  restored.fullnameOverride=restoreName;
+  restored.persistence.existingClaim='';
+  restored.persistence.retain=false;
+  restored.auth.existingSecret='';
+  restored.backup.enabled=false;
+  restored.restore.enabled=true;
+  restored.restore.manifestKey=match[1];
+  restored.metrics.enabled=false;
+  restored.metrics.serviceMonitor.enabled=false;
+  restored.metrics.prometheusRule.enabled=false;
+  restored.dashboard.enabled=false;
+  restored.externalSecrets.enabled=false;
+  restored.ingress.enabled=false;
+  restored.gatewayAPI.enabled=false;
+  restored.config.policy='managed';
+  restored.networkPolicy.extraEgress.push(...values.backup.networkPolicy.extraEgress);
+  const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-hermes-restore-'));
+  const file=path.join(temporary,'values.json');
+  const recoveryRelease='hermes-acceptance-recovery';
+  try {
+    fs.writeFileSync(file,JSON.stringify(restored));
+    helm(['install',recoveryRelease,chart,'-f',file,'--wait','--timeout','60s']);
+    assert.match(k(['logs',`${restoreName}-0`,'-c','restore']),/Offline restore verified and completed/);
+    const accept=fs.readFileSync(path.join(chart,'scripts','agent-accept.py'),'utf8');
+    for(const prompt of ['HF_HISTORY_CHECK','HF_MEMORY_CHECK']) console.log(python(accept,'hermes',`${restoreName}-0`,[`TEST_PROMPT=${prompt}`]).trim());
+    // Restart recovery init containers: the completed marker prevents a second
+    // restore or dependency on downloading S3 objects on ordinary restarts.
+    k(['delete','pod',`${restoreName}-0`,'--wait=true','--timeout=60s']);
+    k(['wait','--for=condition=Ready',`pod/${restoreName}-0`,'--timeout=60s']);
+    assert.match(k(['logs',`${restoreName}-0`,'-c','restore']),/already completed/);
+    console.log('PASS independent empty-volume restore, real state reuse and idempotent restart');
+  } finally {
+    try {helm(['uninstall',recoveryRelease,'--wait','--timeout','60s']);}
+    finally {fs.rmSync(file,{force:true});fs.rmdirSync(temporary);}
+  }
+}

--- a/charts/hermes-agent/scripts/runtime-recovery.mjs
+++ b/charts/hermes-agent/scripts/runtime-recovery.mjs
@@ -10,11 +10,16 @@ export async function validateRecovery({k,json,helm,values,name,pod,python,chart
   const acceptance=fs.readFileSync(path.join(chart,'scripts','archive-accept.py'),'utf8');
   console.log(python(`import types\nmodule=types.ModuleType('archive_contract')\nexec(compile(${JSON.stringify(moduleSource)},'archive.py','exec'),module.__dict__)\n${acceptance}\nvalidate(module)\n`,'hermes',pod,['HERMES_HOME=/tmp/hermes-archive-contract']).trim());
   const job='hermes-acceptance-backup';
-  k(['create','job',job,`--from=cronjob/${name}-backup`]);
-  k(['wait','--for=condition=complete',`job/${job}`,'--timeout=60s']);
-  assert.match(k(['logs',`job/${job}`,'-c','snapshot']),/Strict native snapshot verified/);
-  const output=k(['logs',`job/${job}`,'-c','upload']);
-  const match=output.match(/s3:\/\/[^/]+\/(.+\/manifest\.json)/);
+  let match;
+  try {
+    k(['create','job',job,`--from=cronjob/${name}-backup`]);
+    k(['wait','--for=condition=complete',`job/${job}`,'--timeout=60s']);
+    assert.match(k(['logs',`job/${job}`,'-c','snapshot']),/Strict native snapshot verified/);
+    const output=k(['logs',`job/${job}`,'-c','upload']);
+    match=output.match(/s3:\/\/[^/]+\/(.+\/manifest\.json)/);
+  } finally {
+    k(['delete','job',job,'--ignore-not-found=true','--wait=true','--timeout=60s']);
+  }
   assert(match,'Backup upload must publish its completed manifest');
   console.log('PASS native SQLite snapshot, HTTPS S3 upload and remote byte verification');
   const restoreName=`${name.slice(0,40)}-recovered`;

--- a/charts/hermes-agent/scripts/runtime-smoke.mjs
+++ b/charts/hermes-agent/scripts/runtime-smoke.mjs
@@ -25,7 +25,7 @@ if(values.agent.provider!=='custom:fixture') {
   const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-hermes-'));
   const file=path.join(temporary,'values.json');
   try {
-    fs.writeFileSync(file,JSON.stringify({agent:{model:'helmforge-fixture',provider:'custom:fixture',baseUrl:'http://hermes-provider:8080/v1',apiKeyEnv:'OPENAI_API_KEY'},credentials:{existingSecret:'hermes-provider-credentials'},networkPolicy:{allowInternet:false,extraEgress:[{to:[{podSelector:{matchLabels:{app:'hermes-provider'}}}],ports:[{protocol:'TCP',port:8080}]}]},config:{values:{model:{api_mode:'chat_completions'},auxiliary:{free_only:true}}}}));
+    fs.writeFileSync(file,JSON.stringify({agent:{model:'helmforge-fixture',provider:'custom:fixture',baseUrl:'http://hermes-provider:8080/v1',apiKeyEnv:'OPENAI_API_KEY',allowInsecureHTTP:true},credentials:{existingSecret:'hermes-provider-credentials'},networkPolicy:{allowInternet:false,extraEgress:[{to:[{podSelector:{matchLabels:{app:'hermes-provider'}}}],ports:[{protocol:'TCP',port:8080}]}]},config:{values:{model:{api_mode:'chat_completions'},auxiliary:{free_only:true}}}}));
     helm(['upgrade',release,chart,'--reuse-values','-f',file,'--wait','--timeout','60s']);
   } finally {fs.rmSync(file,{force:true});fs.rmdirSync(temporary);}
   values = JSON.parse(helm(['get','values',release,'--all','-o','json']));
@@ -101,6 +101,42 @@ if(values.metrics.enabled && values.metrics.collector.enabled) {
   } finally {k(['delete','networkpolicy',metricsPolicy]);}
   if(values.metrics.serviceMonitor.enabled) assert.equal(json(['get','servicemonitor',name,'-o','json']).spec.endpoints[0].port,'metrics');
   if(values.metrics.prometheusRule.enabled) assert.equal(json(['get','prometheusrule',name,'-o','json']).spec.groups[0].rules[0].alert,'HermesGatewayUnavailable');
+  const metricsContainer=statefulSet.spec.template.spec.containers.find(item=>item.name==='metrics');
+  assert.equal(metricsContainer.securityContext.runAsUser,10001);
+  const boundaryName=`metrics-boundary-${Date.now()}`;
+  const boundaryScript=`import os,pathlib
+assert os.getuid()==10001 and os.getgid()==10001
+found=0
+for process in pathlib.Path('/proc').iterdir():
+ if not process.name.isdigit(): continue
+ try:
+  command=(process/'cmdline').read_bytes()
+  status=(process/'status').read_text()
+ except (FileNotFoundError,PermissionError,ProcessLookupError): continue
+ if b'gateway\\x00run' not in command or 'Uid:\\t10000\\t' not in status: continue
+ found+=1
+ try:
+  (process/'environ').read_bytes()
+  raise AssertionError('Collector identity can read gateway credentials')
+ except PermissionError: pass
+ try:
+  os.kill(int(process.name),0)
+  raise AssertionError('Collector identity can signal gateway')
+ except PermissionError: pass
+assert found>0,'Gateway process must be visible for a meaningful permission check'
+print('PASS collector identity cannot read gateway environment or signal gateway')
+`;
+  const currentPod=json(['get','pod',pod,'-o','json']);
+  currentPod.spec.ephemeralContainers=[...(currentPod.spec.ephemeralContainers||[]),{name:boundaryName,image:statefulSet.spec.template.spec.containers[0].image,command:['/opt/hermes/.venv/bin/python','-c',boundaryScript],securityContext:{...metricsContainer.securityContext,runAsNonRoot:true}}];
+  k(['replace','--raw',`/api/v1/namespaces/${namespace}/pods/${pod}/ephemeralcontainers`,'-f','-'],JSON.stringify(currentPod));
+  let finished;
+  for(let attempt=0;attempt<40;attempt++) {
+    finished=json(['get','pod',pod,'-o','json']).status.ephemeralContainerStatuses?.find(item=>item.name===boundaryName)?.state?.terminated;
+    if(finished)break;
+    await delay(500);
+  }
+  assert.equal(finished?.exitCode,0,'Collector permission boundary test must complete successfully');
+  console.log(k(['logs',pod,'-c',boundaryName]).trim());
   console.log('PASS native gateway telemetry exported as Prometheus metrics');
 }
 if(values.externalSecrets.enabled) {

--- a/charts/hermes-agent/scripts/runtime-smoke.mjs
+++ b/charts/hermes-agent/scripts/runtime-smoke.mjs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {validateRecovery} from './runtime-recovery.mjs';
+
+const [context, namespace, release] = process.argv.slice(2);
+assert.equal(context, 'k3d-helmforge-tests-wsl');
+assert.equal(namespace, 'hf-validate-hermes-agent');
+const chart = path.resolve(import.meta.dirname, '..');
+const base = ['--context', context, '-n', namespace];
+const k = (args, input, timeout=65000) => execFileSync('kubectl', [...base, ...args], {encoding:'utf8',input,timeout,maxBuffer:8*1024*1024,stdio:['pipe','pipe','pipe']});
+const json = args => JSON.parse(k(args));
+const apply = object => k(['apply','-f','-'],JSON.stringify(object));
+const helm = args => execFileSync('helm',[...args,'--kube-context',context,'-n',namespace],{encoding:'utf8',stdio:'pipe',timeout:80000,maxBuffer:8*1024*1024});
+const delay = ms => new Promise(resolve=>setTimeout(resolve,ms));
+let values = JSON.parse(helm(['get','values',release,'--all','-o','json']));
+// The default installation deliberately requires real provider credentials. The
+// acceptance harness replaces inference only with a controlled local provider.
+if(values.agent.provider!=='custom:fixture') {
+  k(['apply','-f',path.join(chart,'ci','fixtures','agent-values.yaml')]);
+  k(['rollout','status','deployment/hermes-provider','--timeout=60s']);
+  const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-hermes-'));
+  const file=path.join(temporary,'values.json');
+  try {
+    fs.writeFileSync(file,JSON.stringify({agent:{model:'helmforge-fixture',provider:'custom:fixture',baseUrl:'http://hermes-provider:8080/v1',apiKeyEnv:'OPENAI_API_KEY'},credentials:{existingSecret:'hermes-provider-credentials'},networkPolicy:{allowInternet:false,extraEgress:[{to:[{podSelector:{matchLabels:{app:'hermes-provider'}}}],ports:[{protocol:'TCP',port:8080}]}]},config:{values:{model:{api_mode:'chat_completions'},auxiliary:{free_only:true}}}}));
+    helm(['upgrade',release,chart,'--reuse-values','-f',file,'--wait','--timeout','60s']);
+  } finally {fs.rmSync(file,{force:true});fs.rmdirSync(temporary);}
+  values = JSON.parse(helm(['get','values',release,'--all','-o','json']));
+}
+const statefulSet=json(['get','sts','-l',`app.kubernetes.io/instance=${release}`,'-o','json']).items[0];
+const name=statefulSet.metadata.name;
+const pod=`${name}-0`;
+const python=(script,container='hermes',target=pod,env=[])=>k(['exec','-i',target,'-c',container,'--','env',...env,'/opt/hermes/.venv/bin/python','-'],script);
+const accept=prompt=>python(fs.readFileSync(path.join(chart,'scripts','agent-accept.py'),'utf8'),'hermes',pod,[`TEST_PROMPT=${prompt}`]);
+const credentials=statefulSet.spec.template.spec.containers[0].env.find(item=>item.name==='API_SERVER_KEY').valueFrom.secretKeyRef.name;
+const beforeSecret=json(['get','secret',credentials,'-o','json']).data;
+python(`import os, pathlib, sqlite3
+assert os.getuid()==10000
+assert not pathlib.Path('/var/run/secrets/kubernetes.io/serviceaccount/token').exists()
+try:
+ pathlib.Path('/etc/helmforge-write-test').write_text('fail')
+ raise AssertionError('Root filesystem is writable')
+except PermissionError: pass
+except OSError as error: assert error.errno==30
+assert pathlib.Path('/proc/1/comm').read_text().strip()=='pause'
+assert sqlite3.connect('/opt/data/state.db').execute('pragma integrity_check').fetchone()[0]=='ok'
+assert any(pathlib.Path('/opt/data/skills').rglob('SKILL.md'))
+print('PASS restricted runtime, sandbox reaper, bundled skills and SQLite integrity')
+`);
+console.log(accept('HF_MEMORY_STORE').trim());
+const peer=json(['get','pods','-l','app=hermes-provider','-o','json']).items[0].metadata.name;
+const peerGet=url=>python(`import urllib.request\nprint(urllib.request.urlopen(${JSON.stringify(url)},timeout=3).status)`,'provider',peer);
+if(values.networkPolicy.enabled && values.networkPolicy.ingressFrom.length===0) {
+  assert.throws(()=>peerGet(`http://${name}:${values.service.port}/health`),'Untrusted client must be denied by NetworkPolicy');
+}
+const policy='hermes-acceptance-network';
+apply({apiVersion:'networking.k8s.io/v1',kind:'NetworkPolicy',metadata:{name:policy},spec:{podSelector:{matchLabels:{'app.kubernetes.io/instance':release,'app.kubernetes.io/component':'gateway'}},policyTypes:['Ingress'],ingress:[{from:[{podSelector:{matchLabels:{app:'hermes-provider'}}}],ports:[{protocol:'TCP',port:8642},...(values.dashboard.enabled?[{protocol:'TCP',port:9119}]:[])]}]}});
+try {
+  let reached=false;
+  for(let attempt=0;attempt<8;attempt++) {
+    try {reached=peerGet(`http://${name}:${values.service.port}/health`).trim()==='200';if(reached)break;}catch{}
+    await delay(500);
+  }
+  assert(reached,'Explicitly admitted client must reach the API Service');
+  if(values.service.ipFamilyPolicy==='RequireDualStack') {
+    const service=json(['get','service',name,'-o','json']);
+    assert.equal(service.spec.clusterIPs.length,2);
+    for(const ip of service.spec.clusterIPs) assert.equal(peerGet(`http://${ip.includes(':')?`[${ip}]`:ip}:${values.service.port}/health`).trim(),'200');
+    if(values.dashboard.enabled) {
+      const dashboard=json(['get','service',`${name}-dashboard`,'-o','json']);
+      assert.equal(dashboard.spec.clusterIPs.length,2);
+      for(const ip of dashboard.spec.clusterIPs) assert.equal(peerGet(`http://${ip.includes(':')?`[${ip}]`:ip}:${values.dashboard.service.port}/api/health`).trim(),'200');
+      console.log('PASS IPv4 and IPv6 dashboard Service access');
+    }
+  }
+} finally {k(['delete','networkpolicy',policy]);}
+console.log('PASS default-deny and explicitly allowed API network access');
+if(values.dashboard.enabled) {
+  console.log(python(fs.readFileSync(path.join(chart,'scripts','dashboard-accept.py'),'utf8'),'dashboard').trim());
+}
+if(values.metrics.enabled && values.metrics.collector.enabled) {
+  let metrics='';
+  for(let attempt=0;attempt<12;attempt++) {
+    metrics=python("import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:8889/metrics',timeout=5).read().decode())");
+    if(/^hermes_gateway_up\{[^\n]*\} 1(?:\.0)?$/m.test(metrics)) break;
+    await delay(2000);
+  }
+  assert.match(metrics,/^hermes_gateway_up\{[^\n]*\} 1(?:\.0)?$/m);
+  assert.match(metrics,/^hermes_gateway_active_agents\{/m);
+  const metricsUrl=`http://${name}-metrics:8889/metrics`;
+  if(values.networkPolicy.enabled && values.metrics.ingressFrom.length===0) assert.throws(()=>peerGet(metricsUrl),'Metrics must deny untrusted peers');
+  const metricsPolicy='hermes-acceptance-metrics';
+  apply({apiVersion:'networking.k8s.io/v1',kind:'NetworkPolicy',metadata:{name:metricsPolicy},spec:{podSelector:{matchLabels:{'app.kubernetes.io/instance':release,'app.kubernetes.io/component':'gateway'}},policyTypes:['Ingress'],ingress:[{from:[{podSelector:{matchLabels:{app:'hermes-provider'}}}],ports:[{protocol:'TCP',port:8889}]}]}});
+  try {
+    await delay(1000);
+    const exposed=python(`import urllib.request\nprint(urllib.request.urlopen(${JSON.stringify(metricsUrl)},timeout=5).read().decode())`,'provider',peer);
+    assert.match(exposed,/^hermes_gateway_up\{[^\n]*\} 1(?:\.0)?$/m);
+  } finally {k(['delete','networkpolicy',metricsPolicy]);}
+  if(values.metrics.serviceMonitor.enabled) assert.equal(json(['get','servicemonitor',name,'-o','json']).spec.endpoints[0].port,'metrics');
+  if(values.metrics.prometheusRule.enabled) assert.equal(json(['get','prometheusrule',name,'-o','json']).spec.groups[0].rules[0].alert,'HermesGatewayUnavailable');
+  console.log('PASS native gateway telemetry exported as Prometheus metrics');
+}
+if(values.externalSecrets.enabled) {
+  for(const item of json(['get','externalsecrets','-l',`app.kubernetes.io/instance=${release}`,'-o','json']).items) {
+    k(['wait','--for=condition=Ready',`externalsecret/${item.metadata.name}`,'--timeout=60s']);
+    assert(json(['get','secret',item.spec.target.name,'-o','json']).data);
+  }
+  console.log('PASS ESO reconciled Secrets consumed by authenticated gateway');
+}
+if(values.persistence.enabled) {
+  python("from pathlib import Path\np=Path('/opt/data/config.yaml')\np.write_text(p.read_text()+'\\n# helmforge-ci-user-edit\\n')");
+  const oldUid=json(['get','pod',pod,'-o','json']).metadata.uid;
+  k(['delete','pod',pod,'--wait=true','--timeout=60s']);
+  k(['wait','--for=condition=Ready',`pod/${pod}`,'--timeout=60s']);
+  assert.notEqual(json(['get','pod',pod,'-o','json']).metadata.uid,oldUid);
+  assert.deepEqual(json(['get','secret',credentials,'-o','json']).data,beforeSecret);
+  console.log(accept('HF_HISTORY_CHECK').trim());
+  console.log(accept('HF_MEMORY_CHECK').trim());
+  const configEdited=python("from pathlib import Path\nprint('helmforge-ci-user-edit' in Path('/opt/data/config.yaml').read_text())").trim();
+  assert.equal(configEdited,values.config.policy==='seed'?'True':'False','Configuration ownership must survive Pod replacement as declared');
+}
+if(release.endsWith('-ci-agent-values')) {
+  const claim=statefulSet.spec.template.spec.volumes.find(volume=>volume.name==='data').persistentVolumeClaim.claimName;
+  const claimUid=json(['get','pvc',claim,'-o','json']).metadata.uid;
+  const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-hermes-retain-'));
+  const file=path.join(temporary,'values.json');
+  try {
+    fs.writeFileSync(file,JSON.stringify(values));
+    helm(['uninstall',release,'--wait','--timeout','60s']);
+    assert.equal(json(['get','pvc',claim,'-o','json']).metadata.uid,claimUid);
+    assert.deepEqual(json(['get','secret',credentials,'-o','json']).data,beforeSecret);
+    helm(['install',release,chart,'-f',file,'--wait','--timeout','60s']);
+    assert.equal(json(['get','pvc',claim,'-o','json']).metadata.uid,claimUid);
+    assert.deepEqual(json(['get','secret',credentials,'-o','json']).data,beforeSecret);
+    console.log(accept('HF_HISTORY_CHECK').trim());
+    console.log('PASS Helm uninstall/reinstall retains the same PVC, API identity and real conversation');
+  } finally {fs.rmSync(file,{force:true});fs.rmdirSync(temporary);}
+}
+await validateRecovery({k,json,helm,values,name,pod,python,chart,namespace,release});
+console.log('PASS Hermes authentication, inference, tool dispatch and persistent state');

--- a/charts/hermes-agent/templates/NOTES.txt
+++ b/charts/hermes-agent/templates/NOTES.txt
@@ -1,0 +1,50 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "hermes-agent.validate" . -}}
+HERMES AGENT
+
+1. Release
+   {{ .Release.Name }} in {{ .Release.Namespace }}; upstream release {{ .Chart.AppVersion }}.
+   One gateway writer per data volume. Plan a maintenance window for upgrades.
+
+2. Runtime
+   kubectl -n {{ .Release.Namespace }} rollout status statefulset/{{ include "hermes-agent.fullname" . }}
+   Model: {{ .Values.agent.model }}; provider: {{ .Values.agent.provider }}.
+   Inference requires provider credentials in credentials.existingSecret.
+
+3. API access
+   Service: {{ include "hermes-agent.fullname" . }}:{{ .Values.service.port }}.
+   kubectl -n {{ .Release.Namespace }} port-forward service/{{ include "hermes-agent.fullname" . }} 8642:{{ .Values.service.port }}
+   API key: Secret {{ include "hermes-agent.authSecret" . }}, key {{ .Values.auth.key }}.
+   Send Authorization: Bearer <token>. API credentials authorize configured agent tools.
+   Admit trusted callers using networkPolicy.ingressFrom; configure TLS at your gateway.
+
+4. Dashboard and channels
+   Dashboard enabled: {{ .Values.dashboard.enabled }}; it uses separate administrative credentials.
+   Configuration policy: {{ .Values.config.policy }}. Seed mode preserves dashboard edits.
+   Messaging adapters require explicit user allowlists and their upstream token Secret.
+   Agent, dashboard and tools share one trusted execution and data boundary.
+
+5. Persistence
+   Persistent state: {{ .Values.persistence.enabled }}; claim: {{ include "hermes-agent.claim" . }}.
+   Retention after uninstall: {{ .Values.persistence.retain }}.
+   State includes SQLite sessions, memory, skills, cron definitions and workspace.
+   Environment-only credentials must be retained independently in Secrets/ESO.
+
+6. Backup and recovery
+   Scheduled S3 backup: {{ .Values.backup.enabled }}; schedule {{ .Values.backup.schedule }} ({{ .Values.backup.timeZone }}).
+   Restore enabled: {{ .Values.restore.enabled }}. Recovery never overwrites existing state.
+   Backups are consistent per SQLite database, not one transaction across every file.
+   Configure bucket lifecycle and test recovery; protect archives as sensitive credentials.
+
+7. Monitoring and maintenance
+   Native OTLP enabled: {{ .Values.metrics.enabled }}; ServiceMonitor: {{ .Values.metrics.serviceMonitor.enabled }}.
+   Readiness parses authenticated gateway health. HTTP 200 alone is insufficient.
+   Observe missing gateway metrics, PVC capacity, failed backup Jobs and container restarts.
+   Kubernetes owns process restarts; do not update the immutable installation from the UI.
+
+8. Documentation
+   https://helmforge.dev/docs/charts/hermes-agent
+   https://github.com/helmforgedev/charts/tree/main/charts/hermes-agent/docs
+   https://hermes-agent.nousresearch.com/
+
+Happy Helmforging :)

--- a/charts/hermes-agent/templates/_helpers.tpl
+++ b/charts/hermes-agent/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "hermes-agent.name" -}}{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{- end }}
+{{- define "hermes-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}{{ .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}{{ printf "%s-%s" .Release.Name (include "hermes-agent.name" .) | trunc 63 | trimSuffix "-" }}{{- end }}
+{{- end }}
+{{- define "hermes-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hermes-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "hermes-agent.labels" -}}
+{{ include "hermes-agent.selectorLabels" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- define "hermes-agent.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end }}
+{{- define "hermes-agent.authSecret" -}}{{ default (printf "%s-auth" (include "hermes-agent.fullname" .)) .Values.auth.existingSecret }}{{- end }}
+{{- define "hermes-agent.claim" -}}{{ default (printf "%s-data" (include "hermes-agent.fullname" .)) .Values.persistence.existingClaim }}{{- end }}
+{{- define "hermes-agent.serviceAccount" -}}
+{{- if .Values.serviceAccount.create }}{{ default (include "hermes-agent.fullname" .) .Values.serviceAccount.name }}{{ else }}{{ default "default" .Values.serviceAccount.name }}{{ end }}
+{{- end }}
+{{- define "hermes-agent.httpRouteName" -}}
+{{- $suffix := .route.name | default (printf "route-%v" .index) }}
+{{- printf "%s-%s" (include "hermes-agent.fullname" .root | trunc 40 | trimSuffix "-") ($suffix | trunc 22 | trimSuffix "-") }}
+{{- end }}
+{{- define "hermes-agent.externalSecretName" -}}
+{{- default (printf "%s-%s" (include "hermes-agent.fullname" .root | trunc 40 | trimSuffix "-") (.item.name | default "external" | trunc 22 | trimSuffix "-")) .item.fullnameOverride }}
+{{- end }}
+{{- define "hermes-agent.validate" -}}
+{{- if not .Values.agent.model }}{{ fail "agent.model is required" }}{{- end }}
+{{- if and .Values.persistence.existingClaim (not .Values.persistence.enabled) }}{{ fail "persistence.existingClaim requires persistence.enabled=true" }}{{- end }}
+{{- if hasKey .Values.config.values "platforms" }}{{ fail "config.values.platforms is reserved for the chart's authenticated gateway contract" }}{{- end }}
+{{- if hasKey .Values.config.values "platform_toolsets" }}{{ fail "configure agent.toolsets instead of config.values.platform_toolsets" }}{{- end }}
+{{- range $name, $channel := .Values.channels }}
+{{- if and $channel.enabled (or (empty $channel.allowedUsers) (empty $.Values.credentials.existingSecret)) }}{{ fail (printf "channels.%s requires allowedUsers and credentials.existingSecret" $name) }}{{- end }}
+{{- end }}
+{{- if and .Values.dashboard.enabled (or (ne .Values.config.policy "seed") (empty .Values.dashboard.existingSecret)) }}{{ fail "dashboard.enabled requires config.policy=seed and dashboard.existingSecret" }}{{- end }}
+{{- if and .Values.agent.apiKeyEnv (or (not (hasPrefix "custom:" .Values.agent.provider)) (empty .Values.agent.baseUrl)) }}{{ fail "agent.apiKeyEnv requires a custom:<name> provider and agent.baseUrl" }}{{- end }}
+{{- if and .Values.metrics.enabled (not .Values.metrics.collector.enabled) (empty .Values.metrics.externalEndpoint) }}{{ fail "metrics.externalEndpoint is required without the local collector" }}{{- end }}
+{{- if and (or .Values.metrics.serviceMonitor.enabled .Values.metrics.prometheusRule.enabled) (not (and .Values.metrics.enabled .Values.metrics.collector.enabled)) }}{{ fail "Prometheus integration requires metrics.enabled and metrics.collector.enabled" }}{{- end }}
+{{- if and (hasKey .Values.config.values "monitoring") .Values.metrics.enabled }}{{ fail "metrics.enabled owns config.values.monitoring; configure metrics values instead" }}{{- end }}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) }}{{ fail "gatewayAPI.enabled requires httpRoutes" }}{{- end }}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) }}{{ fail "externalSecrets.enabled requires items" }}{{- end }}
+{{- if or .Values.backup.enabled .Values.restore.enabled }}
+{{- if or (not .Values.persistence.enabled) (empty .Values.backup.s3.bucket) (empty .Values.backup.s3.existingSecret) }}{{ fail "backup/restore requires persistence.enabled, backup.s3.bucket and backup.s3.existingSecret" }}{{- end }}
+{{- if and .Values.backup.enabled (has "ReadWriteOncePod" .Values.persistence.accessModes) }}{{ fail "backup requires a concurrently mountable RWO or RWX claim, not ReadWriteOncePod" }}{{- end }}
+{{- if and (hasPrefix "http://" .Values.backup.s3.endpoint) (not .Values.backup.s3.allowInsecureEndpoint) }}{{ fail "HTTP S3 endpoints require backup.s3.allowInsecureEndpoint=true" }}{{- end }}
+{{- if and (eq .Values.backup.s3.sse "aws:kms") (empty .Values.backup.s3.kmsKeyId) }}{{ fail "backup.s3.sse=aws:kms requires kmsKeyId" }}{{- end }}
+{{- end }}
+{{- if and .Values.restore.enabled (empty .Values.restore.manifestKey) }}{{ fail "restore.enabled requires restore.manifestKey" }}{{- end }}
+{{- range .Values.extraEnv }}
+{{- if or (has .name (list "HOME" "HERMES_HOME" "API_SERVER_KEY" "HERMES_DISABLE_LAZY_INSTALLS" "PYTHONDONTWRITEBYTECODE")) (hasSuffix "ALLOW_ALL_USERS" .name) (hasSuffix "ALLOWED_USERS" .name) }}{{ fail (printf "extraEnv name %s is owned by chart identity/access controls" .name) }}{{- end }}
+{{- end }}
+{{- end }}
+{{- define "hermes-agent.bindHost" -}}{{ ternary "" "0.0.0.0" (or (has "IPv6" .Values.service.ipFamilies) (eq .Values.service.ipFamilyPolicy "RequireDualStack") (eq .Values.service.ipFamilyPolicy "PreferDualStack")) }}{{- end }}
+{{- define "hermes-agent.config" -}}
+{{- $model := dict "default" .Values.agent.model "provider" .Values.agent.provider }}
+{{- if .Values.agent.baseUrl }}{{ $_ := set $model "base_url" .Values.agent.baseUrl }}{{- end }}
+{{- $base := dict "model" $model "agent" (dict "max_turns" .Values.agent.maxIterations) "database" (dict "journal_mode" "wal" "synchronous" "FULL") "terminal" (dict "backend" "local" "cwd" "/opt/data/workspace") }}
+{{- $cfg := mergeOverwrite $base (deepCopy .Values.config.values) }}
+{{- if .Values.agent.apiKeyEnv }}
+{{- $providers := get $cfg "providers" | default dict }}
+{{- $_ := set $providers (trimPrefix "custom:" .Values.agent.provider) (dict "base_url" .Values.agent.baseUrl "api_mode" "chat_completions" "key_env" .Values.agent.apiKeyEnv) }}
+{{- $_ := set $cfg "providers" $providers }}
+{{- end }}
+{{- $bind := include "hermes-agent.bindHost" . }}
+{{- $platforms := dict "api_server" (dict "enabled" true "extra" (dict "host" $bind "port" 8642)) }}
+{{- $toolsets := dict "api_server" .Values.agent.toolsets }}
+{{- range $name, $channel := .Values.channels }}
+{{- $_ := set $platforms $name (dict "enabled" $channel.enabled) }}
+{{- $_ := set $toolsets $name $channel.toolsets }}
+{{- end }}
+{{- $_ := set $cfg "platforms" $platforms }}
+{{- $_ := set $cfg "platform_toolsets" $toolsets }}
+{{- if .Values.dashboard.publicUrl }}
+{{- $dashboard := get $cfg "dashboard" | default dict }}
+{{- $_ := set $dashboard "public_url" .Values.dashboard.publicUrl }}
+{{- $_ := set $cfg "dashboard" $dashboard }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+{{- $endpoint := ternary "http://127.0.0.1:4318/v1/metrics" .Values.metrics.externalEndpoint .Values.metrics.collector.enabled }}
+{{- $_ := set $cfg "monitoring" (dict "gateway_health_export" (dict "enabled" true "metrics_enabled" true "diagnostic_events_enabled" false "warning_error_events_enabled" false "export_interval_seconds" .Values.metrics.intervalSeconds) "export" (dict "otlp" (dict "enabled" true "endpoint" $endpoint "headers_env" dict))) }}
+{{- end }}
+{{- toYaml $cfg }}
+{{- end }}

--- a/charts/hermes-agent/templates/_helpers.tpl
+++ b/charts/hermes-agent/templates/_helpers.tpl
@@ -37,6 +37,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- if and .Values.dashboard.enabled (or (ne .Values.config.policy "seed") (empty .Values.dashboard.existingSecret)) }}{{ fail "dashboard.enabled requires config.policy=seed and dashboard.existingSecret" }}{{- end }}
 {{- if and .Values.agent.apiKeyEnv (or (not (hasPrefix "custom:" .Values.agent.provider)) (empty .Values.agent.baseUrl)) }}{{ fail "agent.apiKeyEnv requires a custom:<name> provider and agent.baseUrl" }}{{- end }}
+{{- if and .Values.agent.apiKeyEnv (not (hasPrefix "https://" .Values.agent.baseUrl)) (not (and .Values.agent.allowInsecureHTTP (hasPrefix "http://" .Values.agent.baseUrl))) }}{{ fail "credentialed custom providers require HTTPS; agent.allowInsecureHTTP is an explicit trusted-network exception" }}{{- end }}
 {{- if and .Values.metrics.enabled (not .Values.metrics.collector.enabled) (empty .Values.metrics.externalEndpoint) }}{{ fail "metrics.externalEndpoint is required without the local collector" }}{{- end }}
 {{- if and (or .Values.metrics.serviceMonitor.enabled .Values.metrics.prometheusRule.enabled) (not (and .Values.metrics.enabled .Values.metrics.collector.enabled)) }}{{ fail "Prometheus integration requires metrics.enabled and metrics.collector.enabled" }}{{- end }}
 {{- if and (hasKey .Values.config.values "monitoring") .Values.metrics.enabled }}{{ fail "metrics.enabled owns config.values.monitoring; configure metrics values instead" }}{{- end }}

--- a/charts/hermes-agent/templates/_recovery.tpl
+++ b/charts/hermes-agent/templates/_recovery.tpl
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "hermes-agent.s3Env" -}}
+- {name: HOME, value: /tmp}
+- {name: S3_BUCKET, value: {{ .Values.backup.s3.bucket | quote }}}
+- {name: S3_PREFIX, value: {{ .Values.backup.s3.prefix | quote }}}
+- {name: S3_REGION, value: {{ .Values.backup.s3.region | quote }}}
+- {name: S3_ENDPOINT, value: {{ .Values.backup.s3.endpoint | quote }}}
+- {name: ALLOW_INSECURE_ENDPOINT, value: {{ .Values.backup.s3.allowInsecureEndpoint | toString | quote }}}
+- {name: S3_SSE, value: {{ .Values.backup.s3.sse | quote }}}
+- {name: S3_KMS_KEY_ID, value: {{ .Values.backup.s3.kmsKeyId | quote }}}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_ACCESS_KEY_ID}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_SECRET_ACCESS_KEY}
+- name: AWS_SESSION_TOKEN
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_SESSION_TOKEN, optional: true}
+{{- if .Values.backup.s3.caSecret }}
+- {name: AWS_CA_BUNDLE, value: /s3-ca/ca.crt}
+{{- end }}
+{{- end }}
+{{- define "hermes-agent.restoreEnv" -}}
+- {name: HERMES_HOME, value: /tmp/hermes-recovery}
+- {name: TARGET_HOME, value: /opt/data}
+- {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+- {name: RESTORE_MANIFEST_KEY, value: {{ .Values.restore.manifestKey | quote }}}
+- {name: MAX_ARCHIVE_BYTES, value: {{ .Values.restore.maxArchiveBytes | int64 | toString | quote }}}
+- {name: MAX_EXPANDED_BYTES, value: {{ .Values.restore.maxExpandedBytes | int64 | toString | quote }}}
+{{- end }}
+{{- define "hermes-agent.restoreInitContainers" -}}
+{{- range $action := list "prepare-restore" "download" "restore" }}
+- name: {{ $action }}
+  {{- if eq $action "download" }}
+  image: {{ printf "%s:%s" $.Values.backup.image.repository $.Values.backup.image.tag | quote }}
+  command: [/bin/bash, /recovery/s3.sh, download]
+  {{- else }}
+  image: {{ include "hermes-agent.image" $ | quote }}
+  command: [/opt/hermes/.venv/bin/python, /recovery/archive.py, {{ $action }}]
+  {{- end }}
+  env:
+    {{- include "hermes-agent.restoreEnv" $ | nindent 4 }}
+    {{- if eq $action "download" }}
+    {{- include "hermes-agent.s3Env" $ | nindent 4 }}
+    {{- else }}
+    - {name: HOME, value: /tmp}
+    {{- end }}
+  securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+  resources: {{ toJson $.Values.backup.resources }}
+  volumeMounts:
+    - {name: recovery, mountPath: /recovery, readOnly: true}
+    - {name: recovery-work, mountPath: /work}
+    - {name: tmp, mountPath: /tmp}
+    {{- if ne $action "download" }}
+    - {name: data, mountPath: /opt/data}
+    {{- else if $.Values.backup.s3.caSecret }}
+    - {name: s3-ca, mountPath: /s3-ca, readOnly: true}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/backup-networkpolicy.yaml
+++ b/charts/hermes-agent/templates/backup-networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.backup.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-backup
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hermes-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backup
+  policyTypes: [Ingress, Egress]
+  ingress: []
+  egress:
+    - to: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}}]
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    - to:
+        - ipBlock: {cidr: 0.0.0.0/0, except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8]}
+        - ipBlock: {cidr: "2000::/3"}
+      ports: [{protocol: TCP, port: 443}]
+    {{- with .Values.backup.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/backup.yaml
+++ b/charts/hermes-agent/templates/backup.yaml
@@ -1,0 +1,98 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-backup
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+automountServiceAccountToken: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-backup
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  timeZone: {{ .Values.backup.timeZone | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "hermes-agent.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "hermes-agent.fullname" . }}-backup
+          automountServiceAccountToken: false
+          securityContext: {runAsNonRoot: true, runAsUser: 10000, runAsGroup: 10000, fsGroup: 10000, fsGroupChangePolicy: OnRootMismatch, seccompProfile: {type: RuntimeDefault}}
+          nodeSelector: {{ toJson .Values.nodeSelector }}
+          tolerations: {{ toJson .Values.tolerations }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets: {{ toJson . }}
+          {{- end }}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      {{- include "hermes-agent.selectorLabels" . | nindent 22 }}
+                      app.kubernetes.io/component: gateway
+          initContainers:
+            - name: snapshot
+              image: {{ include "hermes-agent.image" . | quote }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: [/opt/hermes/.venv/bin/python, /recovery/archive.py, backup]
+              env:
+                - {name: HOME, value: /tmp}
+                - {name: HERMES_HOME, value: /opt/data}
+                - {name: HERMES_IMAGE, value: {{ include "hermes-agent.image" . | quote }}}
+                - {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+              securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+              resources: {{ toJson .Values.backup.resources }}
+              volumeMounts:
+                - {name: data, mountPath: /opt/data}
+                - {name: recovery, mountPath: /recovery, readOnly: true}
+                - {name: work, mountPath: /work}
+                - {name: tmp, mountPath: /tmp}
+          containers:
+            - name: upload
+              image: {{ printf "%s:%s" .Values.backup.image.repository .Values.backup.image.tag | quote }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              command: [/bin/bash, /recovery/s3.sh, upload]
+              env:
+                {{- include "hermes-agent.s3Env" . | nindent 16 }}
+              securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+              resources: {{ toJson .Values.backup.resources }}
+              volumeMounts:
+                - {name: recovery, mountPath: /recovery, readOnly: true}
+                - {name: work, mountPath: /work, readOnly: true}
+                - {name: tmp, mountPath: /tmp}
+                {{- if .Values.backup.s3.caSecret }}
+                - {name: s3-ca, mountPath: /s3-ca, readOnly: true}
+                {{- end }}
+          volumes:
+            - name: data
+              persistentVolumeClaim: {claimName: {{ include "hermes-agent.claim" . }}}
+            - name: recovery
+              configMap: {name: {{ include "hermes-agent.fullname" . }}-recovery}
+            - name: work
+              emptyDir: {sizeLimit: {{ .Values.backup.stagingSize }}}
+            - name: tmp
+              emptyDir: {sizeLimit: 128Mi}
+            {{- if .Values.backup.s3.caSecret }}
+            - name: s3-ca
+              secret: {secretName: {{ .Values.backup.s3.caSecret }}, items: [{key: ca.crt, path: ca.crt}]}
+            {{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/configmap.yaml
+++ b/charts/hermes-agent/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "hermes-agent.validate" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-config
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- include "hermes-agent.config" . | nindent 4 }}
+  SOUL.md: {{ .Values.config.soul | quote }}
+  bootstrap.py: |
+    {{- .Files.Get "files/bootstrap.py" | nindent 4 }}
+  health.py: |
+    {{- .Files.Get "files/health.py" | nindent 4 }}
+  entrypoint.py: |
+    {{- .Files.Get "files/entrypoint.py" | nindent 4 }}

--- a/charts/hermes-agent/templates/dashboard-service.yaml
+++ b/charts/hermes-agent/templates/dashboard-service.yaml
@@ -1,0 +1,24 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-dashboard
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- with .Values.dashboard.service.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toJson . }}
+  {{- end }}
+  ports: [{name: dashboard, port: {{ .Values.dashboard.service.port }}, targetPort: dashboard}]
+  selector:
+    {{- include "hermes-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+{{- end }}

--- a/charts/hermes-agent/templates/externalsecret.yaml
+++ b/charts/hermes-agent/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "hermes-agent.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "hermes-agent.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/gateway-httproute.yaml
+++ b/charts/hermes-agent/templates/gateway-httproute.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes | default list }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "hermes-agent.httpRouteName" (dict "root" $ "route" . "index" $index) }}
+  labels:
+    {{- include "hermes-agent.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .parentRefs }}
+  parentRefs:
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- end }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .rules }}
+    {{- range .rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else if not .omitDefaultBackend }}
+      backendRefs:
+        - name: {{ include "hermes-agent.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ include "hermes-agent.fullname" $ }}
+          port: {{ $.Values.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/headless-service.yaml
+++ b/charts/hermes-agent/templates/headless-service.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-headless
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports: [{name: api, port: 8642, targetPort: api}]
+  selector:
+    {{- include "hermes-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway

--- a/charts/hermes-agent/templates/ingress.yaml
+++ b/charts/hermes-agent/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{ toJson . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "hermes-agent.fullname" $ }}
+                port: {number: {{ $.Values.service.port }}}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/metrics.yaml
+++ b/charts/hermes-agent/templates/metrics.yaml
@@ -1,0 +1,109 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-collector
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 127.0.0.1:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        timeout: 5s
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        translation_strategy: UnderscoreEscapingWithoutSuffixes
+        metric_expiration: 5m
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-metrics
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toJson . }}
+  {{- end }}
+  ports: [{name: metrics, port: 8889, targetPort: metrics}]
+  selector:
+    {{- include "hermes-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+{{- if .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hermes-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  namespaceSelector: {matchNames: [{{ .Release.Namespace | quote }}]}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- if .Values.metrics.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "hermes-agent.fullname" . }}.gateway
+      rules:
+        - alert: HermesGatewayUnavailable
+          expr: hermes_gateway_up{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "hermes-agent.fullname" .) | quote }}} == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations: {summary: "Hermes gateway reports unavailable"}
+        - alert: HermesGatewayMetricsMissing
+          expr: absent(hermes_gateway_up{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "hermes-agent.fullname" .) | quote }}})
+          for: 10m
+          labels: {severity: warning}
+          annotations: {summary: "Native Hermes gateway metrics are absent"}
+        {{- with .Values.metrics.prometheusRule.additionalRules }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/networkpolicy.yaml
+++ b/charts/hermes-agent/templates/networkpolicy.yaml
@@ -1,0 +1,43 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hermes-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  policyTypes: [Ingress, Egress]
+  ingress:
+    {{- with .Values.networkPolicy.ingressFrom }}
+    - from: {{ toJson . }}
+      ports: [{protocol: TCP, port: 8642}]
+    {{- end }}
+    {{- if and .Values.dashboard.enabled .Values.dashboard.ingressFrom }}
+    - from: {{ toJson .Values.dashboard.ingressFrom }}
+      ports: [{protocol: TCP, port: 9119}]
+    {{- end }}
+    {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled .Values.metrics.ingressFrom }}
+    - from: {{ toJson .Values.metrics.ingressFrom }}
+      ports: [{protocol: TCP, port: 8889}]
+    {{- end }}
+    {{- if not (or .Values.networkPolicy.ingressFrom (and .Values.dashboard.enabled .Values.dashboard.ingressFrom) (and .Values.metrics.enabled .Values.metrics.collector.enabled .Values.metrics.ingressFrom)) }}
+    []
+    {{- end }}
+  egress:
+    - to: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}}]
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    {{- if .Values.networkPolicy.allowInternet }}
+    - to:
+        - ipBlock: {cidr: 0.0.0.0/0, except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8]}
+        - ipBlock: {cidr: "2000::/3"}
+      ports: [{protocol: TCP, port: 443}]
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hermes-agent/templates/recovery-configmap.yaml
+++ b/charts/hermes-agent/templates/recovery-configmap.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or .Values.backup.enabled .Values.restore.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}-recovery
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+data:
+  archive.py: |
+    {{- .Files.Get "files/archive.py" | nindent 4 }}
+  s3.sh: |
+    {{- .Files.Get "files/s3.sh" | nindent 4 }}
+{{- end }}

--- a/charts/hermes-agent/templates/secret.yaml
+++ b/charts/hermes-agent/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.auth.existingSecret }}
+{{- $name := include "hermes-agent.authSecret" . }}
+{{- $old := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- if and $old (not (index $old.data .Values.auth.key)) }}{{ fail "Retained API Secret is missing auth.key; migrate the Secret explicitly before changing its key" }}{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- if and .Values.persistence.enabled .Values.persistence.retain }}
+  annotations: {helm.sh/resource-policy: keep}
+  {{- end }}
+type: Opaque
+data:
+  {{ .Values.auth.key }}: {{ if and $old (index $old.data .Values.auth.key) }}{{ index $old.data .Values.auth.key }}{{ else }}{{ randAlphaNum 64 | b64enc }}{{ end }}
+{{- end }}

--- a/charts/hermes-agent/templates/service.yaml
+++ b/charts/hermes-agent/templates/service.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toJson . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toJson . }}
+  {{- end }}
+  selector:
+    {{- include "hermes-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  ports: [{name: api, port: {{ .Values.service.port }}, targetPort: api}]

--- a/charts/hermes-agent/templates/serviceaccount.yaml
+++ b/charts/hermes-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hermes-agent.serviceAccount" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/hermes-agent/templates/statefulset.yaml
+++ b/charts/hermes-agent/templates/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
           startupProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 5, failureThreshold: 30}
           livenessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 20}
           readinessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 10}
-          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          securityContext: {runAsUser: 10001, runAsGroup: 10001, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
           resources: {{ toJson .Values.metrics.collector.resources }}
           volumeMounts:
             - {name: collector-config, mountPath: /etc/otel, readOnly: true}

--- a/charts/hermes-agent/templates/statefulset.yaml
+++ b/charts/hermes-agent/templates/statefulset.yaml
@@ -1,0 +1,168 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "hermes-agent.fullname" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "hermes-agent.fullname" . }}-headless
+  selector:
+    matchLabels:
+      {{- include "hermes-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        {{- include "hermes-agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "hermes-agent.serviceAccount" . }}
+      automountServiceAccountToken: false
+      shareProcessNamespace: true
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toJson . }}
+      {{- end }}
+      nodeSelector: {{ toJson .Values.nodeSelector }}
+      tolerations: {{ toJson .Values.tolerations }}
+      affinity: {{ toJson .Values.affinity }}
+      initContainers:
+        {{- if .Values.restore.enabled }}
+        {{- include "hermes-agent.restoreInitContainers" . | nindent 8 }}
+        {{- end }}
+        - name: configure
+          image: {{ include "hermes-agent.image" . | quote }}
+          command: [/opt/hermes/.venv/bin/python, /helmforge/bootstrap.py]
+          env:
+            - {name: CONFIG_POLICY, value: {{ .Values.config.policy | quote }}}
+            - {name: HERMES_HOME, value: /opt/data}
+            - {name: HOME, value: /opt/data}
+            - {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.resources }}
+          volumeMounts:
+            - {name: data, mountPath: /opt/data}
+            - {name: config, mountPath: /helmforge, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
+      containers:
+        - name: hermes
+          image: {{ include "hermes-agent.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [/opt/hermes/.venv/bin/python, /helmforge/entrypoint.py, /opt/hermes/.venv/bin/hermes, gateway, run, --no-supervise]
+          workingDir: /opt/data/workspace
+          env:
+            - {name: HERMES_HOME, value: /opt/data}
+            - {name: HOME, value: /opt/data}
+            - {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+            - {name: HERMES_DISABLE_LAZY_INSTALLS, value: "1"}
+            - {name: GATEWAY_ALLOW_ALL_USERS, value: "false"}
+            - {name: GATEWAY_ALLOWED_USERS, value: ""}
+            {{- range $name, $channel := .Values.channels }}
+            - {name: {{ upper $name }}_ALLOW_ALL_USERS, value: "false"}
+            - {name: {{ upper $name }}_ALLOWED_USERS, value: {{ join "," $channel.allowedUsers | quote }}}
+            {{- end }}
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef: {name: {{ include "hermes-agent.authSecret" . }}, key: {{ .Values.auth.key }}}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.credentials.existingSecret }}
+          envFrom:
+            - secretRef: {name: {{ .Values.credentials.existingSecret }}}
+          {{- end }}
+          ports: [{name: api, containerPort: 8642}]
+          startupProbe: {httpGet: {path: /health, port: api}, periodSeconds: 5, timeoutSeconds: 3, failureThreshold: 60}
+          livenessProbe: {httpGet: {path: /health, port: api}, periodSeconds: 20, timeoutSeconds: 3, failureThreshold: 3}
+          readinessProbe:
+            exec: {command: [/opt/hermes/.venv/bin/python, /helmforge/health.py]}
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.resources }}
+          volumeMounts:
+            - {name: data, mountPath: /opt/data}
+            - {name: config, mountPath: /helmforge, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
+        {{- if .Values.dashboard.enabled }}
+        - name: dashboard
+          image: {{ include "hermes-agent.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [/opt/hermes/.venv/bin/python, /helmforge/entrypoint.py, /opt/hermes/.venv/bin/hermes, dashboard, --host, {{ include "hermes-agent.bindHost" . | quote }}, --port, "9119", --no-open, --skip-build]
+          workingDir: /opt/data/workspace
+          env:
+            - {name: HERMES_HOME, value: /opt/data}
+            - {name: HOME, value: /opt/data}
+            - {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+            - {name: HERMES_DISABLE_LAZY_INSTALLS, value: "1"}
+            - {name: HERMES_WEB_DIST, value: /opt/hermes/hermes_cli/web_dist}
+          envFrom:
+            - secretRef: {name: {{ .Values.dashboard.existingSecret }}}
+            {{- if .Values.credentials.existingSecret }}
+            - secretRef: {name: {{ .Values.credentials.existingSecret }}}
+            {{- end }}
+          ports: [{name: dashboard, containerPort: 9119}]
+          startupProbe: {httpGet: {path: /api/health, port: dashboard}, periodSeconds: 5, timeoutSeconds: 3, failureThreshold: 60}
+          livenessProbe: {httpGet: {path: /api/health, port: dashboard}, periodSeconds: 20, timeoutSeconds: 3, failureThreshold: 3}
+          readinessProbe: {httpGet: {path: /api/health, port: dashboard}, periodSeconds: 10, timeoutSeconds: 3}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.dashboard.resources }}
+          volumeMounts:
+            - {name: data, mountPath: /opt/data}
+            - {name: config, mountPath: /helmforge, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
+        {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+        - name: metrics
+          image: {{ printf "%s:%s" .Values.metrics.collector.image.repository .Values.metrics.collector.image.tag | quote }}
+          imagePullPolicy: {{ .Values.metrics.collector.image.pullPolicy }}
+          args: [--config=/etc/otel/config.yaml]
+          ports: [{name: metrics, containerPort: 8889}]
+          startupProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 20}
+          readinessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 10}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.metrics.collector.resources }}
+          volumeMounts:
+            - {name: collector-config, mountPath: /etc/otel, readOnly: true}
+        {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim: {claimName: {{ include "hermes-agent.claim" . }}}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          configMap: {name: {{ include "hermes-agent.fullname" . }}-config}
+        - name: tmp
+          emptyDir: {sizeLimit: 512Mi}
+        {{- if .Values.restore.enabled }}
+        - name: recovery
+          configMap: {name: {{ include "hermes-agent.fullname" . }}-recovery}
+        - name: recovery-work
+          emptyDir: {sizeLimit: {{ .Values.backup.stagingSize }}}
+        {{- if .Values.backup.s3.caSecret }}
+        - name: s3-ca
+          secret: {secretName: {{ .Values.backup.s3.caSecret }}, items: [{key: ca.crt, path: ca.crt}]}
+        {{- end }}
+        {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+        - name: collector-config
+          configMap: {name: {{ include "hermes-agent.fullname" . }}-collector}
+        {{- end }}

--- a/charts/hermes-agent/templates/storage.yaml
+++ b/charts/hermes-agent/templates/storage.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hermes-agent.claim" . }}
+  labels:
+    {{- include "hermes-agent.labels" . | nindent 4 }}
+  {{- if .Values.persistence.retain }}
+  annotations: {helm.sh/resource-policy: keep}
+  {{- end }}
+spec:
+  accessModes: {{ .Values.persistence.accessModes | toJson }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests: {storage: {{ .Values.persistence.size | quote }}}
+{{- end }}

--- a/charts/hermes-agent/tests/core_test.yaml
+++ b/charts/hermes-agent/tests/core_test.yaml
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Hermes core contracts
+templates:
+  - configmap.yaml
+  - statefulset.yaml
+  - secret.yaml
+  - storage.yaml
+  - service.yaml
+  - networkpolicy.yaml
+tests:
+  - it: runs exactly one persistent gateway writer
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.shareProcessNamespace
+          value: true
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+  - it: runs without root or privilege escalation
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 10000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+  - it: uses semantic authenticated readiness
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - /opt/hermes/.venv/bin/python
+            - /helmforge/health.py
+  - it: keeps API tokens after retained uninstall
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - matchRegex:
+          path: data.api-key
+          pattern: ^[A-Za-z0-9+/=]+$
+  - it: does not create credentials when existing Secret selected
+    template: secret.yaml
+    set:
+      auth.existingSecret: external-api
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: keeps state after uninstall
+    template: storage.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+  - it: uses an existing claim without allocating another
+    template: storage.yaml
+    set:
+      persistence.existingClaim: agent-state
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: permits deliberate ephemeral operation
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+  - it: keeps target port independent of Service port
+    template: service.yaml
+    set:
+      service.port: 80
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: api
+  - it: passes explicit dual-stack service policy
+    template: service.yaml
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack
+  - it: pins API network policy to container port
+    template: networkpolicy.yaml
+    set:
+      service.port: 80
+      networkPolicy.ingressFrom:
+        - podSelector:
+            matchLabels:
+              role: client
+    asserts:
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8642
+  - it: denies inbound traffic by default
+    template: networkpolicy.yaml
+    asserts:
+      - equal:
+          path: spec.ingress
+          value: []
+  - it: supports extra provider egress without broad cluster access
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.allowInternet: false
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.1.2.3/32
+          ports:
+            - protocol: TCP
+              port: 8080
+    asserts:
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 8080

--- a/charts/hermes-agent/tests/guardrails_test.yaml
+++ b/charts/hermes-agent/tests/guardrails_test.yaml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Hermes guardrails contracts
+templates:
+  - configmap.yaml
+tests:
+  - it: requires an allowlist for enabled messaging
+    template: configmap.yaml
+    set:
+      channels.telegram.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: channels.telegram requires allowedUsers and credentials.existingSecret
+  - it: requires dashboard credential and editable configuration
+    template: configmap.yaml
+    set:
+      dashboard.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: dashboard.enabled requires config.policy=seed and dashboard.existingSecret
+  - it: rejects custom credentials without custom provider
+    template: configmap.yaml
+    set:
+      agent.apiKeyEnv: CUSTOM_KEY
+    asserts:
+      - failedTemplate:
+          errorMessage: agent.apiKeyEnv requires a custom:<name> provider and agent.baseUrl
+  - it: rejects metrics without a receiver
+    template: configmap.yaml
+    set:
+      metrics.enabled: true
+      metrics.collector.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: metrics.externalEndpoint is required without the local collector
+  - it: rejects ServiceMonitor without collector
+    template: configmap.yaml
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: Prometheus integration requires metrics.enabled and metrics.collector.enabled
+  - it: rejects backup without required storage
+    template: configmap.yaml
+    set:
+      backup.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: backup/restore requires persistence.enabled, backup.s3.bucket and backup.s3.existingSecret
+  - it: rejects single-Pod access mode for concurrent backup
+    template: configmap.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: hermes-backups
+      backup.s3.existingSecret: s3
+      persistence.accessModes:
+        - ReadWriteOncePod
+    asserts:
+      - failedTemplate:
+          errorMessage: backup requires a concurrently mountable RWO or RWX claim, not ReadWriteOncePod
+  - it: rejects accidental plaintext object storage
+    template: configmap.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: hermes-backups
+      backup.s3.existingSecret: s3
+      backup.s3.endpoint: http://storage:8333
+    asserts:
+      - failedTemplate:
+          errorMessage: HTTP S3 endpoints require backup.s3.allowInsecureEndpoint=true
+  - it: rejects configuration bypass of API authentication
+    template: configmap.yaml
+    set:
+      config.values.platforms: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: config.values.platforms is reserved for the chart's authenticated gateway contract
+  - it: rejects unsafe allow-all environment override
+    template: configmap.yaml
+    set:
+      extraEnv:
+        - name: GATEWAY_ALLOW_ALL_USERS
+          value: 'true'
+    asserts:
+      - failedTemplate:
+          errorMessage: extraEnv name GATEWAY_ALLOW_ALL_USERS is owned by chart identity/access controls

--- a/charts/hermes-agent/tests/guardrails_test.yaml
+++ b/charts/hermes-agent/tests/guardrails_test.yaml
@@ -83,3 +83,11 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: extraEnv name GATEWAY_ALLOW_ALL_USERS is owned by chart identity/access controls
+  - it: rejects cleartext credentialed custom provider endpoints by default
+    set:
+      agent.provider: custom:internal
+      agent.baseUrl: http://inference.example.com/v1
+      agent.apiKeyEnv: PROVIDER_KEY
+    asserts:
+      - failedTemplate:
+          errorMessage: 'credentialed custom providers require HTTPS; agent.allowInsecureHTTP is an explicit trusted-network exception'

--- a/charts/hermes-agent/tests/integrations_test.yaml
+++ b/charts/hermes-agent/tests/integrations_test.yaml
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Hermes integrations contracts
+templates:
+  - configmap.yaml
+  - dashboard-service.yaml
+  - statefulset.yaml
+  - ingress.yaml
+  - gateway-httproute.yaml
+  - externalsecret.yaml
+  - metrics.yaml
+tests:
+  - it: leaves dashboard disabled by default
+    template: dashboard-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: runs authenticated dashboard in the existing agent boundary
+    template: statefulset.yaml
+    set:
+      dashboard.enabled: true
+      dashboard.existingSecret: dashboard-auth
+      config.policy: seed
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: dashboard
+      - equal:
+          path: spec.template.spec.containers[1].envFrom[0].secretRef.name
+          value: dashboard-auth
+  - it: uses ingressClassName when specified
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+  - it: omits unspecified ingress class
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+  - it: provides canonical HTTPRoute default backend
+    template: gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - parentRefs:
+            - name: edge
+          hostnames:
+            - hermes.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8642
+      - equal:
+          path: spec.hostnames
+          value:
+            - hermes.example.com
+  - it: keeps explicit redirect-only routes backend-free
+    template: gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - rules:
+            - omitDefaultBackend: true
+              filters:
+                - type: RequestRedirect
+                  requestRedirect:
+                    scheme: https
+    asserts:
+      - notExists:
+          path: spec.rules[0].backendRefs
+  - it: does not install External Secrets Operator resources by default
+    template: externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: honors literal ExternalSecret names and target default
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: agent-provider
+          spec:
+            secretStoreRef:
+              name: vault
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: hermes
+    asserts:
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: agent-provider
+      - equal:
+          path: spec.target.name
+          value: agent-provider
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: permits per-item sync and target overrides
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - spec:
+            refreshInterval: 5m
+            target:
+              name: custom-target
+            secretStoreRef:
+              name: vault
+            dataFrom:
+              - extract:
+                  key: hermes
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: 5m
+      - equal:
+          path: spec.target.name
+          value: custom-target
+  - it: does not run Prometheus collector unless metrics enabled
+    template: metrics.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders collector ServiceMonitor and alert resources
+    template: metrics.yaml
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.prometheusRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+  - it: mounts no agent state into the telemetry collector
+    template: statefulset.yaml
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: metrics
+      - equal:
+          path: spec.template.spec.containers[1].volumeMounts
+          value:
+            - name: collector-config
+              mountPath: /etc/otel
+              readOnly: true
+  - it: binds the dashboard on both families for dual-stack Services
+    template: statefulset.yaml
+    set:
+      dashboard.enabled: true
+      dashboard.existingSecret: dashboard-auth
+      config.policy: seed
+      service.ipFamilyPolicy: RequireDualStack
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].command[5]
+          value: ""

--- a/charts/hermes-agent/tests/integrations_test.yaml
+++ b/charts/hermes-agent/tests/integrations_test.yaml
@@ -165,3 +165,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].command[5]
           value: ""
+  - it: isolates collector process credentials with a separate unix identity
+    template: statefulset.yaml
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 10001
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsGroup
+          value: 10001

--- a/charts/hermes-agent/tests/recovery_test.yaml
+++ b/charts/hermes-agent/tests/recovery_test.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Hermes recovery contracts
+templates:
+  - configmap.yaml
+  - backup.yaml
+  - statefulset.yaml
+tests:
+  - it: does not schedule backups by default
+    template: backup.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: forbids concurrent backup jobs and retries
+    template: backup.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: hermes-backups
+      backup.s3.existingSecret: s3
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+        documentIndex: 1
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 0
+        documentIndex: 1
+  - it: uploader cannot mount live agent state
+    template: backup.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: hermes-backups
+      backup.s3.existingSecret: s3
+    asserts:
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /opt/data
+        documentIndex: 1
+  - it: runs offline restore before configuration and gateway startup
+    template: statefulset.yaml
+    set:
+      restore.enabled: true
+      restore.manifestKey: snapshots/hermes-run/manifest.json
+      backup.s3.bucket: hermes-backups
+      backup.s3.existingSecret: s3
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-restore
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: download
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: restore
+      - equal:
+          path: spec.template.spec.initContainers[3].name
+          value: configure

--- a/charts/hermes-agent/values.schema.json
+++ b/charts/hermes-agent/values.schema.json
@@ -1,0 +1,1001 @@
+{
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^.+@sha256:[a-f0-9]{64}$",
+          "not": {
+            "pattern": "^latest(@|$)"
+          }
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "credentials": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseUrl": {
+          "type": "string"
+        },
+        "toolsets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maxIterations": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "apiKeyEnv": {
+          "type": "string",
+          "pattern": "^$|^[A-Za-z_][A-Za-z0-9_]*$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "type": "string",
+          "enum": [
+            "managed",
+            "seed"
+          ]
+        },
+        "values": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "soul": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "ReadWriteOnce",
+              "ReadWriteOncePod",
+              "ReadWriteMany"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "size": {
+          "type": "string"
+        },
+        "retain": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "LoadBalancer",
+            "NodePort"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": [
+            "",
+            "SingleStack",
+            "PreferDualStack",
+            "RequireDualStack"
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "IPv4",
+              "IPv6"
+            ]
+          },
+          "maxItems": 2,
+          "uniqueItems": true
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {
+        "kubernetes.io/os": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {}
+    },
+    "affinity": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "podAnnotations": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "valueFrom"
+            ]
+          }
+        ]
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "podSelector": {
+                "type": "object"
+              },
+              "namespaceSelector": {
+                "type": "object"
+              },
+              "ipBlock": {
+                "type": "object",
+                "required": [
+                  "cidr"
+                ],
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "except": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "extraEgress": {
+          "type": "array",
+          "items": {}
+        },
+        "allowInternet": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 30,
+      "maximum": 600
+    },
+    "channels": {
+      "type": "object",
+      "properties": {
+        "telegram": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowedUsers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_-]+$"
+              },
+              "uniqueItems": true
+            },
+            "toolsets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "discord": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowedUsers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_-]+$"
+              },
+              "uniqueItems": true
+            },
+            "toolsets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "slack": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowedUsers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_-]+$"
+              },
+              "uniqueItems": true
+            },
+            "toolsets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "dashboard": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "publicUrl": {
+          "type": "string",
+          "pattern": "^$|^https://[^ /@]+(?::[0-9]+)?/?$"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "annotations": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "podSelector": {
+                "type": "object"
+              },
+              "namespaceSelector": {
+                "type": "object"
+              },
+              "ipBlock": {
+                "type": "object",
+                "required": [
+                  "cidr"
+                ],
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "except": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressClassName": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "parentRefs": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "hostnames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "spec"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "fullnameOverride": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "spec": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "intervalSeconds": {
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 3600
+        },
+        "externalEndpoint": {
+          "type": "string",
+          "pattern": "^$|^https?://[^ @]+/v1/metrics$"
+        },
+        "collector": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tag": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^.+@sha256:[a-f0-9]{64}$",
+                  "not": {
+                    "pattern": "^latest(@|$)"
+                  }
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "interval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "prometheusRule": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "additionalRules": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "additionalProperties": false
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "podSelector": {
+                "type": "object"
+              },
+              "namespaceSelector": {
+                "type": "object"
+              },
+              "ipBlock": {
+                "type": "object",
+                "required": [
+                  "cidr"
+                ],
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "except": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "backup": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        },
+        "suspend": {
+          "type": "boolean"
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 20
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 20
+        },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 86400
+        },
+        "stagingSize": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "pattern": "^$|^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$"
+            },
+            "prefix": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9/_-]*[A-Za-z0-9_-])?$"
+            },
+            "region": {
+              "type": "string"
+            },
+            "endpoint": {
+              "type": "string",
+              "pattern": "^$|^https?://[^ @]+$"
+            },
+            "allowInsecureEndpoint": {
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "sse": {
+              "type": "string",
+              "enum": [
+                "",
+                "AES256",
+                "aws:kms"
+              ]
+            },
+            "kmsKeyId": {
+              "type": "string"
+            },
+            "caSecret": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^.+@sha256:[a-f0-9]{64}$",
+              "not": {
+                "pattern": "^latest(@|$)"
+              }
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "networkPolicy": {
+          "type": "object",
+          "properties": {
+            "extraEgress": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "restore": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "manifestKey": {
+          "type": "string",
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9/_-]*/manifest\\.json$"
+        },
+        "maxArchiveBytes": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 1099511627776
+        },
+        "maxExpandedBytes": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 2199023255552
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HelmForge Hermes Agent values"
+}

--- a/charts/hermes-agent/values.schema.json
+++ b/charts/hermes-agent/values.schema.json
@@ -100,6 +100,9 @@
         "apiKeyEnv": {
           "type": "string",
           "pattern": "^$|^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "allowInsecureHTTP": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/charts/hermes-agent/values.yaml
+++ b/charts/hermes-agent/values.yaml
@@ -38,6 +38,8 @@ agent:
   maxIterations: 30
   # -- Credential environment variable for a named custom provider; never an inline API key.
   apiKeyEnv: ""
+  # -- Permit HTTP for a credentialed custom endpoint only in isolated tests or explicitly trusted networks.
+  allowInsecureHTTP: false
 # -- Non-secret upstream configuration with explicit ownership on Pod initialization.
 config:
   # -- managed reconciles declared files; seed preserves existing files and permits dashboard edits.

--- a/charts/hermes-agent/values.yaml
+++ b/charts/hermes-agent/values.yaml
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# -- Override the chart name used in resource labels.
+nameOverride: ""
+# -- Override all resource name prefixes for a stable existing installation.
+fullnameOverride: ""
+# -- Official Hermes runtime, pinned to a verified multi-platform release digest.
+image:
+  # -- Official container image repository.
+  repository: docker.io/nousresearch/hermes-agent
+  # -- Pinned release tag and immutable digest.
+  tag: v2026.9.11@sha256:9469b3e78b9545b6d576eb8887a95352e9a0ea83730eaf31431cf862ca1010e1
+  # -- Kubernetes image pull policy.
+  pullPolicy: IfNotPresent
+# -- image pull secrets setting for the gateway.
+imagePullSecrets: []
+# -- Bearer credential protecting API access and configured agent tools.
+auth:
+  # -- Use an existing Secret; empty generates a random token retained with persistent state.
+  existingSecret: ""
+  # -- Secret key containing the API bearer token.
+  key: api-key
+# -- Provider and messaging credentials are injected only from a Kubernetes Secret.
+credentials:
+  # -- Secret containing upstream environment variables such as OPENROUTER_API_KEY.
+  existingSecret: ""
+# -- Default model and explicitly allowed API toolsets.
+agent:
+  # -- Upstream model identifier; a corresponding provider credential is required for inference.
+  model: anthropic/claude-opus-4.6
+  # -- Provider identifier, including custom:<name> for an OpenAI-compatible endpoint.
+  provider: openrouter
+  # -- Optional model endpoint; custom providers should use apiKeyEnv for credential selection.
+  baseUrl: ""
+  # -- API toolsets. Memory-only by default; enabling terminal/browser grants additional capabilities.
+  toolsets:
+    - memory
+  # -- Maximum tool execution turns for one agent request.
+  maxIterations: 30
+  # -- Credential environment variable for a named custom provider; never an inline API key.
+  apiKeyEnv: ""
+# -- Non-secret upstream configuration with explicit ownership on Pod initialization.
+config:
+  # -- managed reconciles declared files; seed preserves existing files and permits dashboard edits.
+  policy: managed
+  # -- Additional upstream configuration. Do not place credentials here; chart-owned sections are validated.
+  values: {}
+  # -- Optional SOUL.md persona. Empty leaves upstream/user persona unmanaged.
+  soul: ""
+# -- One retained state volume per release; no concurrent gateway writers.
+persistence:
+  # -- Persist sessions, SQLite state, memory, skills and workspace.
+  enabled: true
+  # -- Existing persistent claim to mount instead of creating one.
+  existingClaim: ""
+  # -- StorageClass name; empty uses the cluster default.
+  storageClass: ""
+  # -- Claim access modes; shared backup mounts require RWO or RWX.
+  accessModes:
+    - ReadWriteOnce
+  # -- Requested persistent volume capacity.
+  size: 10Gi
+  # -- Keep chart-created PVC and generated API Secret after uninstall.
+  retain: true
+# -- service setting for the gateway.
+service:
+  # -- type setting for service.
+  type: ClusterIP
+  # -- Service port; network policies use the fixed container port.
+  port: 8642
+  # -- Additional Kubernetes annotations.
+  annotations: {}
+  # -- ip family policy setting for service.
+  ipFamilyPolicy: ""
+  # -- ip families setting for service.
+  ipFamilies: []
+  # -- load balancer source ranges setting for service.
+  loadBalancerSourceRanges: []
+# -- service account setting for the gateway.
+serviceAccount:
+  # -- create setting for serviceAccount.
+  create: true
+  # -- Existing or overridden Kubernetes resource name.
+  name: ""
+  # -- Additional Kubernetes annotations.
+  annotations: {}
+# -- Container CPU and memory requests and limits.
+resources:
+  # -- Guaranteed scheduler resource requests.
+  requests:
+    # -- CPU quantity.
+    cpu: 250m
+    # -- Memory quantity.
+    memory: 1Gi
+  # -- Enforced container resource limits.
+  limits:
+    # -- CPU quantity.
+    cpu: "2"
+    # -- Memory quantity.
+    memory: 2Gi
+# -- node selector setting for the gateway.
+nodeSelector:
+  # -- kubernetes.io/os setting for nodeSelector.
+  kubernetes.io/os: linux
+# -- tolerations setting for the gateway.
+tolerations: []
+# -- affinity setting for the gateway.
+affinity: {}
+# -- pod annotations setting for the gateway.
+podAnnotations: {}
+# -- extra env setting for the gateway.
+extraEnv: []
+# -- Default-deny ingress with separate API, dashboard and metrics peer allowlists.
+networkPolicy:
+  # -- Enable this optional integration.
+  enabled: true
+  # -- Kubernetes NetworkPolicy peers allowed to call container port 8642.
+  ingressFrom: []
+  # -- Explicit extra egress rules for custom providers, MCP servers or remote execution.
+  extraEgress: []
+  # -- Allow public IPv4/IPv6 HTTPS egress for providers; private networks require extraEgress.
+  allowInternet: true
+# -- Time for gateway shutdown and in-flight work before Kubernetes terminates the Pod.
+terminationGracePeriodSeconds: 120
+# -- Opt-in messaging adapters; credentials come from credentials.existingSecret and user allowlists are required.
+channels:
+  # -- telegram setting for channels.
+  telegram:
+    # -- Enable this optional integration.
+    enabled: false
+    # -- Explicit upstream user IDs permitted to interact with this messaging adapter.
+    allowedUsers: []
+    # -- Toolsets exposed to this messaging adapter.
+    toolsets:
+      - memory
+  # -- discord setting for channels.
+  discord:
+    # -- Enable this optional integration.
+    enabled: false
+    # -- Explicit upstream user IDs permitted to interact with this messaging adapter.
+    allowedUsers: []
+    # -- Toolsets exposed to this messaging adapter.
+    toolsets:
+      - memory
+  # -- slack setting for channels.
+  slack:
+    # -- Enable this optional integration.
+    enabled: false
+    # -- Explicit upstream user IDs permitted to interact with this messaging adapter.
+    allowedUsers: []
+    # -- Toolsets exposed to this messaging adapter.
+    toolsets:
+      - memory
+# -- Optional privileged administration UI in the gateway Pod; requires config.policy=seed.
+dashboard:
+  # -- Enable this optional integration.
+  enabled: false
+  # -- Secret with HERMES_DASHBOARD_BASIC_AUTH_USERNAME, HERMES_DASHBOARD_BASIC_AUTH_PASSWORD and HERMES_DASHBOARD_BASIC_AUTH_SECRET.
+  existingSecret: ""
+  # -- External HTTPS dashboard origin, used by Host validation and OAuth redirects.
+  publicUrl: ""
+  # -- Container CPU and memory requests and limits.
+  resources:
+    # -- Guaranteed scheduler resource requests.
+    requests:
+      # -- CPU quantity.
+      cpu: 100m
+      # -- Memory quantity.
+      memory: 256Mi
+    # -- Enforced container resource limits.
+    limits:
+      # -- CPU quantity.
+      cpu: "1"
+      # -- Memory quantity.
+      memory: 1Gi
+  # -- service setting for dashboard.
+  service:
+    # -- Service port; network policies use the fixed container port.
+    port: 9119
+    # -- Additional Kubernetes annotations.
+    annotations: {}
+  # -- NetworkPolicy peers allowed to reach the administrative dashboard on container port 9119.
+  ingressFrom: []
+# -- Optional API ingress. TLS termination is the ingress controller responsibility.
+ingress:
+  # -- Enable this optional integration.
+  enabled: false
+  # -- ingress class name setting for ingress.
+  ingressClassName: ""
+  # -- Additional Kubernetes annotations.
+  annotations: {}
+  # -- hosts setting for ingress.
+  hosts:
+    - host: hermes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- tls setting for ingress.
+  tls: []
+# -- Canonical Gateway API HTTPRoutes; backend defaults to the authenticated API Service.
+gatewayAPI:
+  # -- Enable this optional integration.
+  enabled: false
+  # -- http routes setting for gatewayAPI.
+  httpRoutes: []
+# -- Optional integration with an existing External Secrets Operator installation.
+externalSecrets:
+  # -- Enable this optional integration.
+  enabled: false
+  # -- refresh interval setting for externalSecrets.
+  refreshInterval: 1h
+  # -- items setting for externalSecrets.
+  items: []
+# -- Native Hermes gateway health metrics exported through OTLP; no synthetic inference/cost metrics.
+metrics:
+  # -- Enable native upstream OTLP gateway-health metrics.
+  enabled: false
+  # -- interval seconds setting for metrics.
+  intervalSeconds: 15
+  # -- Full external OTLP HTTP metrics URL ending in /v1/metrics when the collector is disabled.
+  externalEndpoint: ""
+  # -- Optional local official collector translating OTLP to Prometheus on port 8889.
+  collector:
+    # -- Enable this optional integration.
+    enabled: true
+    # -- image setting for metrics.collector.
+    image:
+      # -- Official container image repository.
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      # -- Pinned release tag and immutable digest.
+      tag: 0.160.0@sha256:799dc6cf12c96192af37b5bdba804da8c10b3bc563b43cb90c3f3c58d9572ad6
+      # -- Kubernetes image pull policy.
+      pullPolicy: IfNotPresent
+    # -- Container CPU and memory requests and limits.
+    resources:
+      # -- Guaranteed scheduler resource requests.
+      requests:
+        # -- CPU quantity.
+        cpu: 50m
+        # -- Memory quantity.
+        memory: 64Mi
+      # -- Enforced container resource limits.
+      limits:
+        # -- CPU quantity.
+        cpu: 500m
+        # -- Memory quantity.
+        memory: 256Mi
+  # -- service monitor setting for metrics.
+  serviceMonitor:
+    # -- Enable this optional integration.
+    enabled: false
+    # -- Additional Kubernetes labels.
+    labels: {}
+    # -- Prometheus scrape interval.
+    interval: 30s
+    # -- Prometheus scrape timeout.
+    scrapeTimeout: 10s
+  # -- prometheus rule setting for metrics.
+  prometheusRule:
+    # -- Enable this optional integration.
+    enabled: false
+    # -- Additional Kubernetes labels.
+    labels: {}
+    # -- additional rules setting for metrics.prometheusRule.
+    additionalRules: []
+  # -- NetworkPolicy peers allowed to scrape the private metrics Service.
+  ingressFrom: []
+# -- Scheduled SQLite-consistent native snapshots uploaded to S3 with a completion manifest.
+backup:
+  # -- Enable the backup CronJob; requires persistent storage and S3 configuration.
+  enabled: false
+  # -- schedule setting for backup.
+  schedule: 0 3 * * *
+  # -- time zone setting for backup.
+  timeZone: Etc/UTC
+  # -- suspend setting for backup.
+  suspend: false
+  # -- successful jobs history limit setting for backup.
+  successfulJobsHistoryLimit: 1
+  # -- failed jobs history limit setting for backup.
+  failedJobsHistoryLimit: 2
+  # -- active deadline seconds setting for backup.
+  activeDeadlineSeconds: 1800
+  # -- Ephemeral archive staging size; budget for the ZIP and temporary SQLite snapshots.
+  stagingSize: 10Gi
+  # -- Container CPU and memory requests and limits.
+  resources:
+    # -- Guaranteed scheduler resource requests.
+    requests:
+      # -- CPU quantity.
+      cpu: 100m
+      # -- Memory quantity.
+      memory: 256Mi
+    # -- Enforced container resource limits.
+    limits:
+      # -- CPU quantity.
+      cpu: "1"
+      # -- Memory quantity.
+      memory: 1Gi
+  # -- s3 setting for backup.
+  s3:
+    # -- bucket setting for backup.s3.
+    bucket: ""
+    # -- prefix setting for backup.s3.
+    prefix: hermes-agent
+    # -- region setting for backup.s3.
+    region: us-east-1
+    # -- endpoint setting for backup.s3.
+    endpoint: ""
+    # -- Allow HTTP only for explicitly trusted local test/object-storage networks.
+    allowInsecureEndpoint: false
+    # -- Secret with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, optionally AWS_SESSION_TOKEN.
+    existingSecret: ""
+    # -- sse setting for backup.s3.
+    sse: AES256
+    # -- kms key id setting for backup.s3.
+    kmsKeyId: ""
+    # -- Optional Secret containing ca.crt for a private HTTPS endpoint.
+    caSecret: ""
+  # -- image setting for backup.
+  image:
+    # -- Official container image repository.
+    repository: public.ecr.aws/aws-cli/aws-cli
+    # -- Pinned release tag and immutable digest.
+    tag: 2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441
+    # -- Kubernetes image pull policy.
+    pullPolicy: IfNotPresent
+  # -- network policy setting for backup.
+  networkPolicy:
+    # -- Additional backup Pod egress, for example private object storage.
+    extraEgress: []
+# -- Explicit disaster recovery into an empty volume before configuration initialization.
+restore:
+  # -- Restore exactly once into empty state; existing nonempty state is never overwritten.
+  enabled: false
+  # -- Full S3 object key of the completed backup manifest; uses backup.s3 settings.
+  manifestKey: ""
+  # -- Maximum downloaded archive size accepted in bytes.
+  maxArchiveBytes: 10737418240
+  # -- Maximum aggregate uncompressed archive bytes accepted during restore.
+  maxExpandedBytes: 21474836480


### PR DESCRIPTION
## Summary

Add a production Hermes Agent chart using the official v2026.9.11 image pinned by digest. One release runs one persistent gateway, with authenticated API access, retained identity and state, explicit configuration ownership, and controlled tool/channel access.

The optional dashboard uses a separate authentication Secret. Native OTLP telemetry feeds an optional OpenTelemetry collector, Prometheus ServiceMonitor and alert rules. Scheduled S3 backups verify SQLite snapshots, every archive member and the uploaded bytes before publishing a completion manifest; restore only accepts empty storage and remains idempotent across restarts.

Resolves #1187

## Type Of Change

- [x] New chart

## Validation

- `make validate-chart CHART=hermes-agent`: all 18 layers and eight k3d scenarios; 42 unit tests.
- Real Hermes turns and memory tools against a local OpenAI-compatible fixture, with authentication rejection, persisted conversations and memory, configuration ownership, Pod replacement and retained uninstall/reinstall.
- Default-deny networking, both API address families, dashboard authentication, native Prometheus metrics, ESO reconciliation, and HTTPS S3 backup/independent-volume recovery.
- Backup failure tests reject incomplete SQLite snapshots, unreadable included files, altered archives, unsafe paths and nonempty restore targets. SQLite files without conventional extensions are identified by their header.
- `make preflight`, chart standards, template standards and cross-repository parity pass.
- Kubescape v4.0.14 MITRE/NSA/SOC2: 99.393936%. The unsuppressed C-0012 finding matches the literal Bearer header in the readiness helper; its actual credential comes from a Secret-backed environment variable.

## Operational boundaries

One gateway writer per volume; no HPA or shared-writer HA. API callers and dashboard administrators are trusted to operate the configured agent tools. Backups are consistent per SQLite database, not a global transaction across independent files. Provider credentials, live messaging, OIDC and edge-controller routing require environment-specific acceptance; local tests do not make paid model calls or contact real messaging users.

The new chart starts at the required 0.1.0 baseline; the breaking feature commit requests the first CI-managed 1.0.0 release after merge. Upstream manifests exist for amd64 and arm64; local behavioral validation runs on amd64.

## Site Sync

Companion documentation, complete values reference, official icon, catalog and playground are included in the site PR. Organization profile counts become 113 charts and 42 backup-capable charts.

Companion PRs: https://github.com/helmforgedev/site/pull/561 and https://github.com/helmforgedev/.github/pull/26.

Review fixes also cover descriptor-bound backup reads, collector UID separation with a real process-permission test, explicit HTTPS defaults for credentialed custom endpoints, and production staging/recovery sizing. All six review threads are addressed.

