### PR TITLE
feat(openclaw)!: add production openclaw chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What HelmForge Provides
 
-HelmForge is a catalog of 113 Helm charts built around a consistent operating contract:
+HelmForge is a catalog of 114 Helm charts built around a consistent operating contract:
 official upstream images, pinned versions, explicit values, reproducible validation, and signed releases.
 
 Use HelmForge when you want charts that stay close to upstream applications while still behaving like a

--- a/charts/openclaw/.helmignore
+++ b/charts/openclaw/.helmignore
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+.git
+*.tgz
+Chart.lock
+scripts/

--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: openclaw
+description: Persistent OpenClaw gateway with secure device pairing, native telemetry and verified S3 recovery.
+type: application
+version: 0.1.0
+appVersion: 2026.9.4
+kubeVersion: '>=1.30.0-0'
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - openclaw
+  - ai
+  - automation
+  - kubernetes
+home: https://helmforge.dev/docs/charts/openclaw
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/openclaw
+  - https://github.com/openclaw/openclaw
+icon: https://helmforge.dev/icons/charts/openclaw.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Production OpenClaw gateway with secure persistent operations.
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/openclaw
+    - name: Upstream
+      url: https://github.com/openclaw/openclaw

--- a/charts/openclaw/DESIGN.md
+++ b/charts/openclaw/DESIGN.md
@@ -1,0 +1,38 @@
+# OpenClaw design
+
+The chart packages the official OpenClaw gateway as one persistent StatefulSet replica. The gateway owns SQLite state,
+agent directories, device identities, sessions and workspaces. Kubernetes replaces the existing Pod before admitting its
+successor. This is a single-writer deployment with planned downtime, not an HA service or a tenant isolation boundary.
+
+The official image and its real tini entrypoint are preserved. UID/GID 1000, a read-only root filesystem, dropped
+capabilities, RuntimeDefault seccomp and no service-account token reduce container privileges. Writable home and temporary
+storage remain necessary for the application. Tools execute with the agent's credentials and permissions; enabling shell
+tools does not create a sandbox. Remote execution requires an explicitly configured supported upstream backend.
+
+The default minimal tool profile exposes only session status. Providers and channel tokens come from Secrets. Gateway
+token authentication remains enabled, and Control UI device authentication is never bypassed. The unauthenticated UI shell
+is not proof of an authenticated session. The optional OpenAI/OpenResponses endpoints grant operator-level authority and
+must remain private to trusted clients.
+
+Configuration has explicit ownership. Managed mode reconciles declared files at Pod initialization. Seed mode writes
+missing files and preserves subsequent operator changes. Updates to bootstrap scripts/configuration trigger rollout by
+checksum; changes to existing external Secrets require a rollout. A generated gateway token is recovered by Secret lookup
+and retained with the PVC, avoiding silent identity rotation during upgrades.
+
+The gateway's current bind implementation is IPv4-only. Service family settings deliberately reject IPv6 and dual-stack
+requests until the upstream listener can support them. Ingress and Gateway API route to the same authenticated gateway;
+TLS termination, WebSocket upgrade support and timeout policy belong to the selected controller.
+
+The release bundles diagnostics-otel. A pinned official collector receives metrics on loopback and exposes a private
+Prometheus Service. This avoids downloading plugins at startup and avoids giving Prometheus a gateway operator token.
+Traces, logs and model content export are disabled in the chart's metrics integration. Provider usage coverage is not a
+financial accounting guarantee.
+
+Backups use the same OpenClaw version and its native verified archive API. Native SQLite online snapshots capture WAL
+commits and sanitize transient ownership/delivery state. They do not provide global atomicity across databases and files.
+The uploader receives only the staging volume and S3 credentials. Archive bytes are read back and hashed before publishing
+the completion manifest. Restore verifies the manifest/hash and native archive, extracts into isolated staging, and only
+activates into an empty home volume. Interrupted activation fails closed and requires inspection rather than overwriting.
+
+The test strategy uses the actual gateway and a deterministic local model service. The fixture returns tool calls; only
+OpenClaw writes agent state. Paid providers and real messaging accounts are outside automated acceptance.

--- a/charts/openclaw/README.md
+++ b/charts/openclaw/README.md
@@ -1,0 +1,190 @@
+# OpenClaw
+
+Deploy [OpenClaw](https://docs.openclaw.ai/) as a persistent, authenticated agent gateway using its official container image.
+One installation owns its device pairing, agent sessions, tools, memory and workspaces.
+
+## Features
+
+- Official immutable release image; singleton StatefulSet and retained state/token identity.
+- Restricted non-root runtime with the upstream tini entrypoint and no Kubernetes API token.
+- Control UI with device pairing, exact origins, private Ingress and Gateway API.
+- Explicit managed/seed configuration, named agents, provider Secrets and channel allowlists.
+- Native OTLP metrics, official collector, private Prometheus Service, ServiceMonitor and alert rules.
+- Native SQLite-consistent archives, verified S3 publication and empty-volume disaster recovery.
+- Full values schema and application behavior tests with a local model provider.
+
+## Install
+
+Kubernetes 1.30 or newer and a suitable StorageClass are required. The image publishes Linux AMD64 and ARM64 manifests;
+runtime acceptance is performed on AMD64. The gateway currently supports IPv4 listeners.
+
+Create a namespace and a provider Secret from a local environment file excluded from version control. For the default
+Anthropic model, include ANTHROPIC_API_KEY. Ready gateway health alone does not validate provider credentials or quota.
+
+```bash
+kubectl create namespace agents
+kubectl -n agents create secret generic openclaw-provider --from-env-file=provider.env
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm upgrade --install openclaw helmforge/openclaw --namespace agents \
+  --set credentials.existingSecret=openclaw-provider
+```
+
+OCI: `oci://ghcr.io/helmforgedev/helm/openclaw`.
+Use `auth.existingSecret` for render-only GitOps so offline renders do not generate different tokens.
+The default generated Secret is `<fullname>-auth`, key `gateway-token`; Helm upgrades preserve it by lookup.
+
+## Access and trust
+
+Port-forward the Service to 18789 and open `http://localhost:18789`. Use the gateway token in the UI connection settings.
+Remote access needs HTTPS and an explicit allowed origin. Approve only the intended pending device; pairing is preserved
+across restarts. Gateway tokens authorize operator APIs and enabled tools. Keep model APIs private to trusted callers.
+
+One release is one operator trust boundary. There is no shared-writer HA or HPA. Enable shell/browser tools only with an
+understood execution boundary. Upgrades require downtime; preserve a verified recovery point before schema migrations.
+
+## Guides
+
+- [Operations, models, agents, channels and upgrades](docs/operations.md)
+- [Native backup and S3 recovery](docs/backup.md)
+- [Observability](docs/observability.md)
+- [Design and limitations](DESIGN.md)
+
+## Examples
+
+See [simple](examples/simple.yaml), [staging](examples/staging.yaml), [production](examples/production.yaml),
+[custom provider](examples/custom-provider.yaml) and [recovery](examples/restore.yaml).
+Replace hostnames, Secret names and selectors with your environment's actual resources.
+
+## Security Scan
+
+Security Scan: openclaw
+
+| Framework | Score |
+| --- | --- |
+| MITRE + NSA + SOC2 | 99.393936% |
+
+Security posture acceptable. Scanned production manifests with Kubescape v4.0.14.
+C-0012 flags the public SSE-KMS key ARN environment value as a potential secret;
+AWS credentials themselves use Secret references. No finding is suppressed.
+
+## Values
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `nameOverride` | `""` | name override setting for the gateway. |
+| `fullnameOverride` | `""` | fullname override setting for the gateway. |
+| `image.repository` | `"ghcr.io/openclaw/openclaw"` | repository setting for image. |
+| `image.tag` | `"2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101"` | tag setting for image. |
+| `image.pullPolicy` | `"IfNotPresent"` | pull policy setting for image. |
+| `imagePullSecrets` | `[]` | image pull secrets setting for the gateway. |
+| `auth.existingSecret` | `""` | Existing Secret with the gateway token; empty generates and retains a token across upgrades. |
+| `auth.key` | `"gateway-token"` | Secret key containing the gateway token. |
+| `credentials.existingSecret` | `""` | Existing Secret containing provider keys and TELEGRAM_BOT_TOKEN or DISCORD_BOT_TOKEN as applicable. |
+| `agent.defaults` | `{}` | Additional upstream agent defaults, for example memorySearch or sandbox. Model, workspace and concurrency use the explicit fields below. |
+| `agent.entries` | `{}` | Additional named agents; keep their workspace and agentDir below /home/node for chart-managed backup recovery. |
+| `agent.model` | `"anthropic/claude-opus-4-6"` | Upstream provider/model identifier; inference needs the corresponding credential. |
+| `agent.toolProfile` | `"minimal"` | Upstream tool profile: minimal, coding, messaging or full. Minimal permits session_status only. |
+| `agent.allowTools` | `[]` | Additional upstream tool allowlist; exec and filesystem access grant access within the agent container. |
+| `agent.denyTools` | `[]` | Additional upstream tool denylist. |
+| `agent.maxConcurrent` | `1` | Maximum concurrent agent runs. |
+| `config.policy` | `"managed"` | managed reconciles declared config on restart; seed preserves UI/CLI config after first initialization. |
+| `config.values` | `{}` | Additional upstream configuration; chart security, state and telemetry fields are reserved. |
+| `config.agentInstructions` | `""` | Optional workspace AGENTS.md content with the selected configuration ownership policy. |
+| `config.soul` | `""` | Optional workspace SOUL.md content with the selected configuration ownership policy. |
+| `persistence.enabled` | `true` | enabled setting for persistence. |
+| `persistence.existingClaim` | `""` | existing claim setting for persistence. |
+| `persistence.storageClass` | `""` | storage class setting for persistence. |
+| `persistence.accessModes` | `["ReadWriteOnce"]` | access modes setting for persistence. |
+| `persistence.size` | `"10Gi"` | size setting for persistence. |
+| `persistence.retain` | `true` | retain setting for persistence. |
+| `service.type` | `"ClusterIP"` | type setting for service. |
+| `service.port` | `18789` | port setting for service. |
+| `service.annotations` | `{}` | annotations setting for service. |
+| `service.ipFamilyPolicy` | `""` | ip family policy setting for service. |
+| `service.ipFamilies` | `[]` | ip families setting for service. |
+| `service.loadBalancerSourceRanges` | `[]` | load balancer source ranges setting for service. |
+| `serviceAccount.create` | `true` | create setting for serviceAccount. |
+| `serviceAccount.name` | `""` | name setting for serviceAccount. |
+| `serviceAccount.annotations` | `{}` | annotations setting for serviceAccount. |
+| `resources.requests.cpu` | `"250m"` | cpu setting for resources.requests. |
+| `resources.requests.memory` | `"1Gi"` | memory setting for resources.requests. |
+| `resources.limits.cpu` | `"2"` | cpu setting for resources.limits. |
+| `resources.limits.memory` | `"3Gi"` | memory setting for resources.limits. |
+| `nodeSelector.kubernetes.io/os` | `"linux"` | Upstream/Kubernetes setting. |
+| `tolerations` | `[]` | tolerations setting for the gateway. |
+| `affinity` | `{}` | affinity setting for the gateway. |
+| `podAnnotations` | `{}` | pod annotations setting for the gateway. |
+| `extraEnv` | `[]` | extra env setting for the gateway. |
+| `networkPolicy.enabled` | `true` | enabled setting for networkPolicy. |
+| `networkPolicy.ingressFrom` | `[]` | ingress from setting for networkPolicy. |
+| `networkPolicy.extraEgress` | `[]` | extra egress setting for networkPolicy. |
+| `networkPolicy.allowInternet` | `true` | allow internet setting for networkPolicy. |
+| `terminationGracePeriodSeconds` | `120` | termination grace period seconds setting for the gateway. |
+| `ingress.enabled` | `false` | enabled setting for ingress. |
+| `ingress.ingressClassName` | `""` | ingress class name setting for ingress. |
+| `ingress.annotations` | `{}` | annotations setting for ingress. |
+| `ingress.hosts` | `[{"host":"openclaw.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | hosts setting for ingress. |
+| `ingress.tls` | `[]` | tls setting for ingress. |
+| `gatewayAPI.enabled` | `false` | enabled setting for gatewayAPI. |
+| `gatewayAPI.httpRoutes` | `[]` | http routes setting for gatewayAPI. |
+| `externalSecrets.enabled` | `false` | enabled setting for externalSecrets. |
+| `externalSecrets.refreshInterval` | `"1h"` | refresh interval setting for externalSecrets. |
+| `externalSecrets.items` | `[]` | items setting for externalSecrets. |
+| `metrics.enabled` | `false` | Enable bundled diagnostics-otel metrics; no runtime plugin downloads. |
+| `metrics.intervalSeconds` | `15` | interval seconds setting for metrics. |
+| `metrics.externalEndpoint` | `""` | External OTLP HTTP base endpoint when the local collector is disabled. |
+| `metrics.collector.enabled` | `true` | enabled setting for metrics.collector. |
+| `metrics.collector.image.repository` | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"` | repository setting for metrics.collector.image. |
+| `metrics.collector.image.tag` | `"0.160.0@sha256:799dc6cf12c96192af37b5bdba804da8c10b3bc563b43cb90c3f3c58d9572ad6"` | tag setting for metrics.collector.image. |
+| `metrics.collector.image.pullPolicy` | `"IfNotPresent"` | pull policy setting for metrics.collector.image. |
+| `metrics.collector.resources.requests.cpu` | `"50m"` | cpu setting for metrics.collector.resources.requests. |
+| `metrics.collector.resources.requests.memory` | `"64Mi"` | memory setting for metrics.collector.resources.requests. |
+| `metrics.collector.resources.limits.cpu` | `"500m"` | cpu setting for metrics.collector.resources.limits. |
+| `metrics.collector.resources.limits.memory` | `"256Mi"` | memory setting for metrics.collector.resources.limits. |
+| `metrics.serviceMonitor.enabled` | `false` | enabled setting for metrics.serviceMonitor. |
+| `metrics.serviceMonitor.labels` | `{}` | labels setting for metrics.serviceMonitor. |
+| `metrics.serviceMonitor.interval` | `"30s"` | interval setting for metrics.serviceMonitor. |
+| `metrics.serviceMonitor.scrapeTimeout` | `"10s"` | scrape timeout setting for metrics.serviceMonitor. |
+| `metrics.prometheusRule.enabled` | `false` | enabled setting for metrics.prometheusRule. |
+| `metrics.prometheusRule.labels` | `{}` | labels setting for metrics.prometheusRule. |
+| `metrics.prometheusRule.additionalRules` | `[]` | additional rules setting for metrics.prometheusRule. |
+| `metrics.ingressFrom` | `[]` | ingress from setting for metrics. |
+| `backup.enabled` | `false` | enabled setting for backup. |
+| `backup.schedule` | `"0 3 * * *"` | schedule setting for backup. |
+| `backup.timeZone` | `"Etc/UTC"` | time zone setting for backup. |
+| `backup.suspend` | `false` | suspend setting for backup. |
+| `backup.successfulJobsHistoryLimit` | `1` | successful jobs history limit setting for backup. |
+| `backup.failedJobsHistoryLimit` | `2` | failed jobs history limit setting for backup. |
+| `backup.activeDeadlineSeconds` | `1800` | active deadline seconds setting for backup. |
+| `backup.stagingSize` | `"10Gi"` | Ephemeral capacity for native tar.gz archive and temporary SQLite snapshots; size for peak usage. |
+| `backup.resources.requests.cpu` | `"100m"` | cpu setting for backup.resources.requests. |
+| `backup.resources.requests.memory` | `"256Mi"` | memory setting for backup.resources.requests. |
+| `backup.resources.limits.cpu` | `"1"` | cpu setting for backup.resources.limits. |
+| `backup.resources.limits.memory` | `"2Gi"` | memory setting for backup.resources.limits. |
+| `backup.s3.bucket` | `""` | bucket setting for backup.s3. |
+| `backup.s3.prefix` | `"openclaw"` | prefix setting for backup.s3. |
+| `backup.s3.region` | `"us-east-1"` | region setting for backup.s3. |
+| `backup.s3.endpoint` | `""` | endpoint setting for backup.s3. |
+| `backup.s3.allowInsecureEndpoint` | `false` | allow insecure endpoint setting for backup.s3. |
+| `backup.s3.existingSecret` | `""` | existing secret setting for backup.s3. |
+| `backup.s3.sse` | `"AES256"` | sse setting for backup.s3. |
+| `backup.s3.kmsKeyId` | `""` | kms key id setting for backup.s3. |
+| `backup.s3.caSecret` | `""` | ca secret setting for backup.s3. |
+| `backup.image.repository` | `"public.ecr.aws/aws-cli/aws-cli"` | repository setting for backup.image. |
+| `backup.image.tag` | `"2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441"` | tag setting for backup.image. |
+| `backup.image.pullPolicy` | `"IfNotPresent"` | pull policy setting for backup.image. |
+| `backup.networkPolicy.extraEgress` | `[]` | extra egress setting for backup.networkPolicy. |
+| `restore.enabled` | `false` | enabled setting for restore. |
+| `restore.manifestKey` | `""` | manifest key setting for restore. |
+| `restore.maxArchiveBytes` | `10737418240` | max archive bytes setting for restore. |
+| `restore.maxExpandedBytes` | `21474836480` | Maximum expanded bytes accepted during recovery. |
+| `gateway.controlUi.enabled` | `true` | Enable the bundled Control UI with device pairing enforced. |
+| `gateway.controlUi.allowedOrigins` | `["http://localhost:18789","http://127.0.0.1:18789"]` | Exact trusted browser origins; add the HTTPS public origin before exposing the UI. |
+| `gateway.trustedProxies` | `[]` | Explicit trusted reverse-proxy IPs/CIDRs for client identity; never trust all networks. |
+| `gateway.chatCompletions.enabled` | `false` | Expose authenticated OpenAI-compatible chat completions. |
+| `gateway.responses.enabled` | `false` | Expose authenticated OpenResponses API. |
+| `channels.telegram.enabled` | `false` | enabled setting for channels.telegram. |
+| `channels.telegram.allowFrom` | `[]` | allow from setting for channels.telegram. |
+| `channels.discord.enabled` | `false` | enabled setting for channels.discord. |
+| `channels.discord.allowFrom` | `[]` | allow from setting for channels.discord. |

--- a/charts/openclaw/README.md
+++ b/charts/openclaw/README.md
@@ -38,7 +38,8 @@ The default generated Secret is `<fullname>-auth`, key `gateway-token`; Helm upg
 
 Port-forward the Service to 18789 and open `http://localhost:18789`. Use the gateway token in the UI connection settings.
 Remote access needs HTTPS and an explicit allowed origin. Approve only the intended pending device; pairing is preserved
-across restarts. Gateway tokens authorize operator APIs and enabled tools. Keep model APIs private to trusted callers.
+across restarts. With NetworkPolicy enabled, remote ingress requires `networkPolicy.ingressFrom`; ServiceMonitor requires
+`metrics.ingressFrom`. Missing selectors fail rendering. Gateway tokens authorize operator APIs and enabled tools. Keep model APIs private to trusted callers.
 
 One release is one operator trust boundary. There is no shared-writer HA or HPA. Enable shell/browser tools only with an
 understood execution boundary. Upgrades require downtime; preserve a verified recovery point before schema migrations.

--- a/charts/openclaw/ci/agent-values.yaml
+++ b/charts/openclaw/ci/agent-values.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/charts/openclaw/ci/backup-s3-values.yaml
+++ b/charts/openclaw/ci/backup-s3-values.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    bucket: openclaw-backups
+    existingSecret: openclaw-s3-credentials
+    endpoint: https://openclaw-s3:8333
+    caSecret: openclaw-s3-ca
+    sse: ''
+  networkPolicy:
+    extraEgress:
+      - to:
+          - podSelector:
+              matchLabels:
+                app: openclaw-s3
+                component: server
+        ports:
+          - protocol: TCP
+            port: 8333

--- a/charts/openclaw/ci/default-values.yaml
+++ b/charts/openclaw/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+{}

--- a/charts/openclaw/ci/external-secrets-values.yaml
+++ b/charts/openclaw/ci/external-secrets-values.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+auth:
+  existingSecret: openclaw-eso-auth
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: openclaw-eso-auth
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        target:
+          template:
+            engineVersion: v2
+            data:
+              gateway-token: openclaw-fixture-{{ .password }}-long-token
+        data:
+          - secretKey: password
+            remoteRef:
+              key: test/password

--- a/charts/openclaw/ci/fixtures/agent-values.yaml
+++ b/charts/openclaw/ci/fixtures/agent-values.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/openclaw/ci/fixtures/backup-s3-values.yaml
+++ b/charts/openclaw/ci/fixtures/backup-s3-values.yaml
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-s3-ca
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  ca.crt: "-----BEGIN CERTIFICATE-----\r\nMIIDTTCCAjWgAwIBAgIUbfyw/d1NTUGfcUtKIQ4AlIsv17IwDQYJKoZIhvcNAQEL\r\nBQAwFjEUMBIGA1UEAwwLb3BlbmNsYXctczMwHhcNMjYwOTExMjM0MTI1WhcNMzYw\r\nOTA4MjM0MTI1WjAWMRQwEgYDVQQDDAtvcGVuY2xhdy1zMzCCASIwDQYJKoZIhvcN\r\nAQEBBQADggEPADCCAQoCggEBALaYXyGBARA1mbivlM004eg+SXDDA3kiHrL1IbLO\r\nco9e3H1y9MwI1Vkjg9y5hi13zM+SIZwK7sCzmKFG5bD4i7Lz9mYUjiABaMg9lY0c\r\nlE2D0ZRAcr0rsBE6vSL5gTzHhHQEh4U5EK/SxzSmJ9962npVJjgzRW7MAynqmS8z\r\npgPEGInqoZOB38uv4hcZ+n/Ww2YZKMyIl0pVzL7f1b7nXl4CC1fW+giG3cejYwTZ\r\nTT3toZFT8i5Uzfgzry6MbepJcvZ3LzTzQJSAkLHk/zggvHVEKcVBOoSgxdzMbn1G\r\nnf+TUOD1c67kfEgO8uqLJPQyW6GT7Nqu9BrkezeB3wzLOhkCAwEAAaOBkjCBjzAd\r\nBgNVHQ4EFgQUrDHnPDGS1DW25IZCJuO6KxXi/8YwHwYDVR0jBBgwFoAUrDHnPDGS\r\n1DW25IZCJuO6KxXi/8YwDwYDVR0TAQH/BAUwAwEB/zA8BgNVHREENTAzggtvcGVu\r\nY2xhdy1zM4Ikb3BlbmNsYXctczMuaGYtdmFsaWRhdGUtb3BlbmNsYXcuc3ZjMA0G\r\nCSqGSIb3DQEBCwUAA4IBAQAG3eoiIFdPl11M5OyOTbrP70PYSnneVTLDFh51N6sG\r\nk+k5ZuCy/1FjxOvaMp3kYI2extUWTqNE1U1l/Bo1peOqNhUU5yCahIFiH1CDhx8M\r\nubPJI95ilg350xeVEKpCQowd8/H3ZRa5CHHMk0wgsDaVOkgAAZSOVLBE3RzUtP6c\r\n+OsLNWJp1VF11aW/d6jb7j50xlRNvv7L+d9McNIEZBDFPEDJB6TYOcq1JN3cYZ2g\r\njsEgJ6s3aQt7EMEBgK7k4Hdz6MZDIc1jIdEua3fZ0MfzHeLTNVgDi2exM84BCdWF\r\n1mX76XdCB5KU+MPf8KlgHYBoj4BvNx00ja7ykR71Ow/s\r\n-----END CERTIFICATE-----\r\n"
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-s3-tls
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: kubernetes.io/tls
+stringData:
+  tls.crt: "-----BEGIN CERTIFICATE-----\r\nMIIDTTCCAjWgAwIBAgIUbfyw/d1NTUGfcUtKIQ4AlIsv17IwDQYJKoZIhvcNAQEL\r\nBQAwFjEUMBIGA1UEAwwLb3BlbmNsYXctczMwHhcNMjYwOTExMjM0MTI1WhcNMzYw\r\nOTA4MjM0MTI1WjAWMRQwEgYDVQQDDAtvcGVuY2xhdy1zMzCCASIwDQYJKoZIhvcN\r\nAQEBBQADggEPADCCAQoCggEBALaYXyGBARA1mbivlM004eg+SXDDA3kiHrL1IbLO\r\nco9e3H1y9MwI1Vkjg9y5hi13zM+SIZwK7sCzmKFG5bD4i7Lz9mYUjiABaMg9lY0c\r\nlE2D0ZRAcr0rsBE6vSL5gTzHhHQEh4U5EK/SxzSmJ9962npVJjgzRW7MAynqmS8z\r\npgPEGInqoZOB38uv4hcZ+n/Ww2YZKMyIl0pVzL7f1b7nXl4CC1fW+giG3cejYwTZ\r\nTT3toZFT8i5Uzfgzry6MbepJcvZ3LzTzQJSAkLHk/zggvHVEKcVBOoSgxdzMbn1G\r\nnf+TUOD1c67kfEgO8uqLJPQyW6GT7Nqu9BrkezeB3wzLOhkCAwEAAaOBkjCBjzAd\r\nBgNVHQ4EFgQUrDHnPDGS1DW25IZCJuO6KxXi/8YwHwYDVR0jBBgwFoAUrDHnPDGS\r\n1DW25IZCJuO6KxXi/8YwDwYDVR0TAQH/BAUwAwEB/zA8BgNVHREENTAzggtvcGVu\r\nY2xhdy1zM4Ikb3BlbmNsYXctczMuaGYtdmFsaWRhdGUtb3BlbmNsYXcuc3ZjMA0G\r\nCSqGSIb3DQEBCwUAA4IBAQAG3eoiIFdPl11M5OyOTbrP70PYSnneVTLDFh51N6sG\r\nk+k5ZuCy/1FjxOvaMp3kYI2extUWTqNE1U1l/Bo1peOqNhUU5yCahIFiH1CDhx8M\r\nubPJI95ilg350xeVEKpCQowd8/H3ZRa5CHHMk0wgsDaVOkgAAZSOVLBE3RzUtP6c\r\n+OsLNWJp1VF11aW/d6jb7j50xlRNvv7L+d9McNIEZBDFPEDJB6TYOcq1JN3cYZ2g\r\njsEgJ6s3aQt7EMEBgK7k4Hdz6MZDIc1jIdEua3fZ0MfzHeLTNVgDi2exM84BCdWF\r\n1mX76XdCB5KU+MPf8KlgHYBoj4BvNx00ja7ykR71Ow/s\r\n-----END CERTIFICATE-----\r\n"
+  tls.key: "-----BEGIN PRIVATE KEY-----\r\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2mF8hgQEQNZm4\r\nr5TNNOHoPklwwwN5Ih6y9SGyznKPXtx9cvTMCNVZI4PcuYYtd8zPkiGcCu7As5ih\r\nRuWw+Iuy8/ZmFI4gAWjIPZWNHJRNg9GUQHK9K7AROr0i+YE8x4R0BIeFORCv0sc0\r\npiffetp6VSY4M0VuzAMp6pkvM6YDxBiJ6qGTgd/Lr+IXGfp/1sNmGSjMiJdKVcy+\r\n39W+515eAgtX1voIht3Ho2ME2U097aGRU/IuVM34M68ujG3qSXL2dy8080CUgJCx\r\n5P84ILx1RCnFQTqEoMXczG59Rp3/k1Dg9XOu5HxIDvLqiyT0Mluhk+zarvQa5Hs3\r\ngd8MyzoZAgMBAAECggEAEJGHclAVI14lvnkqMKungw4h1lpPtp5muDjfj6zFfuZt\r\n7fEwLtJvX4kGNlFcUERiYIRjSdhBHVm+lAXNok8PSBP0jAM5+UP/eMoDx7vr5hO7\r\nwO7PKoSsE4gnsOSAel4lUey2Sluo/LdMzaV1EUWBzR9sWiWm23ymHdfUghC28/jg\r\nILqQVB9gY1Q2fsxucsDr318oMQfkDy0sB3IlYtPP6XpLB+jzzUqZnWSZ0AQGdTJ1\r\n5v8iSMpCIQL6bUGCWD1D+I0rJ+dE2rX2t3Ov+HDeXCsCbPRtJ8C4krbqxn5mx4jS\r\nWKPoqOD1fG1Si00HUnZOyGLXZ6GkHTzu/NdAn5YAoQKBgQDpzhuOxa7739y3qdu2\r\n2vr89u8IRD7yeSL+H2U3mFkI/0PUdl8WQXbB/Lj8+7LoqvVPVGvhjzGbPlnpWRcs\r\n/j2ZMS1eL+jywRDkbCr/p/Bvi+Im4ukwwHf4rsQsaepqYA+lz62Ded1iRt+ZxYBS\r\ntFUG5rOSfIpS58QYDq5LAMpM6QKBgQDH7cT53uqDShulVJGVziXYhgsu3spgjL20\r\nq5bzeW1QyJ+QNXfF5CsHYIhurvsLP8rpTDgy5EWbu1IK9cIR2Szp7rz+xEFR59lh\r\n2EH+GBQyvIgdugC7CH5pTz6pT3AUEjaa+sxwrHYZB7nQ0Jlcb6+lTxD2yVUaTQzw\r\n7btVKN+FsQKBgQCX1YGP9lDswTRVEbndxde476PLeoZmcMSIw1q3//fSH/OsxjJ6\r\nAYld8QExSUOmVV95ZRmqIZPVfWhmYbTrQzA9i/IqeHKPM1IFBTnnTOiXiAAVwMYv\r\nIs7GcLh1H1NcQYXn6DaGa12ZtO0Ar4HmM7YEBU4Yk0hBDsIJ3X7StnCqAQKBgGPJ\r\n+sIZEIZdS/U2g7/4+AzdwuEvFGYieWGfL6Xw2q4ypOnutgyQ+SUiepZ8QhN4UMgn\r\nYfmM1G2JjsanqakM9A0DO1QSEuRVy7u5nB6+V/6G+Y2U1F6GO8pGYmlRnAh4msa6\r\nHaazffK6V3WxWIq5uDrTfw0eqpqJEMeEcTdtQjvRAoGBAOL78zpj2b1pm8rT3QKY\r\n/LLI+PM3dy8dGfEVLRQYrX/PwAxnpl0v4ej26ztF4Ccj/BCR/h6IMNI99kIaHSVg\r\nG0UlWI+9rnyGqeLY1xHZUrpPymnuSMvw0RErU+AIOVYM6OwpfQNy+st5spRtalFG\r\nV3HDR9I+9iq/bUbK6MHC1fAg\r\n-----END PRIVATE KEY-----\r\n"
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-s3-credentials
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: openclaw-ci-backup
+  AWS_SECRET_ACCESS_KEY: openclaw-ci-backup-secret-never-production
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-s3-admin
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: openclaw-ci-admin
+  AWS_SECRET_ACCESS_KEY: openclaw-ci-admin-secret-never-production
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-s3-config
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+data:
+  s3.json: >
+    {"identities":[{"name":"ci-admin","credentials":[{"accessKey":"openclaw-ci-admin","secretKey":"openclaw-ci-admin-secret-never-production"}],"actions":["Admin","Read","Write","List","Tagging"]},{"name":"ci-backup","credentials":[{"accessKey":"openclaw-ci-backup","secretKey":"openclaw-ci-backup-secret-never-production"}],"actions":["Read:openclaw-backups","Write:openclaw-backups","List:openclaw-backups"]}]}
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-s3
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-s3
+      component: server
+  template:
+    metadata:
+      labels:
+        app: openclaw-s3
+        component: server
+        helmforge.dev/runtime-fixture: 'true'
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: seaweedfs
+          image: chrislusf/seaweedfs:4.46@sha256:08d516132314207d10c8e37cbffc1f32b147d870169688734cc61c6231625b62
+          command:
+            - weed
+          args:
+            - server
+            - '-dir=/data'
+            - '-ip=127.0.0.1'
+            - '-ip.bind=0.0.0.0'
+            - '-master.volumeSizeLimitMB=64'
+            - '-volume.max=4'
+            - '-filer'
+            - '-s3'
+            - '-s3.config=/config/s3.json'
+            - '-s3.cert.file=/tls/tls.crt'
+            - '-s3.key.file=/tls/tls.key'
+          workingDir: /data
+          ports:
+            - name: s3
+              containerPort: 8333
+          startupProbe:
+            tcpSocket:
+              port: s3
+            periodSeconds: 2
+            failureThreshold: 90
+          readinessProbe:
+            tcpSocket:
+              port: s3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              cpu: '1'
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: openclaw-s3-config
+        - name: tls
+          secret:
+            secretName: openclaw-s3-tls
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-s3
+  labels:
+    app: openclaw-s3
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  selector:
+    app: openclaw-s3
+    component: server
+  ports:
+    - name: s3
+      port: 8333
+      targetPort: s3
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openclaw-s3-create-bucket
+  labels:
+    helmforge.dev/runtime-fixture: 'true'
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 240
+  template:
+    metadata:
+      labels:
+        app: openclaw-s3
+        component: setup
+        helmforge.dev/runtime-fixture: 'true'
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-bucket
+          image: public.ecr.aws/aws-cli/aws-cli:2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441
+          command:
+            - /bin/bash
+            - '-ec'
+          args:
+            - |
+              set -u
+              export AWS_MAX_ATTEMPTS=1
+              probe_key="helmforge-fixture-readiness/${HOSTNAME}.bin"
+              # One MiB exercises volume storage rather than only small inline filer metadata.
+              dd if=/dev/zero of=/tmp/probe.upload bs=1048576 count=1 status=none
+              expected="$(sha256sum /tmp/probe.upload)"; expected="${expected%% *}"
+              s3() {
+                aws --endpoint-url https://openclaw-s3:8333 --cli-connect-timeout 2 --cli-read-timeout 3 s3api "$@"
+              }
+              for ((attempt=0; attempt<60 && SECONDS<180; attempt++)); do
+                if s3 head-bucket --bucket openclaw-backups >/tmp/readiness-error 2>&1 ||
+                  s3 create-bucket --bucket openclaw-backups >/tmp/readiness-error 2>&1; then
+                  if s3 put-object --bucket openclaw-backups --key "$probe_key" --body /tmp/probe.upload >/tmp/readiness-error 2>&1 &&
+                    s3 get-object --bucket openclaw-backups --key "$probe_key" /tmp/probe.download >/tmp/readiness-error 2>&1; then
+                    actual="$(sha256sum /tmp/probe.download)"; actual="${actual%% *}"
+                    if [[ "$actual" == "$expected" && "$(stat -c %s /tmp/probe.download)" == 1048576 ]] &&
+                      s3 delete-object --bucket openclaw-backups --key "$probe_key" >/tmp/readiness-error 2>&1; then
+                      echo 'HTTPS S3 fixture passed real object upload, download, byte/hash verification and exact probe cleanup'
+                      exit 0
+                    fi
+                  fi
+                fi
+                sleep 2
+              done
+              echo 'HTTPS S3 fixture data path did not become ready within its bounded retry budget' >&2
+              cat /tmp/readiness-error >&2
+              exit 1
+          envFrom:
+            - secretRef:
+                name: openclaw-s3-admin
+          env:
+            - name: AWS_DEFAULT_REGION
+              value: us-east-1
+            - name: AWS_CA_BUNDLE
+              value: /tls/ca.crt
+            - name: AWS_EC2_METADATA_DISABLED
+              value: 'true'
+            - name: AWS_PAGER
+              value: ''
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ca
+              mountPath: /tls
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: ca
+          secret:
+            secretName: openclaw-s3-ca
+        - name: tmp
+          emptyDir: {}

--- a/charts/openclaw/ci/fixtures/external-secrets-values.yaml
+++ b/charts/openclaw/ci/fixtures/external-secrets-values.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/openclaw/ci/fixtures/gateway-api-values.yaml
+++ b/charts/openclaw/ci/fixtures/gateway-api-values.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/openclaw/ci/fixtures/observability-values.yaml
+++ b/charts/openclaw/ci/fixtures/observability-values.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/openclaw/ci/fixtures/seed-values.yaml
+++ b/charts/openclaw/ci/fixtures/seed-values.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-provider
+data:
+  server.mjs: |
+    // SPDX-License-Identifier: Apache-2.0
+    // Only the external model service is simulated. The real gateway executes tools.
+    import http from 'node:http';
+    http.createServer(async(req,res)=>{
+     if(req.url==='/health'){res.end('ok');return;}
+     if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+     let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+     let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+     if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+     const messages=body.messages??[];
+     const latestUser=messages.findLastIndex(x=>x.role==='user');
+     const request=JSON.stringify(messages[latestUser]??{});
+     const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+     let tool;
+     if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+     if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+     const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+     const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+     const finish=tool?'tool_calls':'stop';
+     const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+     console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+     if(body.stream){
+      res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+      const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+      res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+      res.end('data: [DONE]\n\n');
+     }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+    }).listen(8080,'0.0.0.0');
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-provider-credentials
+stringData:
+  OPENCLAW_FIXTURE_API_KEY: helmforge-fixture-only
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-provider
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw-provider
+  template:
+    metadata:
+      labels:
+        app: openclaw-provider
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provider
+          image: ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+          command:
+            - node
+            - /fixture/server.mjs
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: fixture
+              mountPath: /fixture
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: fixture
+          configMap:
+            name: openclaw-provider
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-provider
+spec:
+  selector:
+    app: openclaw-provider
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/charts/openclaw/ci/gateway-api-values.yaml
+++ b/charts/openclaw/ci/gateway-api-values.yaml
@@ -44,6 +44,13 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 8080
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: gateway-system
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
 ingress:
   enabled: true
   ingressClassName: nginx

--- a/charts/openclaw/ci/gateway-api-values.yaml
+++ b/charts/openclaw/ci/gateway-api-values.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+  controlUi:
+    allowedOrigins:
+      - https://openclaw.example.com
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: openclaw.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: openclaw-edge-tls
+      hosts:
+        - openclaw.example.com
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: api
+      parentRefs:
+        - name: edge
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - openclaw.example.com

--- a/charts/openclaw/ci/observability-values.yaml
+++ b/charts/openclaw/ci/observability-values.yaml
@@ -47,3 +47,7 @@ metrics:
     enabled: true
   prometheusRule:
     enabled: true
+  ingressFrom:
+    - podSelector:
+        matchLabels:
+          app: openclaw-provider

--- a/charts/openclaw/ci/observability-values.yaml
+++ b/charts/openclaw/ci/observability-values.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true

--- a/charts/openclaw/ci/seed-values.yaml
+++ b/charts/openclaw/ci/seed-values.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: fixture/helmforge-fixture
+  allowTools:
+    - read
+    - write
+credentials:
+  existingSecret: openclaw-provider-credentials
+gateway:
+  chatCompletions:
+    enabled: true
+config:
+  values:
+    models:
+      mode: replace
+      providers:
+        fixture:
+          baseUrl: http://openclaw-provider:8080/v1
+          apiKey: ${OPENCLAW_FIXTURE_API_KEY}
+          api: openai-completions
+          models:
+            - id: helmforge-fixture
+              name: Local acceptance fixture
+              reasoning: false
+              input:
+                - text
+              contextWindow: 128000
+              maxTokens: 4096
+              cost:
+                input: 0
+                output: 0
+                cacheRead: 0
+                cacheWrite: 0
+  policy: seed
+networkPolicy:
+  allowInternet: false
+  extraEgress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: openclaw-provider
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/charts/openclaw/docs/backup.md
+++ b/charts/openclaw/docs/backup.md
@@ -1,0 +1,44 @@
+# Native backup and S3 recovery
+
+Enable `backup.enabled` with a persistent claim, an S3 bucket and an existing credential Secret. The CronJob uses
+`concurrencyPolicy: Forbid`, a deadline and no automatic Job retries. It schedules on the gateway's node so RWO storage
+can be mounted concurrently; ReadWriteOncePod is incompatible with this online backup workflow.
+
+The snapshot init container runs OpenClaw's native `backup create --verify --json`. The archive includes discovered
+state, configured agent roots, config dependencies, credentials and workspaces. Canonical SQLite databases use online
+snapshots, including committed WAL data, and native integrity/ownership verification. This is per-database consistency,
+not one transaction spanning every database and workspace file. Third-party SQLite files outside owned agent roots
+may be ordinary file copies. Quiesce the application if cross-file atomicity is required.
+
+Native backups deliberately remove transient leases and delivery queue records. Recovery is not an exactly-once
+continuation of external actions. Some logs, volatile files and plugin dependency trees are excluded. Protect exports
+or custom external data separately. Kubernetes Secrets, model-provider accounts, external browser state and object
+storage are not restored by an application archive.
+
+The AWS CLI container receives only the completed archive volume and S3 credentials. It uploads to a unique run prefix,
+reads the remote archive back to verify SHA-256, then uploads the completion manifest last. Only a successful Job and
+completed manifest establish offsite success; OpenClaw's local backup status alone does not. Interrupted runs can leave
+objects without a manifest. Configure bucket lifecycle for retention and incomplete multipart uploads.
+
+Use HTTPS; a private endpoint can use a CA Secret with `ca.crt`. HTTP requires an explicit insecure-endpoint opt-in for
+trusted environments. SSE-S3 and SSE-KMS are supported; configure KMS permissions separately. Backups contain credentials
+and conversation state: scope the storage identity to the required prefix and protect object access. Checksums detect
+corruption but are not signatures against an attacker who can rewrite both archive and manifest.
+
+## Recovery procedure
+
+1. Select a completed manifest and preserve the old deployment/state for investigation.
+2. Use a new empty claim and the matching upstream image version. Stop any writers that might use that destination.
+3. Configure `restore.enabled`, `restore.manifestKey`, S3 credentials and size limits. Keep messaging disconnected while
+   validating the recovered installation.
+4. Init containers download bounded data, validate checksum and native archive integrity, extract to staging, and activate
+   assets into empty persisted home. External asset paths are rejected for automatic activation and need manual recovery.
+5. Confirm gateway health, known sessions, workspaces and credentials before reconnecting external channels. Review pending
+   actions; ratchet-based credentials can require relinking after rollback.
+6. A completion marker makes restarting the same restored release idempotent. Changing the manifest on existing state is
+   rejected. Interrupted activation leaves a marker and requires inspection and a fresh claim; it never overwrites state.
+
+Staging needs room for the archive and snapshot scratch space. Restore additionally needs extracted data plus the final
+state copy. `backup.stagingSize` is an emptyDir ceiling, not reserved disk; provision node ephemeral capacity and scheduling
+resources accordingly. The native archive has no universal data-size limit; chart restore limits bound downloads and
+expanded entries. Test recovery with representative data and storage throughput before setting deadlines.

--- a/charts/openclaw/docs/observability.md
+++ b/charts/openclaw/docs/observability.md
@@ -4,6 +4,7 @@
 to a loopback collector. The pinned official collector translates metrics into Prometheus format on a separate private
 Service, port 8889. Enable `metrics.serviceMonitor.enabled` for an installed Prometheus Operator and set its discovery
 labels and `metrics.ingressFrom` peer selectors.
+When NetworkPolicy is enabled, an enabled ServiceMonitor without these selectors fails rendering.
 
 This integration does not install the separate diagnostics-prometheus plugin at startup and does not share the gateway
 operator token with the scraper. The collector receives metrics only; prompt/tool content capture, traces and logs are
@@ -11,7 +12,8 @@ disabled. Native usage and latency series depend on activity and provider report
 not guaranteed billing records. Empty activity-dependent series are expected before requests occur.
 
 To use an existing OTLP collector, disable the local collector and set `metrics.externalEndpoint` to its OTLP HTTP base
-URL. Allow the destination in NetworkPolicy. ServiceMonitor and chart Prometheus rules require the local collector.
+URL, such as `https://collector.example.com`, or its complete `/v1/metrics` URL. Allow the destination in NetworkPolicy.
+ServiceMonitor and chart Prometheus rules require the local collector.
 External collector authentication and TLS policy can be supplied through supported upstream environment configuration
 in the credentials Secret; verify the endpoint integration in your environment.
 

--- a/charts/openclaw/docs/observability.md
+++ b/charts/openclaw/docs/observability.md
@@ -1,0 +1,20 @@
+# Observability
+
+`metrics.enabled` activates the release-bundled diagnostics-otel plugin. The gateway exports native metrics over OTLP HTTP
+to a loopback collector. The pinned official collector translates metrics into Prometheus format on a separate private
+Service, port 8889. Enable `metrics.serviceMonitor.enabled` for an installed Prometheus Operator and set its discovery
+labels and `metrics.ingressFrom` peer selectors.
+
+This integration does not install the separate diagnostics-prometheus plugin at startup and does not share the gateway
+operator token with the scraper. The collector receives metrics only; prompt/tool content capture, traces and logs are
+disabled. Native usage and latency series depend on activity and provider reporting. They are operational observations,
+not guaranteed billing records. Empty activity-dependent series are expected before requests occur.
+
+To use an existing OTLP collector, disable the local collector and set `metrics.externalEndpoint` to its OTLP HTTP base
+URL. Allow the destination in NetworkPolicy. ServiceMonitor and chart Prometheus rules require the local collector.
+External collector authentication and TLS policy can be supplied through supported upstream environment configuration
+in the credentials Secret; verify the endpoint integration in your environment.
+
+The optional PrometheusRule detects failed scrapes; add deployment-specific alerts with `additionalRules`. Also monitor
+gateway readiness, restart count, PVC fullness, node ephemeral storage and failed/missing scheduled backup Jobs. A local
+OpenClaw backup success record does not prove S3 publication. Kubernetes Job completion and the remote manifest do.

--- a/charts/openclaw/docs/operations.md
+++ b/charts/openclaw/docs/operations.md
@@ -1,0 +1,62 @@
+# Operations and configuration
+
+OpenClaw is a personal/operator-trusted gateway. Deploy separate releases and claims for independent trust domains.
+There is one writer per release. Do not scale its StatefulSet or reuse its claim in another active gateway.
+
+## First access and device pairing
+
+Port-forward the Service to local port 18789 and open `http://localhost:18789`. Retrieve the gateway token from the Secret
+named in Helm NOTES. Supply it in the Control UI connection settings. Treat token-bearing URLs as credentials and keep
+them out of logs and tickets. Remote browser access needs HTTPS, an exact `gateway.controlUi.allowedOrigins` entry,
+WebSocket-capable routing, and a NetworkPolicy peer allowlist.
+
+Remote device enrollment remains enabled. Inspect `openclaw devices list` in the running container and approve only the
+request ID associated with the intended browser using `openclaw devices approve <requestId>`. Local loopback connections
+can be auto-approved after authentication; this is not evidence of remote pairing. Do not enable dangerous device or
+origin bypass flags. Configure `gateway.trustedProxies` only for the actual reverse-proxy addresses.
+
+## Models, tools, agents and channels
+
+Set `agent.model` to an upstream provider/model ID and supply its environment key through `credentials.existingSecret`.
+Custom provider definitions belong in `config.values.models.providers`; use SecretRef or environment placeholders for
+API keys, never literal credentials in values. An OpenAI-compatible backend normally uses `api: openai-completions`.
+
+`agent.toolProfile` defaults to `minimal`. Add specific tools with `agent.allowTools`; deny unwanted tools with
+`agent.denyTools`. Filesystem tools are workspace-limited and elevated execution is disabled. Shell execution still has
+access to the container's writable data and environment. Kubernetes hardening does not turn mutually untrusted agents
+into isolated tenants. Configure upstream remote sandboxing in `agent.defaults.sandbox` when needed and independently
+validate the selected remote service. The chart does not mount a Docker socket or grant cluster permissions.
+
+`agent.defaults` accepts additional upstream settings, such as memory search and heartbeat. `agent.entries` adds named
+agents; state and workspace paths must remain below `/home/node` for automated recovery. Model routing and other
+non-secret upstream settings can be supplied in `config.values`. Keep application state on the persistent home volume.
+
+Telegram and Discord are opt-in and require nonempty `allowFrom` lists plus their upstream environment token in the
+credentials Secret. Group traffic is disabled by the simple chart contract. Test account access and permissions before
+connecting real users. External APIs, channels and browser services have their own permissions and recovery requirements.
+
+## Ownership and upgrades
+
+Managed mode applies declared JSON, AGENTS.md and SOUL.md on initialization. Existing state and sessions are preserved;
+operator edits to managed files are overwritten at the next restart. Empty instruction values leave those workspace
+files unmanaged. Seed mode initializes missing files only; subsequent UI/CLI edits are authoritative. Updating values
+in seed mode does not overwrite existing config. Back up before deliberately replacing or reseeding an existing file.
+
+Rotate external credentials by updating the Secret and restarting the StatefulSet. Keep the generated gateway Secret
+with retained state; changing a token deliberately can require updating clients. Uninstall retains the chart-created
+claim and generated Secret by default. Reinstall with the same release identity to reuse them, or explicitly reference
+the retained resources. Claims are independent of StatefulSet recreation.
+
+Before upgrading, create and verify a recovery point, review upstream migrations and schedule downtime. Kubernetes
+owns restarts and the image is immutable: do not run self-update inside the gateway. Helm rollback does not reverse
+database migrations. If an older release cannot read the upgraded schema, recover a pre-upgrade archive into a new claim.
+
+## Health and networking
+
+Startup/readiness inspect `/startupz` JSON; liveness inspects `/healthz`. `/readyz` includes individual channel health and
+is useful for diagnosis without evicting the entire UI when a channel is down. Probes reject the UI's HTML fallback.
+The current upstream gateway binds IPv4; IPv6 Service requests are rejected by the chart.
+
+NetworkPolicy denies ingress unless callers are explicitly selected. Default egress permits cluster DNS and public HTTPS;
+private model servers, MCP, remote browsers and non-HTTPS services need `networkPolicy.extraEgress`. Ingress controllers
+also require an ingress peer rule. Controller-specific TLS redirects and WebSocket timeouts must be configured at the edge.

--- a/charts/openclaw/docs/operations.md
+++ b/charts/openclaw/docs/operations.md
@@ -10,6 +10,11 @@ named in Helm NOTES. Supply it in the Control UI connection settings. Treat toke
 them out of logs and tickets. Remote browser access needs HTTPS, an exact `gateway.controlUi.allowedOrigins` entry,
 WebSocket-capable routing, and a NetworkPolicy peer allowlist.
 
+With NetworkPolicy enabled, Ingress or Gateway API requires nonempty `networkPolicy.ingressFrom` selectors for the
+actual controller Pods/namespaces. Missing selectors fail rendering. Route names must be unique; rendered HTTPRoute
+names include a deterministic hash to keep long names distinct. Parent Helm `global` values are accepted when using
+this chart as a dependency; application settings and images still use this chart's explicit values.
+
 Remote device enrollment remains enabled. Inspect `openclaw devices list` in the running container and approve only the
 request ID associated with the intended browser using `openclaw devices approve <requestId>`. Local loopback connections
 can be auto-approved after authentication; this is not evidence of remote pairing. Do not enable dangerous device or

--- a/charts/openclaw/examples/custom-provider.yaml
+++ b/charts/openclaw/examples/custom-provider.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+agent:
+  model: internal/private-model
+credentials:
+  existingSecret: openclaw-provider
+config:
+  values:
+    models:
+      providers:
+        internal:
+          baseUrl: https://models.example.com/v1
+          apiKey: ${INTERNAL_API_KEY}
+          api: openai-completions
+          models:
+            - id: private-model
+              name: Private model
+              contextWindow: 128000
+              maxTokens: 4096

--- a/charts/openclaw/examples/production.yaml
+++ b/charts/openclaw/examples/production.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+credentials:
+  existingSecret: openclaw-provider
+auth:
+  existingSecret: openclaw-gateway
+persistence:
+  size: 50Gi
+resources:
+  requests:
+    cpu: '1'
+    memory: 2Gi
+  limits:
+    cpu: '4'
+    memory: 4Gi
+gateway:
+  controlUi:
+    allowedOrigins:
+      - https://agent.example.com
+networkPolicy:
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: gateway-system
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: gateway
+      parentRefs:
+        - name: edge
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - agent.example.com
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+  prometheusRule:
+    enabled: true
+    labels:
+      release: prometheus
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+backup:
+  enabled: true
+  stagingSize: 50Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+      ephemeral-storage: 20Gi
+    limits:
+      cpu: '2'
+      memory: 2Gi
+      ephemeral-storage: 50Gi
+  s3:
+    bucket: company-agent-backups
+    existingSecret: openclaw-s3
+    prefix: production/openclaw
+    sse: aws:kms
+    kmsKeyId: arn:aws:kms:us-east-1:123456789012:key/replace-me

--- a/charts/openclaw/examples/restore.yaml
+++ b/charts/openclaw/examples/restore.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+credentials:
+  existingSecret: openclaw-provider
+auth:
+  existingSecret: openclaw-gateway
+restore:
+  enabled: true
+  manifestKey: production/openclaw/openclaw-20260911T120000Z-0123456789abcdef/manifest.json
+backup:
+  s3:
+    bucket: company-agent-backups
+    existingSecret: openclaw-s3
+    prefix: production/openclaw

--- a/charts/openclaw/examples/simple.yaml
+++ b/charts/openclaw/examples/simple.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+credentials:
+  existingSecret: openclaw-provider

--- a/charts/openclaw/examples/staging.yaml
+++ b/charts/openclaw/examples/staging.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+credentials:
+  existingSecret: openclaw-provider
+auth:
+  existingSecret: openclaw-gateway
+config:
+  policy: seed
+persistence:
+  size: 20Gi
+gateway:
+  controlUi:
+    allowedOrigins:
+      - https://agent.staging.example.com
+metrics:
+  enabled: true

--- a/charts/openclaw/files/archive.mjs
+++ b/charts/openclaw/files/archive.mjs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {spawnSync} from 'node:child_process';
+import {createRequire} from 'node:module';
+const work='/work', archive=work+'/backup.tar.gz', target='/home/node';
+const require=createRequire('/app/package.json');
+const action=process.argv[2];
+const key=process.env.RESTORE_MANIFEST_KEY;
+const completed=target+'/.helmforge-restore.json';
+const incomplete=target+'/.helmforge-restore-incomplete';
+function native(args){
+ const result=spawnSync('node',['/app/openclaw.mjs','backup',...args,'--json'],{encoding:'utf8',maxBuffer:20*1024*1024,env:{...process.env,DO_NOT_TRACK:'1'}});
+ if(result.status!==0)throw new Error('Native backup command failed: '+result.stderr.slice(-3000));
+ try{return JSON.parse(result.stdout);}catch{throw new Error('Native backup did not return a single JSON result');}
+}
+async function checksum(file){const h=crypto.createHash('sha256');for await(const b of fs.createReadStream(file))h.update(b);return h.digest('hex');}
+function json(file){return JSON.parse(fs.readFileSync(file,'utf8'));}
+function emptyTarget(){
+ if(!fs.lstatSync(target).isDirectory())throw new Error('Recovery target must be a directory');
+ if(fs.existsSync(incomplete))throw new Error('Interrupted recovery requires operator inspection and a fresh empty claim');
+ if(fs.readdirSync(target).some(n=>n!=='lost+found'))throw new Error('Refusing to overwrite nonempty state');
+}
+if(action==='backup'){
+ if(fs.existsSync(archive))throw new Error('Archive destination already exists');
+ const result=native(['create','--output',archive,'--verify']);
+ if(result.verified!==true||result.dryRun!==false||result.archivePath!==archive||!result.includeWorkspace||result.onlyConfig)throw new Error('Native archive result is not a complete verified snapshot');
+ if(!result.assets?.some(a=>a.sourcePath==='/home/node/.openclaw'))throw new Error('State asset missing from snapshot');
+ const run='openclaw-'+new Date().toISOString().replaceAll('-','').replaceAll(':','').replace(/\.\d{3}Z$/,'Z')+'-'+crypto.randomBytes(8).toString('hex');
+ const size=fs.statSync(archive).size,sha256=await checksum(archive);
+ fs.writeFileSync(work+'/manifest.json',JSON.stringify({schemaVersion:1,application:'openclaw',image:process.env.OPENCLAW_IMAGE,run,archive:'backup.tar.gz',size,sha256,createdAt:result.createdAt}),{mode:0o600,flag:'wx'});
+ fs.writeFileSync(work+'/upload.tsv',`${run}\t${size}\t${sha256}\n`,{mode:0o600,flag:'wx'});
+ console.log('Native SQLite-consistent archive verified for S3 publication');
+}else if(action==='prepare-restore'){
+ if(fs.existsSync(completed)){
+  if(json(completed).manifestKey!==key)throw new Error('Existing recovery identity differs from requested manifest');
+  fs.writeFileSync(work+'/skip-restore','complete',{mode:0o600});
+ }else emptyTarget();
+}else if(action==='restore'){
+ if(fs.existsSync(work+'/skip-restore'))process.exit(0);
+ emptyTarget();
+ const manifest=json(work+'/manifest.json');
+ if(process.env.OPENCLAW_IMAGE && manifest.image!==process.env.OPENCLAW_IMAGE)throw new Error('Recovery requires the exact backup image; restore before upgrading');
+ if(manifest.schemaVersion!==1||manifest.application!=='openclaw'||manifest.archive!=='backup.tar.gz'||!Number.isSafeInteger(manifest.size)||manifest.size<=0||manifest.size>Number(process.env.MAX_ARCHIVE_BYTES)||!/^[a-f0-9]{64}$/.test(manifest.sha256))throw new Error('Invalid recovery manifest');
+ if(fs.lstatSync(archive).size!==manifest.size||await checksum(archive)!==manifest.sha256)throw new Error('Archive size/checksum mismatch');
+ const tar=require('tar');let expanded=0;
+ await tar.t({file:archive,onReadEntry(entry){expanded+=entry.size;if(expanded>Number(process.env.MAX_EXPANDED_BYTES))throw new Error('Expanded archive exceeds configured limit');}});
+ const stage=work+'/restored';
+ const restored=native(['restore',archive,'--target',stage]);
+ if(restored.ok!==true||restored.targetPath!==stage)throw new Error('Native restore did not validate staging');
+ const root=path.resolve(stage,restored.archiveRoot);
+ if(!root.startsWith(stage+'/'))throw new Error('Invalid archive root');
+ const nativeManifest=json(root+'/manifest.json');
+ const assets=nativeManifest.assets;
+ if(!Array.isArray(assets)||!assets.some(a=>a.sourcePath==='/home/node/.openclaw'))throw new Error('Restored state asset missing');
+ // Native verification validates symlinks and payloads. Activation only accepts
+ // assets in this chart's persisted home; external roots require manual recovery.
+ const moves=assets.map(a=>{
+  const source=path.resolve(stage,a.archivePath),destination=path.resolve(a.sourcePath);
+  if(!source.startsWith(root+'/')||!destination.startsWith(target+'/'))throw new Error('Archive requires manual recovery of external assets');
+  return {source,destination};
+ }).sort((a,b)=>a.destination.length-b.destination.length);
+ fs.writeFileSync(incomplete,key,{flag:'wx',mode:0o600});
+ for(const move of moves){
+  if(moves.some(parent=>parent!==move&&move.destination.startsWith(parent.destination+'/')))continue;
+  fs.mkdirSync(path.dirname(move.destination),{recursive:true,mode:0o700});
+  fs.cpSync(move.source,move.destination,{recursive:true,errorOnExist:true,force:false,verbatimSymlinks:true});
+ }
+ fs.writeFileSync(completed,JSON.stringify({manifestKey:key,sha256:manifest.sha256}),{flag:'wx',mode:0o600});
+ fs.unlinkSync(incomplete);
+ console.log('Verified OpenClaw state activated into the empty volume');
+}else throw new Error('Unknown archive operation');

--- a/charts/openclaw/files/bootstrap.mjs
+++ b/charts/openclaw/files/bootstrap.mjs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import fs from 'node:fs';
+import path from 'node:path';
+const state='/home/node/.openclaw';
+const policy=process.env.CONFIG_POLICY;
+if(!['managed','seed'].includes(policy))throw new Error('Invalid configuration policy');
+function directory(p){fs.mkdirSync(p,{recursive:true,mode:0o700});if(!fs.lstatSync(p).isDirectory())throw new Error('State path must be a directory');fs.chmodSync(p,0o700);}
+directory(state);directory(path.join(state,'workspace'));directory('/home/node/.config');directory('/home/node/.config/openclaw');
+for(const [source,target] of [['openclaw.json',path.join(state,'openclaw.json')],['AGENTS.md',path.join(state,'workspace/AGENTS.md')],['SOUL.md',path.join(state,'workspace/SOUL.md')]]){
+ const data=fs.readFileSync('/helmforge/'+source);
+ if(source!=='openclaw.json'&&!data.length)continue;
+ if(fs.existsSync(target)){if(!fs.lstatSync(target).isFile())throw new Error('Managed configuration must be a regular file');if(policy==='seed')continue;}
+ const tmp=target+'.helmforge-'+process.pid;
+ try{fs.writeFileSync(tmp,data,{flag:'wx',mode:0o600});fs.renameSync(tmp,target);}finally{if(fs.existsSync(tmp))fs.unlinkSync(tmp);}
+}
+console.log('OpenClaw configuration initialized with '+policy+' ownership');

--- a/charts/openclaw/files/health.mjs
+++ b/charts/openclaw/files/health.mjs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+const live=process.argv[2]==='live';
+try{
+ const response=await fetch('http://127.0.0.1:18789/'+(live?'healthz':'startupz'),{signal:AbortSignal.timeout(3000)});
+ if(!response.ok)process.exit(1);
+ const body=await response.json();
+ process.exit(body.ok===true && body.status===(live?'live':'started')?0:1);
+}catch{process.exit(1);}

--- a/charts/openclaw/files/s3.sh
+++ b/charts/openclaw/files/s3.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+umask 077
+if [[ "$1" == download && -f /work/skip-restore ]]; then exit 0; fi
+fail() { printf 'S3 operation failed: %s\n' "$1" >&2; exit 1; }
+export AWS_PAGER='' AWS_EC2_METADATA_DISABLED=true
+[[ ${S3_BUCKET:-} =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail 'invalid bucket'
+[[ ${S3_PREFIX:-} =~ ^[A-Za-z0-9][A-Za-z0-9/_-]*$ && "$S3_PREFIX" != */ ]] || fail 'invalid prefix'
+endpoint=()
+if [[ -n ${S3_ENDPOINT:-} ]]; then
+  case "$S3_ENDPOINT" in
+    https://*) ;;
+    http://*) [[ ${ALLOW_INSECURE_ENDPOINT:-false} == true ]] || fail 'HTTPS required' ;;
+    *) fail 'invalid endpoint' ;;
+  esac
+  [[ "$S3_ENDPOINT" != *'@'* ]] || fail 'endpoint must not contain credentials'
+  endpoint=(--endpoint-url "$S3_ENDPOINT")
+fi
+cloud() { aws "${endpoint[@]}" --region "$S3_REGION" "$@"; }
+encryption=()
+case ${S3_SSE:-} in
+  '') ;;
+  AES256) encryption=(--sse AES256) ;;
+  aws:kms) encryption=(--sse aws:kms --sse-kms-key-id "$S3_KMS_KEY_ID") ;;
+  *) fail 'invalid encryption mode' ;;
+esac
+case "$1" in
+  upload)
+    IFS=$'\t' read -r run size checksum < /work/upload.tsv
+    [[ "$run" =~ ^openclaw-[0-9]{8}T[0-9]{6}Z-[0-9a-f]{16}$ && "$size" =~ ^[0-9]+$ && "$checksum" =~ ^[0-9a-f]{64}$ ]] || fail 'invalid snapshot metadata'
+    [[ -f /work/backup.tar.gz && ! -L /work/backup.tar.gz && -s /work/manifest.json ]] || fail 'missing completed archive'
+    [[ $(stat -c %s /work/backup.tar.gz) == "$size" ]] || fail 'local size changed'
+    actual=$(sha256sum /work/backup.tar.gz); actual=${actual%% *}
+    [[ "$actual" == "$checksum" ]] || fail 'local checksum changed'
+    target="s3://${S3_BUCKET}/${S3_PREFIX}/${run}"
+    cloud s3 cp /work/backup.tar.gz "${target}/backup.tar.gz" --only-show-errors "${encryption[@]}"
+    actual=$(cloud s3 cp "${target}/backup.tar.gz" - --only-show-errors | sha256sum); actual=${actual%% *}
+    [[ "$actual" == "$checksum" ]] || fail 'remote byte verification failed'
+    cloud s3 cp /work/manifest.json "${target}/manifest.json" --only-show-errors "${encryption[@]}" --content-type application/json
+    printf 'Backup committed and remote archive verified: %s/manifest.json\n' "$target"
+    ;;
+  download)
+    [[ ${RESTORE_MANIFEST_KEY:-} =~ ^[A-Za-z0-9][A-Za-z0-9/_-]*/manifest\.json$ ]] || fail 'invalid manifest key'
+    [[ ${MAX_ARCHIVE_BYTES:-} =~ ^[0-9]+$ ]] || fail 'invalid archive size limit'
+    target="s3://${S3_BUCKET}/${RESTORE_MANIFEST_KEY%/manifest.json}"
+    cloud s3 cp "${target}/manifest.json" - --only-show-errors | head -c 20971521 > /work/manifest.json
+    [[ $(stat -c %s /work/manifest.json) -le 20971520 ]] || fail 'manifest too large'
+    cloud s3 cp "${target}/backup.tar.gz" - --only-show-errors | head -c "$((MAX_ARCHIVE_BYTES + 1))" > /work/backup.tar.gz
+    [[ $(stat -c %s /work/backup.tar.gz) -le "$MAX_ARCHIVE_BYTES" ]] || fail 'archive too large'
+    ;;
+  *) fail 'unknown operation' ;;
+esac

--- a/charts/openclaw/scripts/agent-accept.mjs
+++ b/charts/openclaw/scripts/agent-accept.mjs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+const token=process.env.OPENCLAW_GATEWAY_TOKEN;
+const prompt=process.env.TEST_PROMPT??'HF_STORE';
+const url='http://127.0.0.1:18789/v1/chat/completions';
+const payload={model:'openclaw/default',user:'helmforge-acceptance',messages:[{role:'user',content:prompt}]};
+const denied=await fetch(url,{method:'POST',headers:{'content-type':'application/json',authorization:'Bearer invalid'},body:JSON.stringify(payload)});
+assert.equal(denied.status,401,'Invalid gateway token must fail');
+const response=await fetch(url,{method:'POST',headers:{'content-type':'application/json',authorization:'Bearer '+token},body:JSON.stringify(payload),signal:AbortSignal.timeout(90000)});
+const body=await response.json();
+assert.equal(response.status,200,JSON.stringify(body));
+assert(body.choices?.[0]?.message?.content,'Gateway must return real provider output');
+if(prompt==='HF_READ')assert.match(body.choices[0].message.content,/HELMFORGE_PERSISTED_OPENCLAW_MEMORY/);
+console.log('PASS authenticated agent request '+prompt);

--- a/charts/openclaw/scripts/pairing-client.cjs
+++ b/charts/openclaw/scripts/pairing-client.cjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+const {createRequire} = require('node:module');
+const requireApp = createRequire('/app/package.json');
+const WebSocket = requireApp('ws');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = process.env.TEST_IDENTITY_FILE || '/tmp/openclaw-ci-identity.pem';
+let privateKey;
+try { privateKey = crypto.createPrivateKey(fs.readFileSync(path)); }
+catch (error) {
+  if (error.code !== 'ENOENT') throw error;
+  const pair = crypto.generateKeyPairSync('ed25519');
+  fs.writeFileSync(path, pair.privateKey.export({type:'pkcs8',format:'pem'}), {mode:0o600,flag:'wx'});
+  privateKey = pair.privateKey;
+}
+const publicDer = crypto.createPublicKey(privateKey).export({type:'spki',format:'der'});
+// Ed25519 SubjectPublicKeyInfo = fixed12byte prefix + raw32byte public key.
+if (publicDer.length !== 44 || publicDer.subarray(0,12).toString('hex') !== '302a300506032b6570032100')
+  throw new Error('unexpected Ed25519 public key encoding');
+const raw = publicDer.subarray(12);
+const deviceId = crypto.createHash('sha256').update(raw).digest('hex');
+const token = process.env.TEST_GATEWAY_TOKEN;
+if (!token) throw new Error('TEST_GATEWAY_TOKEN missing');
+const ws = new WebSocket(process.env.TEST_GATEWAY_WS_URL, {
+  origin: process.env.TEST_ORIGIN,
+  handshakeTimeout: 10000,
+});
+const timer = setTimeout(() => { ws.terminate(); console.error('pairing timeout'); process.exitCode=1; }, 20000);
+let finished=false;
+function finish(result) {
+  if (finished) return;
+  finished=true; clearTimeout(timer);
+  console.log(JSON.stringify(result)); ws.close();
+}
+ws.on('error', () => { if(!finished) { clearTimeout(timer); console.error('websocket connection error'); process.exitCode=1; } });
+ws.on('message', rawFrame => {
+  const frame=JSON.parse(rawFrame.toString());
+  if(frame.type==='event' && frame.event==='connect.challenge') {
+    const {nonce,ts}=frame.payload;
+    if(typeof nonce!=='string' || !nonce || !Number.isSafeInteger(ts)) throw new Error('invalid challenge');
+    const scopes=['operator.read'];
+    const client={id:'openclaw-control-ui',version:'2026.9.4',platform:'linux',mode:'webchat',displayName:'HelmForge CI pairing'};
+    const payload=['v3',deviceId,client.id,client.mode,'operator',scopes.join(','),String(ts),token,nonce,'linux',''].join('|');
+    ws.send(JSON.stringify({type:'req',id:'hf-connect',method:'connect',params:{
+      minProtocol:4,maxProtocol:4,client,role:'operator',scopes,caps:[],auth:{token},
+      device:{id:deviceId,publicKey:raw.toString('base64url'),signedAt:ts,nonce,
+        signature:crypto.sign(null,Buffer.from(payload),privateKey).toString('base64url')},
+    }}));
+  } else if(frame.type==='res' && frame.id==='hf-connect') {
+    if(frame.ok) {
+      if(frame.payload?.type!=='hello-ok') throw new Error('unexpected successful connect payload');
+      finish({ok:true,deviceId,protocol:frame.payload.protocol});
+    } else {
+      finish({ok:false,deviceId,code:frame.error?.details?.code,
+        requestId:frame.error?.details?.requestId || null});
+    }
+  }
+});
+ws.on('close', () => { if(!finished) { clearTimeout(timer); console.error('closed before connect result'); process.exitCode=1; } });

--- a/charts/openclaw/scripts/provider-fixture.mjs
+++ b/charts/openclaw/scripts/provider-fixture.mjs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Only the external model service is simulated. The real gateway executes tools.
+import http from 'node:http';
+http.createServer(async(req,res)=>{
+ if(req.url==='/health'){res.end('ok');return;}
+ if(req.url==='/v1/models'){res.setHeader('content-type','application/json');res.end(JSON.stringify({object:'list',data:[{id:'helmforge-fixture',object:'model'}]}));return;}
+ let raw='';for await(const part of req){raw+=part;if(raw.length>2*1024*1024){res.writeHead(413).end();return;}}
+ let body;try{body=JSON.parse(raw);}catch{res.writeHead(400).end();return;}
+ if(req.headers.authorization!=='Bearer helmforge-fixture-only'){res.writeHead(401).end();return;}
+ const messages=body.messages??[];
+ const latestUser=messages.findLastIndex(x=>x.role==='user');
+ const request=JSON.stringify(messages[latestUser]??{});
+ const toolResults=messages.slice(latestUser+1).filter(x=>x.role==='tool');
+ let tool;
+ if(!toolResults.length&&request.includes('HF_STORE'))tool={name:'write',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt',content:'HELMFORGE_PERSISTED_OPENCLAW_MEMORY'})};
+ if(!toolResults.length&&request.includes('HF_READ'))tool={name:'read',arguments:JSON.stringify({path:'/home/node/.openclaw/workspace/helmforge-memory.txt'})};
+ const content=tool?null:(toolResults.length?JSON.stringify(toolResults):'HELMFORGE_OPENCLAW_RESPONSE');
+ const message=tool?{role:'assistant',content:null,tool_calls:[{id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+ const finish=tool?'tool_calls':'stop';
+ const common={id:'chatcmpl-helmforge',created:Math.floor(Date.now()/1000),model:'helmforge-fixture'};
+ console.log(JSON.stringify({method:req.method,path:req.url,stream:!!body.stream,tool:tool?.name??null}));
+ if(body.stream){
+  res.writeHead(200,{'content-type':'text/event-stream','cache-control':'no-cache'});
+  const delta=tool?{role:'assistant',tool_calls:[{index:0,id:'call_helmforge',type:'function',function:tool}]}:{role:'assistant',content};
+  res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta,finish_reason:null}]})+'\n\n');
+  res.write('data: '+JSON.stringify({...common,object:'chat.completion.chunk',choices:[{index:0,delta:{},finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}})+'\n\n');
+  res.end('data: [DONE]\n\n');
+ }else{res.setHeader('content-type','application/json');res.end(JSON.stringify({...common,object:'chat.completion',choices:[{index:0,message,finish_reason:finish}],usage:{prompt_tokens:30,completion_tokens:12,total_tokens:42}}));}
+}).listen(8080,'0.0.0.0');

--- a/charts/openclaw/scripts/runtime-pairing.mjs
+++ b/charts/openclaw/scripts/runtime-pairing.mjs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+export function pairingClient({k,json,chart,values,name,pod,peer,secretName}){
+ const secret=json(['get','secret',secretName,'-o','json']);
+ const token=Buffer.from(secret.data[values.auth.key],'base64').toString();
+ const code=fs.readFileSync(path.join(chart,'scripts/pairing-client.cjs'),'utf8');
+ const policy={apiVersion:'networking.k8s.io/v1',kind:'NetworkPolicy',metadata:{name:'openclaw-pairing-test'},spec:{podSelector:{matchLabels:{'app.kubernetes.io/instance':json(['get','pod',pod,'-o','json']).metadata.labels['app.kubernetes.io/instance'],'app.kubernetes.io/component':'gateway'}},policyTypes:['Ingress'],ingress:[{from:[{podSelector:{matchLabels:{app:'openclaw-provider'}}}],ports:[{protocol:'TCP',port:18789}]}]}};
+ const run=({wrongToken=false,wrongOrigin=false}={})=>{
+  const env={TEST_GATEWAY_TOKEN:wrongToken?'incorrect-pairing-token':token,TEST_GATEWAY_WS_URL:`ws://${name}:${values.service.port}`,TEST_ORIGIN:wrongOrigin?'https://untrusted.example.invalid':values.gateway.controlUi.allowedOrigins[0]};
+  // Send credentials only through stdin, never process arguments or logs.
+  return JSON.parse(k(['exec','-i',peer,'-c','provider','--','node'],`Object.assign(process.env,${JSON.stringify(env)});\n${code}`));
+ };
+ const cli=(args)=>JSON.parse(k(['exec',pod,'-c','openclaw','--','node','/app/openclaw.mjs','devices',...args,'--json']));
+ return {
+  async enroll(){
+   k(['apply','-f','-'],JSON.stringify(policy));await new Promise(r=>setTimeout(r,1000));
+   try{
+    const pending=run();assert.equal(pending.ok,false);assert.equal(pending.code,'PAIRING_REQUIRED');assert(pending.requestId);
+    const requested=cli(['list']).pending.filter(x=>x.requestId===pending.requestId&&x.deviceId===pending.deviceId);
+    assert.equal(requested.length,1,'Approve only the exact test device');
+    cli(['approve',pending.requestId]);
+    assert.equal(run().ok,true);
+    assert.equal(run({wrongToken:true}).code,'AUTH_TOKEN_MISMATCH');
+    assert.equal(run({wrongOrigin:true}).code,'CONTROL_UI_ORIGIN_NOT_ALLOWED');
+    console.log('PASS remote signed Control UI pairing, exact approval, token and origin rejection');
+   }finally{k(['delete','networkpolicy','openclaw-pairing-test']);}
+  },
+  async reconnect(){
+   k(['apply','-f','-'],JSON.stringify(policy));await new Promise(r=>setTimeout(r,1000));
+   try{assert.equal(run().ok,true);console.log('PASS paired device reconnects after gateway upgrade');}
+   finally{k(['delete','networkpolicy','openclaw-pairing-test']);}
+  }
+ };
+}

--- a/charts/openclaw/scripts/runtime-recovery.mjs
+++ b/charts/openclaw/scripts/runtime-recovery.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+export async function validateRecovery({k,json,helm,node,values,name,chart,namespace}){
+ if(!values.backup.enabled)return;
+ const negativeName='openclaw-recovery-guards';
+ const negativeSource=`import fs from 'node:fs';import assert from 'node:assert/strict';import {spawnSync} from 'node:child_process';
+fs.writeFileSync('/work/backup.tar.gz','invalid');fs.writeFileSync('/work/manifest.json',JSON.stringify({schemaVersion:1,application:'openclaw',archive:'backup.tar.gz',size:7,sha256:'0'.repeat(64)}));
+let result=spawnSync('node',['/recovery/archive.mjs','restore'],{encoding:'utf8'});assert.notEqual(result.status,0);assert.match(result.stderr,/Archive size\\/checksum mismatch/);
+fs.writeFileSync('/home/node/occupied','preserve');result=spawnSync('node',['/recovery/archive.mjs','prepare-restore'],{encoding:'utf8'});assert.notEqual(result.status,0);assert.match(result.stderr,/Refusing to overwrite nonempty state/);assert.equal(fs.readFileSync('/home/node/occupied','utf8'),'preserve');console.log('PASS corrupt archive and occupied target refused');`;
+ const guard={apiVersion:'batch/v1',kind:'Job',metadata:{name:negativeName},spec:{backoffLimit:0,activeDeadlineSeconds:60,template:{spec:{restartPolicy:'Never',automountServiceAccountToken:false,securityContext:{runAsNonRoot:true,runAsUser:1000,runAsGroup:1000,fsGroup:1000,seccompProfile:{type:'RuntimeDefault'}},containers:[{name:'guards',image:values.image.repository+':'+values.image.tag,command:['node','--input-type=module','-e',negativeSource],env:[{name:'MAX_ARCHIVE_BYTES',value:'1000'},{name:'MAX_EXPANDED_BYTES',value:'1000'},{name:'RESTORE_MANIFEST_KEY',value:'test/manifest.json'}],securityContext:{readOnlyRootFilesystem:true,allowPrivilegeEscalation:false,capabilities:{drop:['ALL']}},resources:{requests:{cpu:'50m',memory:'64Mi'},limits:{cpu:'500m',memory:'256Mi'}},volumeMounts:[{name:'home',mountPath:'/home/node'},{name:'work',mountPath:'/work'},{name:'recovery',mountPath:'/recovery',readOnly:true}]}],volumes:[{name:'home',emptyDir:{}},{name:'work',emptyDir:{}},{name:'recovery',configMap:{name:name+'-recovery'}}]}}}};
+ try{k(['apply','-f','-'],JSON.stringify(guard));k(['wait','--for=condition=complete',`job/${negativeName}`,'--timeout=60s']);assert.match(k(['logs',`job/${negativeName}`]),/corrupt archive and occupied target refused/);}
+ finally{k(['delete','job',negativeName,'--ignore-not-found=true','--wait=true','--timeout=60s']);}
+ console.log('PASS corrupt recovery data and occupied state fail closed');
+ const job='openclaw-acceptance-backup';let manifestKey;
+ try{
+  k(['create','job',job,`--from=cronjob/${name}-backup`]);
+  k(['wait','--for=condition=complete',`job/${job}`,'--timeout=120s']);
+  assert.match(k(['logs',`job/${job}`,'-c','snapshot']),/Native SQLite-consistent archive verified/);
+  const match=k(['logs',`job/${job}`,'-c','upload']).match(/s3:\/\/[^/]+\/(.+\/manifest\.json)/);
+  assert(match,'Offsite backup must publish a completion manifest');manifestKey=match[1];
+ }finally{k(['delete','job',job,'--ignore-not-found=true','--wait=true','--timeout=60s']);}
+ console.log('PASS native SQLite snapshot and TLS S3 remote byte verification');
+ const restored=structuredClone(values);const restoredName=name.slice(0,40)+'-recovered';
+ restored.fullnameOverride=restoredName;restored.persistence.existingClaim='';restored.persistence.retain=false;
+ restored.backup.enabled=false;restored.restore={...restored.restore,enabled:true,manifestKey};
+ restored.metrics.enabled=false;restored.metrics.serviceMonitor.enabled=false;restored.metrics.prometheusRule.enabled=false;
+ restored.externalSecrets.enabled=false;restored.ingress.enabled=false;restored.gatewayAPI.enabled=false;
+ restored.auth.existingSecret=json(['get','statefulset',name,'-o','json']).spec.template.spec.containers[0].env.find(x=>x.name==='OPENCLAW_GATEWAY_TOKEN').valueFrom.secretKeyRef.name;
+ restored.networkPolicy.extraEgress.push(...values.backup.networkPolicy.extraEgress);
+ const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-openclaw-recovery-'));const file=path.join(temporary,'values.json');
+ const release='openclaw-acceptance-recovery';const pod=restoredName+'-0';
+ try{
+  fs.writeFileSync(file,JSON.stringify(restored));
+  helm(['install',release,chart,'-f',file,'--wait','--timeout','180s']);
+  assert.match(k(['logs',pod,'-c','restore']),/Verified OpenClaw state activated/);
+  console.log(node(fs.readFileSync(path.join(chart,'scripts/agent-accept.mjs'),'utf8'),pod,'openclaw',['TEST_PROMPT=HF_READ']).trim());
+  node(`import assert from 'node:assert/strict';import fs from 'node:fs';import {DatabaseSync} from 'node:sqlite';
+for(const f of ['/home/node/.openclaw/state/openclaw.sqlite','/home/node/.openclaw/agents/default/agent/openclaw-agent.sqlite']){assert(fs.existsSync(f),f);const db=new DatabaseSync(f,{readOnly:true});assert.equal(db.prepare('PRAGMA integrity_check').get().integrity_check,'ok');db.close();}console.log('PASS native restored SQLite integrity');`,pod);
+  k(['delete','pod',pod,'--wait=true','--timeout=60s']);
+  k(['rollout','status',`statefulset/${restoredName}`,'--timeout=120s']);
+  assert(!k(['logs',pod,'-c','download']).includes('download failed'));
+  console.log(node(fs.readFileSync(path.join(chart,'scripts/agent-accept.mjs'),'utf8'),pod,'openclaw',['TEST_PROMPT=HF_READ']).trim());
+  console.log('PASS empty-volume activation, real recovered agent and idempotent restart');
+ }finally{
+  try{helm(['uninstall',release,'--wait','--timeout','60s']);}finally{fs.unlinkSync(file);fs.rmdirSync(temporary);}
+ }
+}

--- a/charts/openclaw/scripts/runtime-smoke.mjs
+++ b/charts/openclaw/scripts/runtime-smoke.mjs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {execFileSync} from 'node:child_process';
+import {validateRecovery} from './runtime-recovery.mjs';
+import {pairingClient} from './runtime-pairing.mjs';
+const [context,namespace,release]=process.argv.slice(2);
+assert.equal(context,'k3d-helmforge-tests-wsl');assert.equal(namespace,'hf-validate-openclaw');
+const chart=path.resolve(import.meta.dirname,'..');
+const k=(args,input,timeout=180000)=>execFileSync('kubectl',['--context',context,'-n',namespace,...args],{encoding:'utf8',input,timeout,maxBuffer:8*1024*1024,stdio:['pipe','pipe','pipe']});
+const helm=args=>execFileSync('helm',[...args,'--kube-context',context,'-n',namespace],{encoding:'utf8',timeout:240000,maxBuffer:8*1024*1024,stdio:'pipe'});
+const json=args=>JSON.parse(k(args));
+let values=JSON.parse(helm(['get','values',release,'--all','-o','json']));
+if(values.agent.model!=='fixture/helmforge-fixture'){
+ k(['apply','-f',path.join(chart,'ci/fixtures/agent-values.yaml')]);
+ k(['rollout','status','deployment/openclaw-provider','--timeout=120s']);
+ helm(['upgrade',release,chart,'--reset-then-reuse-values','-f',path.join(chart,'ci/agent-values.yaml'),'--wait','--timeout','180s']);
+ values=JSON.parse(helm(['get','values',release,'--all','-o','json']));
+}
+const sts=json(['get','statefulset','-l',`app.kubernetes.io/instance=${release}`,'-o','json']).items[0];
+const name=sts.metadata.name,pod=name+'-0';
+const node=(source,target=pod,container='openclaw',env=[])=>k(['exec','-i',target,'-c',container,'--','env',...env,'node','--input-type=module'],source);
+const accept=prompt=>node(fs.readFileSync(path.join(chart,'scripts/agent-accept.mjs'),'utf8'),pod,'openclaw',[`TEST_PROMPT=${prompt}`]);
+node(`import assert from 'node:assert/strict';import fs from 'node:fs';assert.equal(process.getuid(),1000);assert(!fs.existsSync('/var/run/secrets/kubernetes.io/serviceaccount/token'));assert.match(fs.readFileSync('/proc/1/comm','utf8'),/tini/);assert.throws(()=>fs.writeFileSync('/etc/helmforge-test','fail'));console.log('PASS restricted runtime and official init');`);
+console.log(accept('HF_STORE').trim());
+node(`import assert from 'node:assert/strict';import fs from 'node:fs';assert.equal(fs.readFileSync('/home/node/.openclaw/workspace/helmforge-memory.txt','utf8'),'HELMFORGE_PERSISTED_OPENCLAW_MEMORY');`);
+console.log(accept('HF_READ').trim());
+const secretName=sts.spec.template.spec.containers[0].env.find(x=>x.name==='OPENCLAW_GATEWAY_TOKEN').valueFrom.secretKeyRef.name;
+const identity=json(['get','secret',secretName,'-o','json']).data;
+if(values.externalSecrets.enabled){
+ const secrets=json(['get','externalsecrets','-o','json']).items;
+ assert(secrets.length>0);
+ for(const secret of secrets)assert(secret.status?.conditions?.some(c=>c.type==='Ready'&&c.status==='True'));
+ console.log('PASS External Secrets synchronized and consumed by the gateway');
+}
+const peer=json(['get','pods','-l','app=openclaw-provider','-o','json']).items[0].metadata.name;
+const get=url=>node(`const r=await fetch(${JSON.stringify(url)},{signal:AbortSignal.timeout(3000)});console.log(r.status);` ,peer,'provider');
+if(values.networkPolicy.enabled&&!values.networkPolicy.ingressFrom.length)assert.throws(()=>get(`http://${name}:${values.service.port}/healthz`));
+const policy={apiVersion:'networking.k8s.io/v1',kind:'NetworkPolicy',metadata:{name:'openclaw-acceptance'},spec:{podSelector:{matchLabels:{'app.kubernetes.io/instance':release,'app.kubernetes.io/component':'gateway'}},policyTypes:['Ingress'],ingress:[{from:[{podSelector:{matchLabels:{app:'openclaw-provider'}}}],ports:[{protocol:'TCP',port:18789}]}]}};
+k(['apply','-f','-'],JSON.stringify(policy));
+try{await new Promise(r=>setTimeout(r,1500));assert.equal(get(`http://${name}:${values.service.port}/healthz`).trim(),'200');}finally{k(['delete','networkpolicy','openclaw-acceptance']);}
+console.log('PASS network peer denial and admission');
+const pairing=pairingClient({k,json,chart,values,name,pod,peer,secretName});
+await pairing.enroll();
+if(values.metrics.enabled&&values.metrics.collector.enabled){
+ const metrics=node(`const r=await fetch('http://127.0.0.1:8889/metrics');if(!r.ok)throw new Error('Metrics unavailable');console.log(await r.text());`);
+ assert.match(metrics,/openclaw[_.]/,'Collector must expose native OpenClaw metrics');
+ console.log('PASS native OpenClaw OTLP to Prometheus');
+}
+const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-openclaw-'));
+try{
+ const upgradeFile=path.join(temporary,'upgrade.json');fs.writeFileSync(upgradeFile,JSON.stringify({podAnnotations:{'helmforge.dev/acceptance-upgrade':'true'}}));
+ helm(['upgrade',release,chart,'--reset-then-reuse-values','-f',upgradeFile,'--wait','--timeout','180s']);
+ assert.deepEqual(json(['get','secret',secretName,'-o','json']).data,identity);
+ console.log(accept('HF_READ').trim());
+ console.log('PASS gateway identity and tool-written state survive upgrade');
+ await pairing.reconnect();
+}finally{for(const file of fs.readdirSync(temporary))fs.unlinkSync(path.join(temporary,file));fs.rmdirSync(temporary);}
+await validateRecovery({k,json,helm,node,values,name,chart,namespace});
+console.log('OpenClaw behavioral acceptance passed');

--- a/charts/openclaw/scripts/runtime-smoke.mjs
+++ b/charts/openclaw/scripts/runtime-smoke.mjs
@@ -47,6 +47,7 @@ await pairing.enroll();
 if(values.metrics.enabled&&values.metrics.collector.enabled){
  const metrics=node(`const r=await fetch('http://127.0.0.1:8889/metrics');if(!r.ok)throw new Error('Metrics unavailable');console.log(await r.text());`);
  assert.match(metrics,/openclaw[_.]/,'Collector must expose native OpenClaw metrics');
+ if(values.metrics.serviceMonitor.enabled)assert.equal(get(`http://${name}-metrics:8889/metrics`).trim(),'200');
  console.log('PASS native OpenClaw OTLP to Prometheus');
 }
 const temporary=fs.mkdtempSync(path.join(os.tmpdir(),'hf-openclaw-'));

--- a/charts/openclaw/templates/NOTES.txt
+++ b/charts/openclaw/templates/NOTES.txt
@@ -1,0 +1,50 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "openclaw.validate" . -}}
+OPENCLAW
+
+1. Release
+   {{ .Release.Name }} in {{ .Release.Namespace }}; OpenClaw {{ .Chart.AppVersion }}.
+   One gateway writer per persistent volume. Upgrades require a maintenance window.
+
+2. Runtime
+   kubectl -n {{ .Release.Namespace }} rollout status statefulset/{{ include "openclaw.fullname" . }}
+   Model: {{ .Values.agent.model }}. Tool profile: {{ .Values.agent.toolProfile }}.
+   Configure the model provider credentials in credentials.existingSecret.
+
+3. Access
+   kubectl -n {{ .Release.Namespace }} port-forward service/{{ include "openclaw.fullname" . }} 18789:{{ .Values.service.port }}
+   Control UI: http://localhost:18789
+   Gateway token: Secret {{ include "openclaw.authSecret" . }}, key {{ .Values.auth.key }}.
+   Device pairing remains enforced. Approve only the intended pending device.
+   Remote access needs HTTPS, explicit allowed origins and permitted network peers.
+
+4. Configuration and channels
+   Ownership policy: {{ .Values.config.policy }}. Seed mode preserves existing UI/CLI edits.
+   Managed mode applies declared configuration on Pod initialization.
+   Enabled messaging channels require Secret credentials and explicit user allowlists.
+   Gateway operators, models and enabled tools share this installation's trust boundary.
+
+5. Persistence
+   Enabled: {{ .Values.persistence.enabled }}. Claim: {{ include "openclaw.claim" . }}.
+   Retain after uninstall: {{ .Values.persistence.retain }}.
+   Persisted home includes state, agent workspaces, sessions and file credentials.
+   Protect Kubernetes Secrets separately. Do not run two gateways against this claim.
+
+6. Backup and recovery
+   Scheduled S3 backup: {{ .Values.backup.enabled }}; {{ .Values.backup.schedule }} in {{ .Values.backup.timeZone }}.
+   Restore: {{ .Values.restore.enabled }}; empty destination required.
+   Native archives snapshot each owned SQLite database, not one global transaction.
+   Restore rolls back sessions and credentials; review pending actions and channel relinking.
+
+7. Monitoring and maintenance
+   Native OTLP: {{ .Values.metrics.enabled }}; ServiceMonitor: {{ .Values.metrics.serviceMonitor.enabled }}.
+   Startup and readiness parse /startupz JSON. Liveness parses /healthz JSON.
+   /readyz includes channel health and is intended for deeper diagnostics.
+   Monitor PVC capacity, restarts, telemetry gaps and failed backup Jobs.
+
+8. Documentation
+   https://helmforge.dev/docs/charts/openclaw
+   https://github.com/helmforgedev/charts/tree/main/charts/openclaw/docs
+   https://docs.openclaw.ai/
+
+Happy Helmforging :)

--- a/charts/openclaw/templates/_config.tpl
+++ b/charts/openclaw/templates/_config.tpl
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "openclaw.config" -}}
+{{- $cfg := deepCopy .Values.config.values }}
+{{- $_ := set $cfg "gateway" (dict "mode" "local" "bind" "lan" "port" 18789 "auth" (dict "mode" "token") "trustedProxies" .Values.gateway.trustedProxies "controlUi" (dict "enabled" .Values.gateway.controlUi.enabled "allowedOrigins" .Values.gateway.controlUi.allowedOrigins) "http" (dict "endpoints" (dict "chatCompletions" .Values.gateway.chatCompletions "responses" .Values.gateway.responses))) }}
+{{- $defaults := mergeOverwrite (deepCopy .Values.agent.defaults) (dict "workspace" "/home/node/.openclaw/workspace" "model" (dict "primary" .Values.agent.model) "maxConcurrent" .Values.agent.maxConcurrent) }}
+{{- $agents := mergeOverwrite (dict "default" (dict "name" "OpenClaw" "workspace" "/home/node/.openclaw/workspace")) (deepCopy .Values.agent.entries) }}
+{{- $_ := set $cfg "agents" (dict "defaults" $defaults "entries" $agents) }}
+{{- $_ := set $cfg "tools" (dict "profile" .Values.agent.toolProfile "alsoAllow" .Values.agent.allowTools "deny" .Values.agent.denyTools "fs" (dict "workspaceOnly" true) "elevated" (dict "enabled" false)) }}
+{{- $channels := dict }}
+{{- range $name, $channel := .Values.channels }}
+{{- $_ := set $channels $name (dict "enabled" $channel.enabled "dmPolicy" "allowlist" "allowFrom" $channel.allowFrom "groupPolicy" "disabled") }}
+{{- end }}
+{{- $_ := set $cfg "channels" $channels }}
+{{- $plugins := list }}
+{{- if .Values.channels.telegram.enabled }}{{- $plugins = append $plugins "telegram" }}{{- end }}
+{{- if .Values.channels.discord.enabled }}{{- $plugins = append $plugins "discord" }}{{- end }}
+{{- $entries := dict }}
+{{- if .Values.metrics.enabled }}
+{{- $plugins = append $plugins "diagnostics-otel" }}
+{{- $_ := set $entries "diagnostics-otel" (dict "enabled" true) }}
+{{- $endpoint := ternary "http://127.0.0.1:4318" .Values.metrics.externalEndpoint .Values.metrics.collector.enabled }}
+{{- $_ := set $cfg "diagnostics" (dict "enabled" true "otel" (dict "enabled" true "endpoint" $endpoint "protocol" "http/protobuf" "serviceName" "openclaw-gateway" "metrics" true "traces" false "logs" false "captureContent" false "flushIntervalMs" (mul .Values.metrics.intervalSeconds 1000))) }}
+{{- end }}
+{{- $_ := set $cfg "plugins" (dict "allow" $plugins "entries" $entries) }}
+{{- $_ := set $cfg "logging" (mergeOverwrite (dict "consoleStyle" "json") (get $cfg "logging" | default dict)) }}
+{{- toPrettyJson $cfg }}
+{{- end }}

--- a/charts/openclaw/templates/_helpers.tpl
+++ b/charts/openclaw/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "openclaw.name" -}}{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{- end }}
+{{- define "openclaw.fullname" -}}
+{{- if .Values.fullnameOverride }}{{ .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}{{ printf "%s-%s" .Release.Name (include "openclaw.name" .) | trunc 63 | trimSuffix "-" }}{{- end }}
+{{- end }}
+{{- define "openclaw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "openclaw.labels" -}}
+{{ include "openclaw.selectorLabels" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- define "openclaw.image" -}}{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}{{- end }}
+{{- define "openclaw.authSecret" -}}{{ default (printf "%s-auth" (include "openclaw.fullname" .)) .Values.auth.existingSecret }}{{- end }}
+{{- define "openclaw.claim" -}}{{ default (printf "%s-data" (include "openclaw.fullname" .)) .Values.persistence.existingClaim }}{{- end }}
+{{- define "openclaw.serviceAccount" -}}
+{{- if .Values.serviceAccount.create }}{{ default (include "openclaw.fullname" .) .Values.serviceAccount.name }}{{ else }}{{ default "default" .Values.serviceAccount.name }}{{ end }}
+{{- end }}
+{{- define "openclaw.httpRouteName" -}}
+{{- $suffix := .route.name | default (printf "route-%v" .index) }}
+{{- printf "%s-%s" (include "openclaw.fullname" .root | trunc 40 | trimSuffix "-") ($suffix | trunc 22 | trimSuffix "-") }}
+{{- end }}
+{{- define "openclaw.externalSecretName" -}}
+{{- default (printf "%s-%s" (include "openclaw.fullname" .root | trunc 40 | trimSuffix "-") (.item.name | default "external" | trunc 22 | trimSuffix "-")) .item.fullnameOverride }}
+{{- end }}
+{{- define "openclaw.validate" -}}
+{{- range $key := list "workspace" "model" "maxConcurrent" }}
+{{- if hasKey $.Values.agent.defaults $key }}{{ fail (printf "agent.defaults.%s is reserved; use the explicit agent values" $key) }}{{- end }}
+{{- end }}
+{{- range $id, $agent := .Values.agent.entries }}
+{{- range $key := list "workspace" "agentDir" }}
+{{- $path := get $agent $key | default "" }}
+{{- if and $path (or (not (hasPrefix "/home/node/" $path)) (contains ".." $path)) }}{{ fail (printf "agent.entries.%s.%s must stay inside /home/node" $id $key) }}{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.persistence.existingClaim (not .Values.persistence.enabled) }}{{ fail "persistence.existingClaim requires persistence.enabled" }}{{- end }}
+{{- if or (has "IPv6" .Values.service.ipFamilies) (eq .Values.service.ipFamilyPolicy "RequireDualStack") }}{{ fail "OpenClaw's official gateway currently binds IPv4 only; use IPv4 SingleStack" }}{{- end }}
+{{- range $key := list "gateway" "agents" "tools" "channels" "diagnostics" "plugins" }}
+{{- if hasKey $.Values.config.values $key }}{{ fail (printf "config.values.%s is chart-owned; use the explicit values contract" $key) }}{{- end }}
+{{- end }}
+{{- if and (or .Values.ingress.enabled .Values.gatewayAPI.enabled) (empty .Values.gateway.controlUi.allowedOrigins) }}{{ fail "remote access requires explicit gateway.controlUi.allowedOrigins" }}{{- end }}
+{{- range .Values.gateway.controlUi.allowedOrigins }}{{- if contains "*" . }}{{ fail "wildcard Control UI origins are forbidden" }}{{- end }}{{- end }}
+{{- range .Values.gateway.trustedProxies }}{{- if has . (list "0.0.0.0/0" "::/0") }}{{ fail "trustedProxies must identify actual reverse proxies" }}{{- end }}{{- end }}
+{{- range $name, $channel := .Values.channels }}
+{{- if and $channel.enabled (or (empty $channel.allowFrom) (empty $.Values.credentials.existingSecret)) }}{{ fail (printf "channels.%s requires allowFrom and credentials.existingSecret" $name) }}{{- end }}
+{{- end }}
+{{- if and .Values.metrics.enabled (not .Values.metrics.collector.enabled) (empty .Values.metrics.externalEndpoint) }}{{ fail "external metrics require metrics.externalEndpoint" }}{{- end }}
+{{- if and (or .Values.metrics.serviceMonitor.enabled .Values.metrics.prometheusRule.enabled) (not (and .Values.metrics.enabled .Values.metrics.collector.enabled)) }}{{ fail "Prometheus integration requires metrics.enabled and metrics.collector.enabled" }}{{- end }}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) }}{{ fail "gatewayAPI.enabled requires httpRoutes" }}{{- end }}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) }}{{ fail "externalSecrets.enabled requires items" }}{{- end }}
+{{- if or .Values.backup.enabled .Values.restore.enabled }}
+{{- if or (not .Values.persistence.enabled) (empty .Values.backup.s3.bucket) (empty .Values.backup.s3.existingSecret) }}{{ fail "backup/restore requires persistent storage, backup.s3.bucket and backup.s3.existingSecret" }}{{- end }}
+{{- if and .Values.backup.enabled (has "ReadWriteOncePod" .Values.persistence.accessModes) }}{{ fail "backup requires RWO or RWX, not ReadWriteOncePod" }}{{- end }}
+{{- if and (hasPrefix "http://" .Values.backup.s3.endpoint) (not .Values.backup.s3.allowInsecureEndpoint) }}{{ fail "HTTP S3 requires explicit backup.s3.allowInsecureEndpoint" }}{{- end }}
+{{- if and (eq .Values.backup.s3.sse "aws:kms") (empty .Values.backup.s3.kmsKeyId) }}{{ fail "aws:kms requires backup.s3.kmsKeyId" }}{{- end }}
+{{- end }}
+{{- if and .Values.restore.enabled (empty .Values.restore.manifestKey) }}{{ fail "restore.enabled requires restore.manifestKey" }}{{- end }}
+{{- range .Values.extraEnv }}
+{{- if or (hasPrefix "OPENCLAW_" .name) (has .name (list "HOME" "NODE_OPTIONS" "NODE_ENV" "DO_NOT_TRACK" "CONFIG_POLICY")) }}{{ fail (printf "extraEnv.%s conflicts with the chart runtime contract" .name) }}{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/templates/_helpers.tpl
+++ b/charts/openclaw/templates/_helpers.tpl
@@ -22,12 +22,21 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- define "openclaw.httpRouteName" -}}
 {{- $suffix := .route.name | default (printf "route-%v" .index) }}
-{{- printf "%s-%s" (include "openclaw.fullname" .root | trunc 40 | trimSuffix "-") ($suffix | trunc 22 | trimSuffix "-") }}
+{{- $complete := printf "%s-%s" (include "openclaw.fullname" .root) $suffix }}
+{{- printf "%s-%s" ($complete | trunc 54 | trimSuffix "-") ($complete | sha256sum | trunc 8) }}
 {{- end }}
 {{- define "openclaw.externalSecretName" -}}
 {{- default (printf "%s-%s" (include "openclaw.fullname" .root | trunc 40 | trimSuffix "-") (.item.name | default "external" | trunc 22 | trimSuffix "-")) .item.fullnameOverride }}
 {{- end }}
 {{- define "openclaw.validate" -}}
+{{- $routeNames := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- $name := $route.name | default (printf "route-%v" $index) }}
+{{- if hasKey $routeNames $name }}{{ fail (printf "gatewayAPI.httpRoutes contains duplicate effective name: %s" $name) }}{{- end }}
+{{- $_ := set $routeNames $name true }}
+{{- end }}
+{{- if and .Values.networkPolicy.enabled (or .Values.ingress.enabled .Values.gatewayAPI.enabled) (empty .Values.networkPolicy.ingressFrom) }}{{ fail "remote ingress with NetworkPolicy requires networkPolicy.ingressFrom" }}{{- end }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.serviceMonitor.enabled (empty .Values.metrics.ingressFrom) }}{{ fail "ServiceMonitor with NetworkPolicy requires metrics.ingressFrom" }}{{- end }}
 {{- range $key := list "workspace" "model" "maxConcurrent" }}
 {{- if hasKey $.Values.agent.defaults $key }}{{ fail (printf "agent.defaults.%s is reserved; use the explicit agent values" $key) }}{{- end }}
 {{- end }}

--- a/charts/openclaw/templates/_recovery.tpl
+++ b/charts/openclaw/templates/_recovery.tpl
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "openclaw.s3Env" -}}
+- {name: HOME, value: /tmp}
+- {name: S3_BUCKET, value: {{ .Values.backup.s3.bucket | quote }}}
+- {name: S3_PREFIX, value: {{ .Values.backup.s3.prefix | quote }}}
+- {name: S3_REGION, value: {{ .Values.backup.s3.region | quote }}}
+- {name: S3_ENDPOINT, value: {{ .Values.backup.s3.endpoint | quote }}}
+- {name: ALLOW_INSECURE_ENDPOINT, value: {{ .Values.backup.s3.allowInsecureEndpoint | toString | quote }}}
+- {name: S3_SSE, value: {{ .Values.backup.s3.sse | quote }}}
+- {name: S3_KMS_KEY_ID, value: {{ .Values.backup.s3.kmsKeyId | quote }}}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_ACCESS_KEY_ID}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_SECRET_ACCESS_KEY}
+- name: AWS_SESSION_TOKEN
+  valueFrom:
+    secretKeyRef: {name: {{ .Values.backup.s3.existingSecret }}, key: AWS_SESSION_TOKEN, optional: true}
+{{- if .Values.backup.s3.caSecret }}
+- {name: AWS_CA_BUNDLE, value: /s3-ca/ca.crt}
+{{- end }}
+{{- end }}
+{{- define "openclaw.restoreEnv" -}}
+- {name: OPENCLAW_IMAGE, value: {{ include "openclaw.image" . | quote }}}
+- {name: OPENCLAW_STATE_DIR, value: /tmp/openclaw-recovery}
+- {name: TARGET_HOME, value: /home/node}
+- {name: RESTORE_MANIFEST_KEY, value: {{ .Values.restore.manifestKey | quote }}}
+- {name: MAX_ARCHIVE_BYTES, value: {{ .Values.restore.maxArchiveBytes | int64 | toString | quote }}}
+- {name: MAX_EXPANDED_BYTES, value: {{ .Values.restore.maxExpandedBytes | int64 | toString | quote }}}
+{{- end }}
+{{- define "openclaw.restoreInitContainers" -}}
+{{- range $action := list "prepare-restore" "download" "restore" }}
+- name: {{ $action }}
+  {{- if eq $action "download" }}
+  image: {{ printf "%s:%s" $.Values.backup.image.repository $.Values.backup.image.tag | quote }}
+  command: [/bin/bash, /recovery/s3.sh, download]
+  {{- else }}
+  image: {{ include "openclaw.image" $ | quote }}
+  command: [node, /recovery/archive.mjs, {{ $action }}]
+  {{- end }}
+  env:
+    {{- include "openclaw.restoreEnv" $ | nindent 4 }}
+    {{- if eq $action "download" }}
+    {{- include "openclaw.s3Env" $ | nindent 4 }}
+    {{- else }}
+    - {name: HOME, value: /tmp}
+    {{- end }}
+  securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+  resources: {{ toJson $.Values.backup.resources }}
+  volumeMounts:
+    - {name: recovery, mountPath: /recovery, readOnly: true}
+    - {name: recovery-work, mountPath: /work}
+    - {name: tmp, mountPath: /tmp}
+    {{- if ne $action "download" }}
+    - {name: data, mountPath: /home/node}
+    {{- else if $.Values.backup.s3.caSecret }}
+    - {name: s3-ca, mountPath: /s3-ca, readOnly: true}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/templates/backup-networkpolicy.yaml
+++ b/charts/openclaw/templates/backup-networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.backup.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openclaw.fullname" . }}-backup
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backup
+  policyTypes: [Ingress, Egress]
+  ingress: []
+  egress:
+    - to: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}}]
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    - to:
+        - ipBlock: {cidr: 0.0.0.0/0, except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8]}
+        - ipBlock: {cidr: "2000::/3"}
+      ports: [{protocol: TCP, port: 443}]
+    {{- with .Values.backup.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/openclaw/templates/backup.yaml
+++ b/charts/openclaw/templates/backup.yaml
@@ -1,0 +1,102 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openclaw.fullname" . }}-backup
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+automountServiceAccountToken: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "openclaw.fullname" . }}-backup
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  timeZone: {{ .Values.backup.timeZone | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "openclaw.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "openclaw.fullname" . }}-backup
+          automountServiceAccountToken: false
+          securityContext: {runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000, fsGroupChangePolicy: OnRootMismatch, seccompProfile: {type: RuntimeDefault}}
+          nodeSelector: {{ toJson .Values.nodeSelector }}
+          tolerations: {{ toJson .Values.tolerations }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets: {{ toJson . }}
+          {{- end }}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      {{- include "openclaw.selectorLabels" . | nindent 22 }}
+                      app.kubernetes.io/component: gateway
+          initContainers:
+            - name: snapshot
+              image: {{ include "openclaw.image" . | quote }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: [node, /recovery/archive.mjs, backup]
+              env:
+                - {name: HOME, value: /home/node}
+                - {name: OPENCLAW_STATE_DIR, value: /home/node/.openclaw}
+                - {name: OPENCLAW_CONFIG_PATH, value: /home/node/.openclaw/openclaw.json}
+                - {name: OPENCLAW_IMAGE, value: {{ include "openclaw.image" . | quote }}}
+              {{- if .Values.credentials.existingSecret }}
+              envFrom:
+                - secretRef: {name: {{ .Values.credentials.existingSecret }}}
+              {{- end }}
+              securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+              resources: {{ toJson .Values.backup.resources }}
+              volumeMounts:
+                - {name: data, mountPath: /home/node}
+                - {name: recovery, mountPath: /recovery, readOnly: true}
+                - {name: work, mountPath: /work}
+                - {name: tmp, mountPath: /tmp}
+          containers:
+            - name: upload
+              image: {{ printf "%s:%s" .Values.backup.image.repository .Values.backup.image.tag | quote }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              command: [/bin/bash, /recovery/s3.sh, upload]
+              env:
+                {{- include "openclaw.s3Env" . | nindent 16 }}
+              securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+              resources: {{ toJson .Values.backup.resources }}
+              volumeMounts:
+                - {name: recovery, mountPath: /recovery, readOnly: true}
+                - {name: work, mountPath: /work, readOnly: true}
+                - {name: tmp, mountPath: /tmp}
+                {{- if .Values.backup.s3.caSecret }}
+                - {name: s3-ca, mountPath: /s3-ca, readOnly: true}
+                {{- end }}
+          volumes:
+            - name: data
+              persistentVolumeClaim: {claimName: {{ include "openclaw.claim" . }}}
+            - name: recovery
+              configMap: {name: {{ include "openclaw.fullname" . }}-recovery}
+            - name: work
+              emptyDir: {sizeLimit: {{ .Values.backup.stagingSize }}}
+            - name: tmp
+              emptyDir: {sizeLimit: 128Mi}
+            {{- if .Values.backup.s3.caSecret }}
+            - name: s3-ca
+              secret: {secretName: {{ .Values.backup.s3.caSecret }}, items: [{key: ca.crt, path: ca.crt}]}
+            {{- end }}
+{{- end }}

--- a/charts/openclaw/templates/configmap.yaml
+++ b/charts/openclaw/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "openclaw.validate" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openclaw.fullname" . }}-config
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+data:
+  openclaw.json: |
+    {{- include "openclaw.config" . | nindent 4 }}
+  AGENTS.md: {{ .Values.config.agentInstructions | quote }}
+  SOUL.md: {{ .Values.config.soul | quote }}
+  bootstrap.mjs: |
+    {{- .Files.Get "files/bootstrap.mjs" | nindent 4 }}
+  health.mjs: |
+    {{- .Files.Get "files/health.mjs" | nindent 4 }}

--- a/charts/openclaw/templates/externalsecret.yaml
+++ b/charts/openclaw/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "openclaw.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "openclaw.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/templates/gateway-httproute.yaml
+++ b/charts/openclaw/templates/gateway-httproute.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes | default list }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "openclaw.httpRouteName" (dict "root" $ "route" . "index" $index) }}
+  labels:
+    {{- include "openclaw.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .parentRefs }}
+  parentRefs:
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- end }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .rules }}
+    {{- range .rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else if not .omitDefaultBackend }}
+      backendRefs:
+        - name: {{ include "openclaw.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ include "openclaw.fullname" $ }}
+          port: {{ $.Values.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/templates/headless-service.yaml
+++ b/charts/openclaw/templates/headless-service.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw.fullname" . }}-headless
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports: [{name: api, port: 18789, targetPort: api}]
+  selector:
+    {{- include "openclaw.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway

--- a/charts/openclaw/templates/ingress.yaml
+++ b/charts/openclaw/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{ toJson . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "openclaw.fullname" $ }}
+                port: {number: {{ $.Values.service.port }}}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/openclaw/templates/metrics.yaml
+++ b/charts/openclaw/templates/metrics.yaml
@@ -1,0 +1,109 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openclaw.fullname" . }}-collector
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 127.0.0.1:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        timeout: 5s
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        translation_strategy: UnderscoreEscapingWithoutSuffixes
+        metric_expiration: 5m
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw.fullname" . }}-metrics
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toJson . }}
+  {{- end }}
+  ports: [{name: metrics, port: 8889, targetPort: metrics}]
+  selector:
+    {{- include "openclaw.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+{{- if .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  namespaceSelector: {matchNames: [{{ .Release.Namespace | quote }}]}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- if .Values.metrics.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "openclaw.fullname" . }}.gateway
+      rules:
+        - alert: OpenClawMetricsUnavailable
+          expr: up{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "openclaw.fullname" .) | quote }}} == 0
+          for: 5m
+          labels: {severity: warning}
+          annotations: {summary: "OpenClaw metrics scrape is unavailable"}
+        - alert: OpenClawNativeMetricsMissing
+          expr: absent(openclaw_gateway_event_loop_delay_max_ms_count{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "openclaw.fullname" .) | quote }}})
+          for: 10m
+          labels: {severity: warning}
+          annotations: {summary: "Native OpenClaw gateway telemetry is absent"}
+        {{- with .Values.metrics.prometheusRule.additionalRules }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/templates/networkpolicy.yaml
+++ b/charts/openclaw/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  policyTypes: [Ingress, Egress]
+  ingress:
+    {{- with .Values.networkPolicy.ingressFrom }}
+    - from: {{ toJson . }}
+      ports: [{protocol: TCP, port: 18789}]
+    {{- end }}
+    {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled .Values.metrics.ingressFrom }}
+    - from: {{ toJson .Values.metrics.ingressFrom }}
+      ports: [{protocol: TCP, port: 8889}]
+    {{- end }}
+    {{- if not (or .Values.networkPolicy.ingressFrom (and .Values.metrics.enabled .Values.metrics.collector.enabled .Values.metrics.ingressFrom)) }}
+    []
+    {{- end }}
+  egress:
+    - to: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: kube-system}}}]
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    {{- if .Values.networkPolicy.allowInternet }}
+    - to:
+        - ipBlock: {cidr: 0.0.0.0/0, except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8]}
+        - ipBlock: {cidr: "2000::/3"}
+      ports: [{protocol: TCP, port: 443}]
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/openclaw/templates/recovery-configmap.yaml
+++ b/charts/openclaw/templates/recovery-configmap.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or .Values.backup.enabled .Values.restore.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openclaw.fullname" . }}-recovery
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+data:
+  archive.mjs: |
+    {{- .Files.Get "files/archive.mjs" | nindent 4 }}
+  s3.sh: |
+    {{- .Files.Get "files/s3.sh" | nindent 4 }}
+{{- end }}

--- a/charts/openclaw/templates/secret.yaml
+++ b/charts/openclaw/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.auth.existingSecret }}
+{{- $name := include "openclaw.authSecret" . }}
+{{- $old := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- if and $old (not (index $old.data .Values.auth.key)) }}{{ fail "Retained API Secret is missing auth.key; migrate the Secret explicitly before changing its key" }}{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- if and .Values.persistence.enabled .Values.persistence.retain }}
+  annotations: {helm.sh/resource-policy: keep}
+  {{- end }}
+type: Opaque
+data:
+  {{ .Values.auth.key }}: {{ if and $old (index $old.data .Values.auth.key) }}{{ index $old.data .Values.auth.key }}{{ else }}{{ randAlphaNum 64 | b64enc }}{{ end }}
+{{- end }}

--- a/charts/openclaw/templates/service.yaml
+++ b/charts/openclaw/templates/service.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{ toJson . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toJson . }}
+  {{- end }}
+  selector:
+    {{- include "openclaw.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  ports: [{name: api, port: {{ .Values.service.port }}, targetPort: api}]

--- a/charts/openclaw/templates/serviceaccount.yaml
+++ b/charts/openclaw/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openclaw.serviceAccount" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{ toJson . }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/openclaw/templates/statefulset.yaml
+++ b/charts/openclaw/templates/statefulset.yaml
@@ -1,0 +1,139 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "openclaw.fullname" . }}-headless
+  selector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        {{- include "openclaw.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "openclaw.serviceAccount" . }}
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toJson . }}
+      {{- end }}
+      nodeSelector: {{ toJson .Values.nodeSelector }}
+      tolerations: {{ toJson .Values.tolerations }}
+      affinity: {{ toJson .Values.affinity }}
+      initContainers:
+        {{- if .Values.restore.enabled }}
+        {{- include "openclaw.restoreInitContainers" . | nindent 8 }}
+        {{- end }}
+        - name: configure
+          image: {{ include "openclaw.image" . | quote }}
+          command: [node, /helmforge/bootstrap.mjs]
+          env: [{name: CONFIG_POLICY, value: {{ .Values.config.policy | quote }}}]
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.resources }}
+          volumeMounts:
+            - {name: data, mountPath: /home/node}
+            - {name: config, mountPath: /helmforge, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
+      containers:
+        - name: openclaw
+          image: {{ include "openclaw.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: [node, openclaw.mjs, gateway, --bind, lan, --port, "18789"]
+          env:
+            - {name: HOME, value: /home/node}
+            - {name: OPENCLAW_HOME, value: /home/node}
+            - {name: OPENCLAW_STATE_DIR, value: /home/node/.openclaw}
+            - {name: OPENCLAW_CONFIG_DIR, value: /home/node/.openclaw}
+            - {name: OPENCLAW_CONFIG_PATH, value: /home/node/.openclaw/openclaw.json}
+            - {name: OPENCLAW_WORKSPACE_DIR, value: /home/node/.openclaw/workspace}
+            - {name: OPENCLAW_DISABLE_BONJOUR, value: "1"}
+            - {name: DO_NOT_TRACK, value: "1"}
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef: {name: {{ include "openclaw.authSecret" . }}, key: {{ .Values.auth.key }}}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.credentials.existingSecret }}
+          envFrom:
+            - secretRef: {name: {{ .Values.credentials.existingSecret }}}
+          {{- end }}
+          ports: [{name: api, containerPort: 18789}]
+          startupProbe:
+            exec: {command: [node, /helmforge/health.mjs]}
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            exec: {command: [node, /helmforge/health.mjs]}
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec: {command: [node, /helmforge/health.mjs, live]}
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.resources }}
+          volumeMounts:
+            - {name: data, mountPath: /home/node}
+            - {name: config, mountPath: /helmforge, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
+        {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+        - name: metrics
+          image: {{ printf "%s:%s" .Values.metrics.collector.image.repository .Values.metrics.collector.image.tag | quote }}
+          imagePullPolicy: {{ .Values.metrics.collector.image.pullPolicy }}
+          args: [--config=/etc/otel/config.yaml]
+          ports: [{name: metrics, containerPort: 8889}]
+          startupProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 5, failureThreshold: 30}
+          livenessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 20}
+          readinessProbe: {httpGet: {path: /, port: 13133}, periodSeconds: 10}
+          securityContext: {runAsUser: 10001, runAsGroup: 10001, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          resources: {{ toJson .Values.metrics.collector.resources }}
+          volumeMounts:
+            - {name: collector-config, mountPath: /etc/otel, readOnly: true}
+        {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim: {claimName: {{ include "openclaw.claim" . }}}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          configMap: {name: {{ include "openclaw.fullname" . }}-config}
+        - name: tmp
+          emptyDir: {sizeLimit: 512Mi}
+        {{- if .Values.restore.enabled }}
+        - name: recovery
+          configMap: {name: {{ include "openclaw.fullname" . }}-recovery}
+        - name: recovery-work
+          emptyDir: {sizeLimit: {{ .Values.backup.stagingSize }}}
+        {{- if .Values.backup.s3.caSecret }}
+        - name: s3-ca
+          secret: {secretName: {{ .Values.backup.s3.caSecret }}, items: [{key: ca.crt, path: ca.crt}]}
+        {{- end }}
+        {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.collector.enabled }}
+        - name: collector-config
+          configMap: {name: {{ include "openclaw.fullname" . }}-collector}
+        {{- end }}

--- a/charts/openclaw/templates/storage.yaml
+++ b/charts/openclaw/templates/storage.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openclaw.claim" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- if .Values.persistence.retain }}
+  annotations: {helm.sh/resource-policy: keep}
+  {{- end }}
+spec:
+  accessModes: {{ .Values.persistence.accessModes | toJson }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests: {storage: {{ .Values.persistence.size | quote }}}
+{{- end }}

--- a/charts/openclaw/tests/config_test.yaml
+++ b/charts/openclaw/tests/config_test.yaml
@@ -16,7 +16,8 @@ tests:
           pattern: '"profile": "minimal"'
   - it: includes the operator-selected HTTPS origin
     set:
-      gateway.controlUi.allowedOrigins: [https://agent.example.com]
+      gateway.controlUi.allowedOrigins:
+        - https://agent.example.com
     asserts:
       - matchRegex:
           path: data["openclaw.json"]
@@ -43,3 +44,28 @@ tests:
       - matchRegex:
           path: data["openclaw.json"]
           pattern: '"captureContent": false'
+  - it: rejects duplicate route names even when other fields differ
+    set:
+      gatewayAPI.httpRoutes:
+        - name: same
+          hostnames:
+            - one.example.com
+        - name: same
+          hostnames:
+            - two.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: 'gatewayAPI.httpRoutes contains duplicate effective name: same'
+  - it: requires a permitted controller for remote ingress
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: remote ingress with NetworkPolicy requires networkPolicy.ingressFrom
+  - it: requires a permitted scraper for ServiceMonitor
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: ServiceMonitor with NetworkPolicy requires metrics.ingressFrom

--- a/charts/openclaw/tests/config_test.yaml
+++ b/charts/openclaw/tests/config_test.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: OpenClaw security and configuration
+templates:
+  - configmap.yaml
+tests:
+  - it: keeps token auth and excludes dangerous device bypasses
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: '"mode": "token"'
+      - notMatchRegex:
+          path: data["openclaw.json"]
+          pattern: dangerouslyDisableDeviceAuth
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: '"profile": "minimal"'
+  - it: includes the operator-selected HTTPS origin
+    set:
+      gateway.controlUi.allowedOrigins: [https://agent.example.com]
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: https://agent.example.com
+  - it: refuses overriding chart gateway security through extra config
+    set:
+      config.values.gateway.auth.mode: none
+    asserts:
+      - failedTemplate:
+          errorMessage: config.values.gateway is chart-owned; use the explicit values contract
+  - it: requires explicit channel credentials and callers
+    set:
+      channels.telegram.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: channels.telegram requires allowFrom and credentials.existingSecret
+  - it: enables bundled telemetry without sensitive content capture
+    set:
+      metrics.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: diagnostics-otel
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: '"captureContent": false'

--- a/charts/openclaw/tests/integrations_test.yaml
+++ b/charts/openclaw/tests/integrations_test.yaml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: OpenClaw platform integrations
+templates:
+  - '*.yaml'
+tests:
+  - it: retains state after uninstall
+    template: storage.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+  - it: emits a private metrics Service and ServiceMonitor
+    template: metrics.yaml
+    documentIndex: 2
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - containsDocument:
+          kind: ServiceMonitor
+          apiVersion: monitoring.coreos.com/v1
+          name: RELEASE-NAME-openclaw
+  - it: omits monitoring resources by default
+    template: metrics.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: applies the explicit ingress class
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+  - it: omits an empty ingress class
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+  - it: creates a route to the gateway Service
+    template: gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: api
+          parentRefs:
+            - name: edge
+          hostnames: [openclaw.example.com]
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 18789
+  - it: includes custom private endpoint egress
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.extraEgress:
+        - to:
+            - podSelector:
+                matchLabels: {app: models}
+          ports:
+            - port: 8080
+              protocol: TCP
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - podSelector:
+                  matchLabels: {app: models}
+            ports:
+              - port: 8080
+                protocol: TCP
+  - it: uses the canonical External Secrets target contract
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: external-gateway
+          spec:
+            secretStoreRef: {name: store, kind: ClusterSecretStore}
+            data:
+              - secretKey: gateway-token
+                remoteRef: {key: token}
+    asserts:
+      - equal:
+          path: spec.target.name
+          value: external-gateway
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+  - it: omits External Secrets when disabled
+    template: externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: isolates the S3 uploader from agent state
+    template: backup.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.existingSecret: s3
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /home/node
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].command
+          value: [node, /recovery/archive.mjs, backup]

--- a/charts/openclaw/tests/integrations_test.yaml
+++ b/charts/openclaw/tests/integrations_test.yaml
@@ -15,6 +15,10 @@ tests:
     set:
       metrics.enabled: true
       metrics.serviceMonitor.enabled: true
+      metrics.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: prometheus
     asserts:
       - containsDocument:
           kind: ServiceMonitor
@@ -30,6 +34,10 @@ tests:
     set:
       ingress.enabled: true
       ingress.ingressClassName: nginx
+      networkPolicy.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: edge
     asserts:
       - equal:
           path: spec.ingressClassName
@@ -38,6 +46,10 @@ tests:
     template: ingress.yaml
     set:
       ingress.enabled: true
+      networkPolicy.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: edge
     asserts:
       - notExists:
           path: spec.ingressClassName
@@ -49,7 +61,12 @@ tests:
         - name: api
           parentRefs:
             - name: edge
-          hostnames: [openclaw.example.com]
+          hostnames:
+            - openclaw.example.com
+      networkPolicy.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: edge
     asserts:
       - equal:
           path: spec.rules[0].backendRefs[0].port
@@ -60,7 +77,8 @@ tests:
       networkPolicy.extraEgress:
         - to:
             - podSelector:
-                matchLabels: {app: models}
+                matchLabels:
+                  app: models
           ports:
             - port: 8080
               protocol: TCP
@@ -70,7 +88,8 @@ tests:
           content:
             to:
               - podSelector:
-                  matchLabels: {app: models}
+                  matchLabels:
+                    app: models
             ports:
               - port: 8080
                 protocol: TCP
@@ -81,10 +100,13 @@ tests:
       externalSecrets.items:
         - fullnameOverride: external-gateway
           spec:
-            secretStoreRef: {name: store, kind: ClusterSecretStore}
+            secretStoreRef:
+              name: store
+              kind: ClusterSecretStore
             data:
               - secretKey: gateway-token
-                remoteRef: {key: token}
+                remoteRef:
+                  key: token
     asserts:
       - equal:
           path: spec.target.name
@@ -115,4 +137,69 @@ tests:
             mountPath: /home/node
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].command
-          value: [node, /recovery/archive.mjs, backup]
+          value:
+            - node
+            - /recovery/archive.mjs
+            - backup
+  - it: keeps long route names distinct within Kubernetes name limits
+    template: gateway-httproute.yaml
+    set:
+      fullnameOverride: rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+      gatewayAPI.enabled: true
+      networkPolicy.ingressFrom:
+        - podSelector:
+            matchLabels:
+              app: edge
+      gatewayAPI.httpRoutes:
+        - name: identical-route-prefix-first
+        - name: identical-route-prefix-second
+    asserts:
+      - equal:
+          path: metadata.name
+          value: rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr-ide-1d4ecff7
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr-ide-53d6a990
+        documentIndex: 1
+  - it: accepts parent Helm globals without overriding explicit image settings
+    template: statefulset.yaml
+    set:
+      global:
+        imageRegistry: parent.example.com
+        custom:
+          tenant: example
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr.io/openclaw/openclaw:'
+  - it: accepts OTLP endpoint https://collector.example.com
+    template: configmap.yaml
+    set:
+      metrics.enabled: true
+      metrics.collector.enabled: false
+      metrics.externalEndpoint: https://collector.example.com
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: https://collector.example.com
+  - it: accepts OTLP endpoint https://collector.example.com/v1/metrics
+    template: configmap.yaml
+    set:
+      metrics.enabled: true
+      metrics.collector.enabled: false
+      metrics.externalEndpoint: https://collector.example.com/v1/metrics
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: https://collector.example.com/v1/metrics
+  - it: accepts OTLP endpoint http://127.0.0.1:4318
+    template: configmap.yaml
+    set:
+      metrics.enabled: true
+      metrics.collector.enabled: false
+      metrics.externalEndpoint: http://127.0.0.1:4318
+    asserts:
+      - matchRegex:
+          path: data["openclaw.json"]
+          pattern: http://127.0.0.1:4318

--- a/charts/openclaw/tests/runtime_test.yaml
+++ b/charts/openclaw/tests/runtime_test.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: OpenClaw runtime contracts
+templates:
+  - '*.yaml'
+tests:
+  - it: runs one non-root writer with the official init entrypoint
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - notExists:
+          path: spec.template.spec.containers[0].command
+      - equal:
+          path: >-
+            spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+    template: statefulset.yaml
+  - it: validates JSON probe contracts without exposing credentials
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - node
+            - /helmforge/health.mjs
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value:
+            - node
+            - /helmforge/health.mjs
+            - live
+    template: statefulset.yaml
+  - it: injects provider credentials from the selected Secret
+    set:
+      credentials.existingSecret: provider-credentials
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: provider-credentials
+    template: statefulset.yaml
+  - it: preserves seed configuration ownership
+    set:
+      config.policy: seed
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].env[0].value
+          value: seed
+    template: statefulset.yaml
+  - it: attaches a bounded official telemetry collector only when enabled
+    set:
+      metrics.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: metrics
+    template: statefulset.yaml
+  - it: uses an externally supplied claim
+    set:
+      persistence.existingClaim: persistent-agent
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: persistent-agent
+    template: statefulset.yaml

--- a/charts/openclaw/values.schema.json
+++ b/charts/openclaw/values.schema.json
@@ -442,7 +442,8 @@
             "additionalProperties": false,
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "labels": {
                 "type": "object"
@@ -469,7 +470,8 @@
                 }
               }
             }
-          }
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false
@@ -526,7 +528,7 @@
         },
         "externalEndpoint": {
           "type": "string",
-          "pattern": "^$|^https?://[^ @]+/v1/metrics$"
+          "pattern": "^$|^https?://[^\\s/@?#]+(?:/[^\\s?#]*)?$"
         },
         "collector": {
           "type": "object",
@@ -930,6 +932,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Parent-provided Helm globals are accepted for dependency composition; chart settings remain explicit."
     }
   },
   "additionalProperties": false,

--- a/charts/openclaw/values.schema.json
+++ b/charts/openclaw/values.schema.json
@@ -1,0 +1,937 @@
+{
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^.+@sha256:[a-f0-9]{64}$",
+          "not": {
+            "pattern": "^latest(@|$)"
+          }
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "credentials": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "defaults": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "entries": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "model": {
+          "type": "string"
+        },
+        "toolProfile": {
+          "type": "string",
+          "enum": [
+            "minimal",
+            "coding",
+            "messaging",
+            "full"
+          ]
+        },
+        "allowTools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "denyTools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "maxConcurrent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        }
+      },
+      "additionalProperties": false
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "type": "string",
+          "enum": [
+            "managed",
+            "seed"
+          ]
+        },
+        "values": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "agentInstructions": {
+          "type": "string"
+        },
+        "soul": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "ReadWriteOnce",
+              "ReadWriteOncePod",
+              "ReadWriteMany"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "size": {
+          "type": "string"
+        },
+        "retain": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "LoadBalancer",
+            "NodePort"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "enum": [
+            "",
+            "SingleStack"
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "maxItems": 1,
+          "items": {
+            "const": "IPv4"
+          }
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {
+        "kubernetes.io/os": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {}
+    },
+    "affinity": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "podAnnotations": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "value"
+            ]
+          },
+          {
+            "required": [
+              "valueFrom"
+            ]
+          }
+        ]
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "podSelector": {
+                "type": "object"
+              },
+              "namespaceSelector": {
+                "type": "object"
+              },
+              "ipBlock": {
+                "type": "object",
+                "required": [
+                  "cidr"
+                ],
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "except": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "extraEgress": {
+          "type": "array",
+          "items": {}
+        },
+        "allowInternet": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 30,
+      "maximum": 600
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressClassName": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "parentRefs": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "hostnames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "spec"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "fullnameOverride": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "spec": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "intervalSeconds": {
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 3600
+        },
+        "externalEndpoint": {
+          "type": "string",
+          "pattern": "^$|^https?://[^ @]+/v1/metrics$"
+        },
+        "collector": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tag": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^.+@sha256:[a-f0-9]{64}$",
+                  "not": {
+                    "pattern": "^latest(@|$)"
+                  }
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "interval": {
+              "type": "string"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "prometheusRule": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "additionalRules": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "additionalProperties": false
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "properties": {
+              "podSelector": {
+                "type": "object"
+              },
+              "namespaceSelector": {
+                "type": "object"
+              },
+              "ipBlock": {
+                "type": "object",
+                "required": [
+                  "cidr"
+                ],
+                "properties": {
+                  "cidr": {
+                    "type": "string"
+                  },
+                  "except": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "backup": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "timeZone": {
+          "type": "string"
+        },
+        "suspend": {
+          "type": "boolean"
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 20
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 20
+        },
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 86400
+        },
+        "stagingSize": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "pattern": "^$|^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$"
+            },
+            "prefix": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9/_-]*[A-Za-z0-9_-])?$"
+            },
+            "region": {
+              "type": "string"
+            },
+            "endpoint": {
+              "type": "string",
+              "pattern": "^$|^https?://[^ @]+$"
+            },
+            "allowInsecureEndpoint": {
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "sse": {
+              "type": "string",
+              "enum": [
+                "",
+                "AES256",
+                "aws:kms"
+              ]
+            },
+            "kmsKeyId": {
+              "type": "string"
+            },
+            "caSecret": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^.+@sha256:[a-f0-9]{64}$",
+              "not": {
+                "pattern": "^latest(@|$)"
+              }
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "networkPolicy": {
+          "type": "object",
+          "properties": {
+            "extraEgress": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "restore": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "manifestKey": {
+          "type": "string",
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9/_-]*/manifest\\.json$"
+        },
+        "maxArchiveBytes": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 1099511627776
+        },
+        "maxExpandedBytes": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 2199023255552
+        }
+      },
+      "additionalProperties": false
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "controlUi": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowedOrigins": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^https?://[^/]+$"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "trustedProxies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chatCompletions": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "responses": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "channels": {
+      "type": "object",
+      "properties": {
+        "telegram": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowFrom": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "not": {
+                  "const": "*"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "discord": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowFrom": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "not": {
+                  "const": "*"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# -- name override setting for the gateway.
+nameOverride: ""
+# -- fullname override setting for the gateway.
+fullnameOverride: ""
+# -- Official OpenClaw runtime pinned to a verified release digest.
+image:
+  # -- repository setting for image.
+  repository: ghcr.io/openclaw/openclaw
+  # -- tag setting for image.
+  tag: 2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101
+  # -- pull policy setting for image.
+  pullPolicy: IfNotPresent
+# -- image pull secrets setting for the gateway.
+imagePullSecrets: []
+# -- Gateway token authentication; device pairing remains enabled.
+auth:
+  # -- Existing Secret with the gateway token; empty generates and retains a token across upgrades.
+  existingSecret: ""
+  # -- Secret key containing the gateway token.
+  key: gateway-token
+# -- Provider and channel environment credentials from a Kubernetes Secret.
+credentials:
+  # -- Existing Secret containing provider keys and TELEGRAM_BOT_TOKEN or DISCORD_BOT_TOKEN as applicable.
+  existingSecret: ""
+# -- Default agent model and explicit upstream tool policy.
+agent:
+  # -- Additional upstream agent defaults, for example memorySearch or sandbox. Model, workspace and concurrency use the explicit fields below.
+  defaults: {}
+  # -- Additional named agents; keep their workspace and agentDir below /home/node for chart-managed backup recovery.
+  entries: {}
+  # -- Upstream provider/model identifier; inference needs the corresponding credential.
+  model: anthropic/claude-opus-4-6
+  # -- Upstream tool profile: minimal, coding, messaging or full. Minimal permits session_status only.
+  toolProfile: minimal
+  # -- Additional upstream tool allowlist; exec and filesystem access grant access within the agent container.
+  allowTools: []
+  # -- Additional upstream tool denylist.
+  denyTools: []
+  # -- Maximum concurrent agent runs.
+  maxConcurrent: 1
+# -- Non-secret upstream configuration and workspace instructions.
+config:
+  # -- managed reconciles declared config on restart; seed preserves UI/CLI config after first initialization.
+  policy: managed
+  # -- Additional upstream configuration; chart security, state and telemetry fields are reserved.
+  values: {}
+  # -- Optional workspace AGENTS.md content with the selected configuration ownership policy.
+  agentInstructions: ""
+  # -- Optional workspace SOUL.md content with the selected configuration ownership policy.
+  soul: ""
+# -- persistence setting for the gateway.
+persistence:
+  # -- enabled setting for persistence.
+  enabled: true
+  # -- existing claim setting for persistence.
+  existingClaim: ""
+  # -- storage class setting for persistence.
+  storageClass: ""
+  # -- access modes setting for persistence.
+  accessModes:
+    - ReadWriteOnce
+  # -- size setting for persistence.
+  size: 10Gi
+  # -- retain setting for persistence.
+  retain: true
+# -- service setting for the gateway.
+service:
+  # -- type setting for service.
+  type: ClusterIP
+  # -- port setting for service.
+  port: 18789
+  # -- annotations setting for service.
+  annotations: {}
+  # -- ip family policy setting for service.
+  ipFamilyPolicy: ""
+  # -- ip families setting for service.
+  ipFamilies: []
+  # -- load balancer source ranges setting for service.
+  loadBalancerSourceRanges: []
+# -- service account setting for the gateway.
+serviceAccount:
+  # -- create setting for serviceAccount.
+  create: true
+  # -- name setting for serviceAccount.
+  name: ""
+  # -- annotations setting for serviceAccount.
+  annotations: {}
+# -- resources setting for the gateway.
+resources:
+  # -- requests setting for resources.
+  requests:
+    # -- cpu setting for resources.requests.
+    cpu: 250m
+    # -- memory setting for resources.requests.
+    memory: 1Gi
+  # -- limits setting for resources.
+  limits:
+    # -- cpu setting for resources.limits.
+    cpu: "2"
+    # -- memory setting for resources.limits.
+    memory: 3Gi
+# -- node selector setting for the gateway.
+nodeSelector:
+  kubernetes.io/os: linux
+# -- tolerations setting for the gateway.
+tolerations: []
+# -- affinity setting for the gateway.
+affinity: {}
+# -- pod annotations setting for the gateway.
+podAnnotations: {}
+# -- extra env setting for the gateway.
+extraEnv: []
+# -- network policy setting for the gateway.
+networkPolicy:
+  # -- enabled setting for networkPolicy.
+  enabled: true
+  # -- ingress from setting for networkPolicy.
+  ingressFrom: []
+  # -- extra egress setting for networkPolicy.
+  extraEgress: []
+  # -- allow internet setting for networkPolicy.
+  allowInternet: true
+# -- termination grace period seconds setting for the gateway.
+terminationGracePeriodSeconds: 120
+# -- ingress setting for the gateway.
+ingress:
+  # -- enabled setting for ingress.
+  enabled: false
+  # -- ingress class name setting for ingress.
+  ingressClassName: ""
+  # -- annotations setting for ingress.
+  annotations: {}
+  # -- hosts setting for ingress.
+  hosts:
+    - host: openclaw.example.com
+      # -- paths setting for ingress.hosts.
+      paths:
+        - path: /
+          # -- path type setting for ingress.hosts.paths.
+          pathType: Prefix
+  # -- tls setting for ingress.
+  tls: []
+# -- gateway a p i setting for the gateway.
+gatewayAPI:
+  # -- enabled setting for gatewayAPI.
+  enabled: false
+  # -- http routes setting for gatewayAPI.
+  httpRoutes: []
+# -- external secrets setting for the gateway.
+externalSecrets:
+  # -- enabled setting for externalSecrets.
+  enabled: false
+  # -- refresh interval setting for externalSecrets.
+  refreshInterval: 1h
+  # -- items setting for externalSecrets.
+  items: []
+# -- metrics setting for the gateway.
+metrics:
+  # -- Enable bundled diagnostics-otel metrics; no runtime plugin downloads.
+  enabled: false
+  # -- interval seconds setting for metrics.
+  intervalSeconds: 15
+  # -- External OTLP HTTP base endpoint when the local collector is disabled.
+  externalEndpoint: ""
+  # -- collector setting for metrics.
+  collector:
+    # -- enabled setting for metrics.collector.
+    enabled: true
+    # -- image setting for metrics.collector.
+    image:
+      # -- repository setting for metrics.collector.image.
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      # -- tag setting for metrics.collector.image.
+      tag: 0.160.0@sha256:799dc6cf12c96192af37b5bdba804da8c10b3bc563b43cb90c3f3c58d9572ad6
+      # -- pull policy setting for metrics.collector.image.
+      pullPolicy: IfNotPresent
+    # -- resources setting for metrics.collector.
+    resources:
+      # -- requests setting for metrics.collector.resources.
+      requests:
+        # -- cpu setting for metrics.collector.resources.requests.
+        cpu: 50m
+        # -- memory setting for metrics.collector.resources.requests.
+        memory: 64Mi
+      # -- limits setting for metrics.collector.resources.
+      limits:
+        # -- cpu setting for metrics.collector.resources.limits.
+        cpu: 500m
+        # -- memory setting for metrics.collector.resources.limits.
+        memory: 256Mi
+  # -- service monitor setting for metrics.
+  serviceMonitor:
+    # -- enabled setting for metrics.serviceMonitor.
+    enabled: false
+    # -- labels setting for metrics.serviceMonitor.
+    labels: {}
+    # -- interval setting for metrics.serviceMonitor.
+    interval: 30s
+    # -- scrape timeout setting for metrics.serviceMonitor.
+    scrapeTimeout: 10s
+  # -- prometheus rule setting for metrics.
+  prometheusRule:
+    # -- enabled setting for metrics.prometheusRule.
+    enabled: false
+    # -- labels setting for metrics.prometheusRule.
+    labels: {}
+    # -- additional rules setting for metrics.prometheusRule.
+    additionalRules: []
+  # -- ingress from setting for metrics.
+  ingressFrom: []
+# -- backup setting for the gateway.
+backup:
+  # -- enabled setting for backup.
+  enabled: false
+  # -- schedule setting for backup.
+  schedule: 0 3 * * *
+  # -- time zone setting for backup.
+  timeZone: Etc/UTC
+  # -- suspend setting for backup.
+  suspend: false
+  # -- successful jobs history limit setting for backup.
+  successfulJobsHistoryLimit: 1
+  # -- failed jobs history limit setting for backup.
+  failedJobsHistoryLimit: 2
+  # -- active deadline seconds setting for backup.
+  activeDeadlineSeconds: 1800
+  # -- Ephemeral capacity for native tar.gz archive and temporary SQLite snapshots; size for peak usage.
+  stagingSize: 10Gi
+  # -- resources setting for backup.
+  resources:
+    # -- requests setting for backup.resources.
+    requests:
+      # -- cpu setting for backup.resources.requests.
+      cpu: 100m
+      # -- memory setting for backup.resources.requests.
+      memory: 256Mi
+    # -- limits setting for backup.resources.
+    limits:
+      # -- cpu setting for backup.resources.limits.
+      cpu: "1"
+      # -- memory setting for backup.resources.limits.
+      memory: 2Gi
+  # -- s3 setting for backup.
+  s3:
+    # -- bucket setting for backup.s3.
+    bucket: ""
+    # -- prefix setting for backup.s3.
+    prefix: openclaw
+    # -- region setting for backup.s3.
+    region: us-east-1
+    # -- endpoint setting for backup.s3.
+    endpoint: ""
+    # -- allow insecure endpoint setting for backup.s3.
+    allowInsecureEndpoint: false
+    # -- existing secret setting for backup.s3.
+    existingSecret: ""
+    # -- sse setting for backup.s3.
+    sse: AES256
+    # -- kms key id setting for backup.s3.
+    kmsKeyId: ""
+    # -- ca secret setting for backup.s3.
+    caSecret: ""
+  # -- image setting for backup.
+  image:
+    # -- repository setting for backup.image.
+    repository: public.ecr.aws/aws-cli/aws-cli
+    # -- tag setting for backup.image.
+    tag: 2.36.43@sha256:d948ee299a7ffcaec0d6052a00b9f4c513c61cacfaedfe68b098c85808394441
+    # -- pull policy setting for backup.image.
+    pullPolicy: IfNotPresent
+  # -- network policy setting for backup.
+  networkPolicy:
+    # -- extra egress setting for backup.networkPolicy.
+    extraEgress: []
+# -- restore setting for the gateway.
+restore:
+  # -- enabled setting for restore.
+  enabled: false
+  # -- manifest key setting for restore.
+  manifestKey: ""
+  # -- max archive bytes setting for restore.
+  maxArchiveBytes: 10737418240
+  # -- Maximum expanded bytes accepted during recovery.
+  maxExpandedBytes: 21474836480
+# -- Gateway HTTP APIs and Control UI access policy.
+gateway:
+  # -- control ui setting for gateway.
+  controlUi:
+    # -- Enable the bundled Control UI with device pairing enforced.
+    enabled: true
+    # -- Exact trusted browser origins; add the HTTPS public origin before exposing the UI.
+    allowedOrigins:
+      - http://localhost:18789
+      - http://127.0.0.1:18789
+  # -- Explicit trusted reverse-proxy IPs/CIDRs for client identity; never trust all networks.
+  trustedProxies: []
+  # -- chat completions setting for gateway.
+  chatCompletions:
+    # -- Expose authenticated OpenAI-compatible chat completions.
+    enabled: false
+  # -- responses setting for gateway.
+  responses:
+    # -- Expose authenticated OpenResponses API.
+    enabled: false
+# -- Opt-in bundled messaging channels with explicit user allowlists; credentials must come from a Secret.
+channels:
+  # -- telegram setting for channels.
+  telegram:
+    # -- enabled setting for channels.telegram.
+    enabled: false
+    # -- allow from setting for channels.telegram.
+    allowFrom: []
+  # -- discord setting for channels.
+  discord:
+    # -- enabled setting for channels.discord.
+    enabled: false
+    # -- allow from setting for channels.discord.
+    allowFrom: []


### PR DESCRIPTION
## Summary

Add a persistent OpenClaw gateway using the official 2026.9.4 image pinned by OCI digest. The chart preserves gateway identity and device approval across upgrades, separates managed versus seeded configuration, and provides native verified S3 backup and empty-volume recovery.

- Single-writer StatefulSet, retained storage, non-root execution, read-only root filesystem and default-deny network policy.
- Exact Control UI origins and device pairing, existing Secrets/External Secrets, optional Telegram/Discord allowlists, Ingress and Gateway API.
- Native diagnostics through a pinned OpenTelemetry collector, Prometheus ServiceMonitor and alerts.
- S3 backup with remote checksum verification and completion manifests; guarded restore with size limits, empty-target checks and idempotent restart.
- Operational documentation, examples, schema and behavioral acceptance scripts.

Resolves #1189.

## Type Of Change

- [x] New chart

## PR Governance

- [x] Existing tracking issue linked; enhancement and type:feature labels applied.
- [x] Branch created from updated main and targets main.
- [x] Conventional breaking feature commit allows CI to publish the initial stable release; Chart.yaml uses the required 0.1.0 scaffold baseline.
- [x] Root README, values schema and chart documentation updated.

## Upstream Verification

Official release: https://github.com/openclaw/openclaw/releases/tag/v2026.9.4.

Image: `ghcr.io/openclaw/openclaw:2026.9.4@sha256:cc596b846506a5f4cfcee111394a2725f375f01cca2ebb492a161fd1b747f101`. Manifest verified for Linux AMD64 and ARM64; runtime exercised on AMD64. The official image's CLI validates the rendered configuration.

## Site Sync (GR-007)

Companions: helmforgedev/site#562 and helmforgedev/.github#27. Merge this chart first, confirm the initial release, then merge the companions so canonical documentation links and catalog totals become valid together.

## Local Validation

`make validate-chart CHART=openclaw` passed all 18 layers, including all eight k3d behavioral profiles, on commit 3a3ab45e. Helm unit tests: 29 passed. Preflight, standards, release/attribution and cross-repository parity checks passed.

- Real gateway tool write/read, invalid-token rejection, signed Control UI device enrollment and reconnect after upgrade, network-policy admission/denial and persisted gateway identity.
- Native metrics, External Secrets, configuration ownership and Gateway API profiles.
- TLS S3 backup and isolated restore, checksum/occupied-target rejection, recovered agent read, SQLite integrity and restart idempotence.
- Production Kubescape 4.0.14 scan: 99.393936%; one public KMS ARN is flagged as credential-like, while credentials use Secret references. No suppression.
- Site lint, format, production build, local link checks and five Chromium tests passed.

## Operational boundaries

This upstream gateway uses singleton storage and an IPv4 listener. Backup consistency is per native SQLite database, not a global transaction across every file. Kubernetes Secrets and external dependencies require separate recovery. Runtime tests use a local model fixture; no paid provider, live messaging account, ARM runtime or production cluster was exercised. Control UI validation covers its real signed server protocol, not a browser session through a public TLS ingress.


